### PR TITLE
Add Zenodo connector and model tests

### DIFF
--- a/application/test/connectors/connector_result_test.rb
+++ b/application/test/connectors/connector_result_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class ConnectorResultTest < ActiveSupport::TestCase
+  test 'defaults and accessors' do
+    result = ConnectorResult.new({redirect_url: '/path', message: {notice: 'ok'}})
+    assert_equal '/path', result.redirect_url
+    assert_equal({notice: 'ok'}, result.message)
+    assert result.success?
+    assert_equal({redirect_url: '/path', message: {notice: 'ok'}}, result.to_h)
+  end
+
+  test 'success? false when success field set to false' do
+    result = ConnectorResult.new(success: false)
+    refute result.success?
+  end
+end

--- a/application/test/connectors/zenodo/display_repo_controller_resolver_test.rb
+++ b/application/test/connectors/zenodo/display_repo_controller_resolver_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class Zenodo::DisplayRepoControllerResolverTest < ActionDispatch::IntegrationTest
+  def setup
+    @resolver = Zenodo::DisplayRepoControllerResolver.new
+    @resolver.define_singleton_method(:view_zenodo_landing_path) { '/view/zenodo' }
+  end
+
+  test 'record url returns record path' do
+    url = 'https://zenodo.org/records/12'
+    result = @resolver.get_controller_url(url)
+    assert_equal '/view/zenodo/records/12', result.redirect_url
+    assert result.success?
+  end
+
+  test 'zenodo root url returns landing path' do
+    url = 'https://zenodo.org'
+    result = @resolver.get_controller_url(url)
+    assert_equal '/view/zenodo', result.redirect_url
+  end
+end

--- a/application/test/connectors/zenodo/download_connector_processor_test.rb
+++ b/application/test/connectors/zenodo/download_connector_processor_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class Zenodo::DownloadConnectorProcessorTest < ActiveSupport::TestCase
+  include ModelHelper
+
+  def setup
+    @project = create_project
+    @project.save
+    @file = create_download_file(@project)
+    @file.metadata = { download_url: 'http://example.com/file.txt' }
+    @file.stubs(:update)
+    Project.stubs(:find).with(@project.id).returns(@project)
+    @processor = Zenodo::DownloadConnectorProcessor.new(@file)
+  end
+
+  test 'successful download' do
+    Download::BasicHttpRubyDownloader.any_instance.stubs(:download).yields(nil)
+    FileUtils.stubs(:mkdir_p)
+    result = @processor.download
+    assert_equal FileStatus::SUCCESS, result.status
+  end
+
+  test 'cancelled download' do
+    Download::BasicHttpRubyDownloader.any_instance.stubs(:download).yields(nil)
+    @processor.instance_variable_set(:@cancelled, true)
+    result = @processor.download
+    assert_equal FileStatus::CANCELLED, result.status
+  end
+
+  test 'process cancellation request' do
+    req = OpenStruct.new(body: OpenStruct.new(file_id: @file.id))
+    res = @processor.process(req)
+    assert_equal true, @processor.cancelled
+    assert_equal 'cancellation requested', res[:message]
+  end
+end

--- a/application/test/connectors/zenodo/download_connector_status_test.rb
+++ b/application/test/connectors/zenodo/download_connector_status_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class Zenodo::DownloadConnectorStatusTest < ActiveSupport::TestCase
+  include ModelHelper
+
+  def setup
+    @project = create_project
+    @file = create_download_file(@project)
+    @file.size = 100
+    @file.status = FileStatus::DOWNLOADING
+    @file.metadata = {temp_location: File.join(Dir.tmpdir, 'temp'), download_location: File.join(Dir.tmpdir, 'dest')}
+    File.write(@file.metadata[:temp_location], 'a' * 50)
+    @status = Zenodo::DownloadConnectorStatus.new(@file)
+  end
+
+  def teardown
+    FileUtils.rm_f(@file.metadata[:temp_location])
+    FileUtils.rm_f(@file.metadata[:download_location])
+  end
+
+  test 'calculates progress from temp file' do
+    assert_equal 50, @status.download_progress
+  end
+
+  test 'returns 100 when destination exists' do
+    FileUtils.touch(@file.metadata[:download_location])
+    assert_equal 100, @status.download_progress
+  end
+end

--- a/application/test/connectors/zenodo/upload_bundle_connector_processor_test.rb
+++ b/application/test/connectors/zenodo/upload_bundle_connector_processor_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class Zenodo::UploadBundleConnectorProcessorTest < ActiveSupport::TestCase
+  include ModelHelper
+
+  def setup
+    @processor = Zenodo::UploadBundleConnectorProcessor.new
+    @project = create_project
+    @bundle = create_upload_bundle(@project)
+  end
+
+  test 'params schema' do
+    assert_includes @processor.params_schema, :remote_repo_url
+  end
+
+  test 'create delegates to action' do
+    action = mock('action')
+    Zenodo::Actions::UploadBundleCreate.expects(:new).returns(action)
+    action.expects(:create).with(@project, {foo: 'bar'}).returns(:result)
+    assert_equal :result, @processor.create(@project, {foo: 'bar'})
+  end
+
+  test 'edit returns connector result' do
+    result = @processor.edit(@bundle, {})
+    assert_equal '/connectors/zenodo/connector_edit_form', result.partial
+    assert_equal({upload_bundle: @bundle}, result.locals)
+  end
+
+  test 'update uses deposition_fetch form' do
+    action = mock('action')
+    Zenodo::Actions::DepositionFetch.expects(:new).returns(action)
+    action.expects(:update).with(@bundle, {form: 'deposition_fetch'}).returns(:ok)
+    assert_equal :ok, @processor.update(@bundle, {form: 'deposition_fetch'})
+  end
+end

--- a/application/test/connectors/zenodo/upload_connector_processor_test.rb
+++ b/application/test/connectors/zenodo/upload_connector_processor_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+require_relative '../../helpers/zenodo_helper'
+
+class Zenodo::UploadConnectorProcessorTest < ActiveSupport::TestCase
+  include ModelHelper
+  include ZenodoHelper
+
+  def setup
+    @project = create_project
+    @bundle = create_upload_bundle(@project)
+    @file = create_upload_file(@project, @bundle)
+    @bundle.stubs(:connector_metadata).returns(OpenStruct.new(bucket_url: nil, api_key: OpenStruct.new(value: 'KEY')))
+    @processor = Zenodo::UploadConnectorProcessor.new(@file)
+  end
+
+  test 'upload returns error when bucket_url missing' do
+    result = @processor.upload
+    assert_equal FileStatus::ERROR, result.status
+    assert_match 'Missing bucket URL', result.message
+  end
+
+  test 'process handles cancel and status' do
+    # Prepare metadata with bucket_url so upload works
+    meta = OpenStruct.new(bucket_url: 'https://bucket', api_key: OpenStruct.new(value: 'KEY'))
+    @bundle.stubs(:connector_metadata).returns(meta)
+    @processor = Zenodo::UploadConnectorProcessor.new(@file)
+
+    Zenodo::ZenodoBucketHttpUploader.any_instance.stubs(:upload).yields({total:1, uploaded:1})
+
+    @processor.upload
+    request = OpenStruct.new(command: 'upload.status', body: OpenStruct.new(file_id: @file.id))
+    status = @processor.process(request)
+    assert_equal({message: 'upload in progress', status: {total:1, uploaded:1}}, status)
+
+    cancel_req = OpenStruct.new(command: 'upload.cancel', body: OpenStruct.new(file_id: @file.id))
+    cancel_result = @processor.process(cancel_req)
+    assert_equal true, @processor.cancelled
+    assert_equal 'cancellation requested', cancel_result[:message]
+  end
+end

--- a/application/test/connectors/zenodo/upload_connector_status_test.rb
+++ b/application/test/connectors/zenodo/upload_connector_status_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class Zenodo::UploadConnectorStatusTest < ActiveSupport::TestCase
+  include ModelHelper
+
+  def setup
+    @project = create_project
+    @bundle = create_upload_bundle(@project)
+    @file = create_upload_file(@project, @bundle)
+    @file.status = FileStatus::UPLOADING
+    @status = Zenodo::UploadConnectorStatus.new(@file)
+  end
+
+  test 'progress from command client' do
+    mock_client = mock('client')
+    mock_client.expects(:request).returns(OpenStruct.new(body: OpenStruct.new(status: {total: 10, uploaded: 5})))
+    Command::CommandClient.expects(:new).returns(mock_client)
+    assert_equal 50, @status.upload_progress
+  end
+
+  test 'returns 100 for completed file' do
+    @file.status = FileStatus::SUCCESS
+    assert_equal 100, @status.upload_progress
+  end
+end

--- a/application/test/controllers/zenodo/landing_page_controller_test.rb
+++ b/application/test/controllers/zenodo/landing_page_controller_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class Zenodo::LandingPageControllerTest < ActionDispatch::IntegrationTest
+  test 'search delegates to service' do
+    Zenodo::SearchService.any_instance.stubs(:search).returns(OpenStruct.new(items: []))
+    get view_zenodo_landing_path, params: {query: 'test'}
+    assert_response :success
+  end
+
+  test 'search error redirects' do
+    Zenodo::SearchService.any_instance.stubs(:search).raises('fail')
+    get view_zenodo_landing_path, params: {query: 't'}
+    assert_redirected_to root_path
+  end
+end

--- a/application/test/controllers/zenodo/records_controller_test.rb
+++ b/application/test/controllers/zenodo/records_controller_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class Zenodo::RecordsControllerTest < ActionDispatch::IntegrationTest
+  include FileFixtureHelper
+
+  def setup
+    @record = OpenStruct.new(title: 'rec', files: [])
+    Zenodo::RecordService.any_instance.stubs(:find_record).returns(@record)
+    Zenodo::ProjectService.any_instance.stubs(:initialize_project).returns(Project.new(name: 'P'))
+    Zenodo::ProjectService.any_instance.stubs(:initialize_download_files).returns([])
+  end
+
+  test 'show renders success' do
+    get view_zenodo_record_path('1')
+    assert_response :success
+  end
+
+  test 'show redirects when not found' do
+    Zenodo::RecordService.any_instance.stubs(:find_record).returns(nil)
+    get view_zenodo_record_path('1')
+    assert_redirected_to root_path
+  end
+
+  test 'download initializes project when missing' do
+    Project.stubs(:find).returns(nil)
+    project = Project.new(name: 'P')
+    project.stubs(:save).returns(true)
+    Zenodo::ProjectService.any_instance.stubs(:initialize_project).returns(project)
+    post download_zenodo_record_files_path, params: {id: '1', file_ids: []}
+    assert_redirected_to root_path
+    assert_match 'Files added to project', flash[:notice]
+  end
+end

--- a/application/test/fixtures/dataverse/my_dataverse_collections_response/valid_response.json
+++ b/application/test/fixtures/dataverse/my_dataverse_collections_response/valid_response.json
@@ -1,0 +1,10 @@
+{
+  "success": true,
+  "data": {
+    "total_count": 2,
+    "items": [
+      {"name": "DV1", "type": "dataverse", "url": "https://example.com/dv1", "identifier": "dv1"},
+      {"name": "DV2", "type": "dataverse", "url": "https://example.com/dv2", "identifier": "dv2"}
+    ]
+  }
+}

--- a/application/test/fixtures/zenodo/create_deposition_response.json
+++ b/application/test/fixtures/zenodo/create_deposition_response.json
@@ -1,0 +1,10 @@
+{
+  "id": 1,
+  "metadata": {"doi": "10.1234/zenodo.1"},
+  "links": {
+    "bucket": "https://zenodo.org/api/files/123",
+    "html": "https://zenodo.org/deposit/1",
+    "self": "https://zenodo.org/api/deposit/depositions/1"
+  },
+  "submitted": false
+}

--- a/application/test/fixtures/zenodo/deposition_response.json
+++ b/application/test/fixtures/zenodo/deposition_response.json
@@ -1,0 +1,9 @@
+{
+  "id": 1,
+  "submitted": false,
+  "links": {"bucket": "https://zenodo.org/api/files/123"},
+  "metadata": {"title": "My Deposition"},
+  "files": [
+    {"id": "10", "key": "file.txt", "size": 1234, "links": {"self": "https://zenodo.org/api/files/123/file.txt"}}
+  ]
+}

--- a/application/test/fixtures/zenodo/record_response.json
+++ b/application/test/fixtures/zenodo/record_response.json
@@ -1,0 +1,9 @@
+{
+  "id": 11,
+  "conceptrecid": "10",
+  "metadata": {"title": "Record Title"},
+  "files": [
+    {"id": "1", "key": "data/file1.txt", "size": 100, "links": {"self": "https://zenodo.org/record/11/files/data%2Ffile1.txt"}},
+    {"id": "2", "key": "image.png", "size": 200, "links": {"self": "https://zenodo.org/record/11/files/image.png"}}
+  ]
+}

--- a/application/test/fixtures/zenodo/search_response.json
+++ b/application/test/fixtures/zenodo/search_response.json
@@ -1,0 +1,8 @@
+{
+  "hits": {
+    "hits": [
+      {"id": "1", "metadata": {"title": "Record One"}},
+      {"id": "2", "metadata": {"title": "Record Two"}}
+    ]
+  }
+}

--- a/application/test/helpers/zenodo_helper.rb
+++ b/application/test/helpers/zenodo_helper.rb
@@ -1,0 +1,5 @@
+module ZenodoHelper
+  def load_zenodo_fixture(name)
+    File.read(File.join(__dir__, '..', 'fixtures', 'zenodo', name))
+  end
+end

--- a/application/test/models/dataverse/create_dataset_request_test.rb
+++ b/application/test/models/dataverse/create_dataset_request_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class Dataverse::CreateDatasetRequestTest < ActiveSupport::TestCase
+  test 'to_body contains provided fields' do
+    req = Dataverse::CreateDatasetRequest.new(title: 'Title', description: 'Desc', author: 'Me', contact_email: 'me@example.com', subjects: ['Bio'])
+    body = JSON.parse(req.to_body)
+    citation = body['datasetVersion']['metadataBlocks']['citation']['fields']
+    title_field = citation.find { |f| f['typeName'] == 'title' }
+    assert_equal 'Title', title_field['value']
+  end
+end

--- a/application/test/models/dataverse/my_dataverse_collections_response_test.rb
+++ b/application/test/models/dataverse/my_dataverse_collections_response_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class Dataverse::MyDataverseCollectionsResponseTest < ActiveSupport::TestCase
+  include FileFixtureHelper
+
+  def setup
+    json = load_file_fixture(File.join('dataverse','my_dataverse_collections_response','valid_response.json'))
+    @resp = Dataverse::MyDataverseCollectionsResponse.new(json, page:1, per_page:1)
+  end
+
+  test 'parses items and pagination' do
+    assert_equal 'OK', @resp.status
+    assert_equal 2, @resp.total_count
+    assert_equal 2, @resp.total_pages
+    assert_equal 'DV1', @resp.items.first.name
+  end
+end

--- a/application/test/models/dataverse/remote_dataset_test.rb
+++ b/application/test/models/dataverse/remote_dataset_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class Dataverse::RemoteDatasetTest < ActiveSupport::TestCase
+  test 'valid? and to_h' do
+    ds = Dataverse::RemoteDataset.new(url: 'http://example.com', api_key: '123', dataset_name: 'name', doi: 'doi')
+    assert ds.valid?
+    h = ds.to_h
+    assert_equal 'Dataverse', h[:type]
+    assert_equal 'name', h[:dataset_name]
+  end
+
+  test 'invalid when missing url' do
+    ds = Dataverse::RemoteDataset.new(api_key: '123')
+    refute ds.valid?
+  end
+end

--- a/application/test/models/zenodo/create_deposition_request_test.rb
+++ b/application/test/models/zenodo/create_deposition_request_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class Zenodo::CreateDepositionRequestTest < ActiveSupport::TestCase
+  test 'to_h returns compacted attributes' do
+    req = Zenodo::CreateDepositionRequest.new(title: 't', upload_type: 'software', description: 'd', creators: [{name: 'me'}], keywords: ['k'], publication_date: '2024-01-01')
+    h = req.to_h
+    assert_equal 't', h[:title]
+    assert_equal 'software', h[:upload_type]
+    assert_equal ['k'], h[:keywords]
+  end
+end

--- a/application/test/models/zenodo/create_deposition_response_test.rb
+++ b/application/test/models/zenodo/create_deposition_response_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+require_relative '../../helpers/zenodo_helper'
+
+class Zenodo::CreateDepositionResponseTest < ActiveSupport::TestCase
+  include ZenodoHelper
+
+  def setup
+    json = load_zenodo_fixture('create_deposition_response.json')
+    @resp = Zenodo::CreateDepositionResponse.new(json)
+  end
+
+  test 'parses attributes' do
+    assert_equal 1, @resp.id
+    assert_equal '10.1234/zenodo.1', @resp.doi
+    assert_equal 'https://zenodo.org/api/files/123', @resp.bucket_url
+    assert_equal 'https://zenodo.org/deposit/1', @resp.html_url
+    assert @resp.editable?
+  end
+end

--- a/application/test/models/zenodo/deposition_response_test.rb
+++ b/application/test/models/zenodo/deposition_response_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+require_relative '../../helpers/zenodo_helper'
+
+class Zenodo::DepositionResponseTest < ActiveSupport::TestCase
+  include ZenodoHelper
+
+  def setup
+    json = load_zenodo_fixture('deposition_response.json')
+    @resp = Zenodo::DepositionResponse.new(json)
+  end
+
+  test 'parses values' do
+    assert_equal 1, @resp.id
+    assert_equal 'My Deposition', @resp.title
+    assert_equal 'https://zenodo.org/api/files/123', @resp.bucket_url
+    assert_equal 1, @resp.file_count
+    assert @resp.draft?
+  end
+end

--- a/application/test/models/zenodo/record_response_test.rb
+++ b/application/test/models/zenodo/record_response_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+require_relative '../../helpers/zenodo_helper'
+
+class Zenodo::RecordResponseTest < ActiveSupport::TestCase
+  include ZenodoHelper
+
+  def setup
+    json = load_zenodo_fixture('record_response.json')
+    @resp = Zenodo::RecordResponse.new(json)
+  end
+
+  test 'parses files and title' do
+    assert_equal '11', @resp.id
+    assert_equal '10', @resp.concept_id
+    assert_equal 'Record Title', @resp.title
+    assert_equal 2, @resp.files.size
+    first = @resp.files.first
+    assert_equal '1', first.id
+    assert_equal 'data/file1.txt', first.filename
+  end
+end

--- a/application/test/models/zenodo/search_response_test.rb
+++ b/application/test/models/zenodo/search_response_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+require_relative '../../helpers/zenodo_helper'
+
+class Zenodo::SearchResponseTest < ActiveSupport::TestCase
+  include ZenodoHelper
+
+  test 'parses items' do
+    json = load_zenodo_fixture('search_response.json')
+    resp = Zenodo::SearchResponse.new(json, 1, 2)
+    assert_equal 2, resp.items.size
+    assert_equal 'Record One', resp.items.first.title
+    assert_equal '1', resp.items.first.id
+  end
+end

--- a/application/test/test_helper.rb
+++ b/application/test/test_helper.rb
@@ -29,6 +29,7 @@ end
 require_relative '../config/environment'
 require_relative 'helpers/file_fixture_helper'
 require_relative 'helpers/model_helper'
+require_relative 'helpers/zenodo_helper'
 
 require_relative 'utils/download_files_provider_mock'
 require_relative 'utils/http_mock'
@@ -45,6 +46,7 @@ module ActiveSupport
     # Add more helper methods to be used by all tests here...
     include FileFixtureHelper
     include ModelHelper
+    include ZenodoHelper
 
     setup do
       begin


### PR DESCRIPTION
## Summary
- add helper for Zenodo JSON fixtures
- add tests for ConnectorResult
- cover Zenodo connector processors and status classes
- add Zenodo controller tests and fixtures
- add Dataverse model tests for dataset request, collections response, and remote dataset

## Testing
- `bundle install`
- `rails assets:precompile`
- `rake test`

------
https://chatgpt.com/codex/tasks/task_e_6859076760c483219aafa9ed8f81dde4