### PR TITLE
Add Zenodo pagination

### DIFF
--- a/application/app/controllers/zenodo/landing_page_controller.rb
+++ b/application/app/controllers/zenodo/landing_page_controller.rb
@@ -4,9 +4,10 @@ class Zenodo::LandingPageController < ApplicationController
   def index
     @query = params[:query]
     @page = params[:page]&.to_i || 1
+    @per_page = params[:per_page]&.to_i || 10
     if @query.present?
       service = Zenodo::SearchService.new
-      @results = service.search(@query, page: @page)
+      @results = service.search(@query, page: @page, per_page: @per_page)
     end
   rescue => e
     log_error('Search Zenodo error', { query: @query, page: @page }, e)

--- a/application/app/helpers/zenodo/landing_page_helper.rb
+++ b/application/app/helpers/zenodo/landing_page_helper.rb
@@ -3,6 +3,7 @@ module Zenodo::LandingPageHelper
     return if search_result.first_page?
     html_options['aria-label'] = I18n.t('acts_as_page.link_prev_page_a11y_label')
     html_options[:title] = I18n.t('acts_as_page.link_prev_page_title')
+    html_options[:class] = [html_options[:class], 'btn btn-sm btn-outline-dark'].compact.join(' ')
     link_to('<', view_zenodo_landing_path(query: query, page: search_result.prev_page), html_options)
   end
 
@@ -10,6 +11,7 @@ module Zenodo::LandingPageHelper
     return if search_result.last_page?
     html_options['aria-label'] = I18n.t('acts_as_page.link_next_page_a11y_label')
     html_options[:title] = I18n.t('acts_as_page.link_next_page_title')
+    html_options[:class] = [html_options[:class], 'btn btn-sm btn-outline-dark'].compact.join(' ')
     link_to('>', view_zenodo_landing_path(query: query, page: search_result.next_page), html_options)
   end
 end

--- a/application/app/helpers/zenodo/landing_page_helper.rb
+++ b/application/app/helpers/zenodo/landing_page_helper.rb
@@ -4,7 +4,9 @@ module Zenodo::LandingPageHelper
     html_options['aria-label'] = I18n.t('acts_as_page.link_prev_page_a11y_label')
     html_options[:title] = I18n.t('acts_as_page.link_prev_page_title')
     html_options[:class] = [html_options[:class], 'btn btn-sm btn-outline-dark'].compact.join(' ')
-    link_to('<', view_zenodo_landing_path(query: query, page: search_result.prev_page), html_options)
+    link_to(view_zenodo_landing_path(query: query, page: search_result.prev_page), html_options) do
+      raw('<i class="bi bi-chevron-left"></i>')
+    end
   end
 
   def link_to_search_next_page(query, search_result, html_options = {})
@@ -12,7 +14,9 @@ module Zenodo::LandingPageHelper
     html_options['aria-label'] = I18n.t('acts_as_page.link_next_page_a11y_label')
     html_options[:title] = I18n.t('acts_as_page.link_next_page_title')
     html_options[:class] = [html_options[:class], 'btn btn-sm btn-outline-dark'].compact.join(' ')
-    link_to('>', view_zenodo_landing_path(query: query, page: search_result.next_page), html_options)
+    link_to(view_zenodo_landing_path(query: query, page: search_result.next_page), html_options) do
+      raw('<i class="bi bi-chevron-right"></i>')
+    end
   end
 end
 

--- a/application/app/helpers/zenodo/landing_page_helper.rb
+++ b/application/app/helpers/zenodo/landing_page_helper.rb
@@ -1,0 +1,16 @@
+module Zenodo::LandingPageHelper
+  def link_to_search_prev_page(query, search_result, html_options = {})
+    return if search_result.first_page?
+    html_options['aria-label'] = I18n.t('acts_as_page.link_prev_page_a11y_label')
+    html_options[:title] = I18n.t('acts_as_page.link_prev_page_title')
+    link_to('<', view_zenodo_landing_path(query: query, page: search_result.prev_page), html_options)
+  end
+
+  def link_to_search_next_page(query, search_result, html_options = {})
+    return if search_result.last_page?
+    html_options['aria-label'] = I18n.t('acts_as_page.link_next_page_a11y_label')
+    html_options[:title] = I18n.t('acts_as_page.link_next_page_title')
+    link_to('>', view_zenodo_landing_path(query: query, page: search_result.next_page), html_options)
+  end
+end
+

--- a/application/app/models/zenodo/record_response.rb
+++ b/application/app/models/zenodo/record_response.rb
@@ -2,15 +2,17 @@ require 'addressable'
 
 module Zenodo
   class RecordResponse
-    FileItem = Struct.new(:id, :filename, :filesize, :download_link, :download_url, keyword_init: true)
+    FileItem = Struct.new(:id, :filename, :filesize, :checksum, :download_link, :download_url, keyword_init: true)
 
-    attr_reader :id, :concept_id, :title, :files
+    attr_reader :id, :concept_id, :title, :description, :publication_date, :files
 
     def initialize(json)
       data = JSON.parse(json)
       @id = data['id'].to_s
       @concept_id = data['conceptrecid']
       @title = data.dig('metadata', 'title')
+      @description = data.dig('metadata', 'description')
+      @publication_date = data.dig('metadata', 'publication_date')
       @files = Array(data['files']).map do |f|
         raw_url = f.dig('links', 'self')
         encoded_url = encode_url_path(raw_url)
@@ -19,6 +21,7 @@ module Zenodo
           id: f['id'].to_s,
           filename: f['key'],
           filesize: f['size'],
+          checksum: f['checksum'],
           download_link: raw_url,
           download_url: encoded_url
         )

--- a/application/app/models/zenodo/search_response.rb
+++ b/application/app/models/zenodo/search_response.rb
@@ -39,6 +39,7 @@ module Zenodo
           id: f['id'].to_s,
           filename: f['key'],
           filesize: f['size'],
+          checksum: f['checksum'],
           download_link: raw_url,
           download_url: encoded_url
         )

--- a/application/app/models/zenodo/search_response.rb
+++ b/application/app/models/zenodo/search_response.rb
@@ -1,7 +1,11 @@
+require 'addressable'
+
 module Zenodo
   class SearchResponse
     include ActsAsPage
     attr_reader :items
+
+    FileItem = Zenodo::RecordResponse::FileItem
 
     def initialize(json, page, per_page)
       data = JSON.parse(json)
@@ -15,8 +19,36 @@ module Zenodo
                        total || Array(hits['hits']).count
                      end
       @items = Array(hits['hits']).map do |hit|
-        OpenStruct.new(id: hit['id'].to_s, title: hit.dig('metadata', 'title'))
+        OpenStruct.new(
+          id: hit['id'].to_s,
+          title: hit.dig('metadata', 'title'),
+          description: hit.dig('metadata', 'description'),
+          publication_date: hit.dig('metadata', 'publication_date'),
+          files: parse_files(hit['files'])
+        )
       end
+    end
+
+    private
+
+    def parse_files(files)
+      Array(files).map do |f|
+        raw_url = f.dig('links', 'self')
+        encoded_url = encode_url_path(raw_url)
+        FileItem.new(
+          id: f['id'].to_s,
+          filename: f['key'],
+          filesize: f['size'],
+          download_link: raw_url,
+          download_url: encoded_url
+        )
+      end
+    end
+
+    def encode_url_path(url)
+      Addressable::URI.parse(url).normalize.to_s
+    rescue Addressable::URI::InvalidURIError => e
+      raise "Invalid URL from Zenodo: #{url.inspect} (#{e.message})"
     end
   end
 end

--- a/application/app/models/zenodo/search_response.rb
+++ b/application/app/models/zenodo/search_response.rb
@@ -1,12 +1,20 @@
 module Zenodo
   class SearchResponse
-    attr_reader :page, :per_page, :items
+    include ActsAsPage
+    attr_reader :items
 
     def initialize(json, page, per_page)
       data = JSON.parse(json)
       @page = page
       @per_page = per_page
-      @items = Array(data['hits']['hits']).map do |hit|
+      hits = data.fetch('hits', {})
+      total = hits['total']
+      @total_count = if total.is_a?(Hash)
+                       total['value']
+                     else
+                       total || Array(hits['hits']).count
+                     end
+      @items = Array(hits['hits']).map do |hit|
         OpenStruct.new(id: hit['id'].to_s, title: hit.dig('metadata', 'title'))
       end
     end

--- a/application/app/views/zenodo/landing_page/index.html.erb
+++ b/application/app/views/zenodo/landing_page/index.html.erb
@@ -13,9 +13,11 @@
       <div class="card-header d-flex align-items-center">
         <%= @results.to_s %>
         <nav aria-label="<%= t('.paginator_bar_a11y_label') %>" class="ms-auto">
-          <%= link_to_search_prev_page(@query, @results, class: 'text-decoration-none') %>
-          <%= t('.paginator_page_text', page: @results.page) %>
-          <%= link_to_search_next_page(@query, @results, class: 'text-decoration-none') %>
+          <div class="d-flex align-items-center gap-2">
+            <%= link_to_search_prev_page(@query, @results, class: 'text-decoration-none') %>
+            <%= t('.paginator_page_text', page: @results.page) %>
+            <%= link_to_search_next_page(@query, @results, class: 'text-decoration-none') %>
+          </div>
         </nav>
       </div>
       <% if @results.items.any? %>
@@ -41,9 +43,11 @@
             <tr>
               <td class="text-center">
                 <nav aria-label="<%= t('.paginator_bar_a11y_label') %>" class="pagination mb-0">
-                  <%= link_to_search_prev_page(@query, @results, class: 'text-decoration-none bottom-page-link') %>
-                  <%= t('.paginator_page_text', page: @results.page) %>
-                  <%= link_to_search_next_page(@query, @results, class: 'text-decoration-none bottom-page-link') %>
+                  <div class="d-flex align-items-center gap-2">
+                    <%= link_to_search_prev_page(@query, @results, class: 'text-decoration-none bottom-page-link') %>
+                    <%= t('.paginator_page_text', page: @results.page) %>
+                    <%= link_to_search_next_page(@query, @results, class: 'text-decoration-none bottom-page-link') %>
+                  </div>
                 </nav>
               </td>
             </tr>

--- a/application/app/views/zenodo/landing_page/index.html.erb
+++ b/application/app/views/zenodo/landing_page/index.html.erb
@@ -40,22 +40,20 @@
                 </td>
               </tr>
             <% end %>
-            <tr>
-              <td class="text-center">
-                <nav aria-label="<%= t('.paginator_bar_a11y_label') %>" class="pagination mb-0">
-                  <div class="d-flex align-items-center gap-2">
-                    <%= link_to_search_prev_page(@query, @results, class: 'text-decoration-none bottom-page-link') %>
-                    <%= t('.paginator_page_text', page: @results.page) %>
-                    <%= link_to_search_next_page(@query, @results, class: 'text-decoration-none bottom-page-link') %>
-                  </div>
-                </nav>
-              </td>
-            </tr>
           </tbody>
         </table>
       <% else %>
         <div class="alert alert-warning m-3" role="status"><%= t('.msg_no_items_found_text') %></div>
       <% end %>
+      <div class="card-header d-flex justify-content-end">
+        <nav aria-label="<%= t('.paginator_bar_a11y_label') %>" class="ms-auto">
+          <div class="d-flex align-items-center gap-2">
+            <%= link_to_search_prev_page(@query, @results, class: 'text-decoration-none') %>
+            <%= t('.paginator_page_text', page: @results.page) %>
+            <%= link_to_search_next_page(@query, @results, class: 'text-decoration-none') %>
+          </div>
+        </nav>
+      </div>
     </div>
   <% end %>
 </div>

--- a/application/app/views/zenodo/landing_page/index.html.erb
+++ b/application/app/views/zenodo/landing_page/index.html.erb
@@ -29,7 +29,13 @@
           <tbody>
             <% @results.items.each do |item| %>
               <tr>
-                <td><%= link_to item.title, view_zenodo_record_path(item.id) %></td>
+                <td>
+                  <%= link_to item.title, view_zenodo_record_path(item.id) %>
+                  <div class="small text-muted">
+                    <%= t('.label_publication_date_text') %> <%= item.publication_date %> |
+                    <%= t('.label_files_text') %> <%= item.files.size %>
+                  </div>
+                </td>
               </tr>
             <% end %>
             <tr>

--- a/application/app/views/zenodo/landing_page/index.html.erb
+++ b/application/app/views/zenodo/landing_page/index.html.erb
@@ -9,12 +9,43 @@
     </div>
   <% end %>
   <% if @results %>
-    <ul class="list-group">
-      <% @results.items.each do |item| %>
-        <li class="list-group-item">
-          <%= link_to item.title, view_zenodo_record_path(item.id) %>
-        </li>
+    <div class="card">
+      <div class="card-header d-flex align-items-center">
+        <%= @results.to_s %>
+        <nav aria-label="<%= t('.paginator_bar_a11y_label') %>" class="ms-auto">
+          <%= link_to_search_prev_page(@query, @results, class: 'text-decoration-none') %>
+          <%= t('.paginator_page_text', page: @results.page) %>
+          <%= link_to_search_next_page(@query, @results, class: 'text-decoration-none') %>
+        </nav>
+      </div>
+      <% if @results.items.any? %>
+        <table class="table table-striped table-bordered align-middle mb-0">
+          <caption class="visually-hidden"><%= t('.table_results_caption') %></caption>
+          <thead class="table-light">
+            <tr>
+              <th scope="col"><%= t('.column_title_text') %></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @results.items.each do |item| %>
+              <tr>
+                <td><%= link_to item.title, view_zenodo_record_path(item.id) %></td>
+              </tr>
+            <% end %>
+            <tr>
+              <td class="text-center">
+                <nav aria-label="<%= t('.paginator_bar_a11y_label') %>" class="pagination mb-0">
+                  <%= link_to_search_prev_page(@query, @results, class: 'text-decoration-none bottom-page-link') %>
+                  <%= t('.paginator_page_text', page: @results.page) %>
+                  <%= link_to_search_next_page(@query, @results, class: 'text-decoration-none bottom-page-link') %>
+                </nav>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      <% else %>
+        <div class="alert alert-warning m-3" role="status"><%= t('.msg_no_items_found_text') %></div>
       <% end %>
-    </ul>
+    </div>
   <% end %>
 </div>

--- a/application/app/views/zenodo/records/show.html.erb
+++ b/application/app/views/zenodo/records/show.html.erb
@@ -23,11 +23,11 @@
           </div>
         </div>
       </a>
-      <div id="record-description" class="collapse pt-1">
-        <div class="small text-muted"><%= @record.description %></div>
+      <div id="record-description" class="collapse p-2">
+        <div class="small text-muted"><%= @record.description&.html_safe %></div>
       </div>
     </div>
-    <div class="card-body">
+    <div class="card-body p-0">
       <%= form_with url: download_zenodo_record_files_path, local: true do |f| %>
         <%= hidden_field_tag 'project_id', Current.settings.user_settings.active_project %>
         <%= hidden_field_tag :id, @record_id %>

--- a/application/app/views/zenodo/records/show.html.erb
+++ b/application/app/views/zenodo/records/show.html.erb
@@ -4,12 +4,28 @@
 
   <div class="card">
     <div class="card-header py-2">
-      <%= @record.title %>
-      <div class="small text-muted">
-        <%= t('.label_publication_date_text') %> <%= @record.publication_date %> |
-        <%= t('.label_files_text') %> <%= @record.files.size %>
+      <a class="d-flex align-items-start text-decoration-none w-100"
+         data-bs-toggle="collapse"
+         data-controller="utils--icon-toggle"
+         data-utils--icon-toggle-icon-on-value="bi-caret-right"
+         data-utils--icon-toggle-icon-off-value="bi-caret-down"
+         data-action="click->utils--icon-toggle#toggle"
+         href="#record-description"
+         role="button"
+         aria-expanded="false"
+         aria-controls="record-description">
+        <i data-utils--icon-toggle-target="icon" class="bi bi-caret-right me-2 transition" aria-hidden="true"></i>
+        <div>
+          <%= @record.title %>
+          <div class="small text-muted">
+            <%= t('.label_publication_date_text') %> <%= @record.publication_date %> |
+            <%= t('.label_files_text') %> <%= @record.files.size %>
+          </div>
+        </div>
+      </a>
+      <div id="record-description" class="collapse pt-1">
+        <div class="small text-muted"><%= @record.description %></div>
       </div>
-      <div class="small text-muted"><%= @record.description %></div>
     </div>
     <div class="card-body">
       <%= form_with url: download_zenodo_record_files_path, local: true do |f| %>

--- a/application/app/views/zenodo/records/show.html.erb
+++ b/application/app/views/zenodo/records/show.html.erb
@@ -3,12 +3,19 @@
   <%= render partial: '/shared/breadcrumbs', locals: { links: [{text: t('shared.breadcrumbs.zenodo'), url: view_zenodo_landing_path}, {text: @record.title}]} %>
 
   <div class="card">
-    <div class="card-header"><%= @record.title %></div>
+    <div class="card-header py-2">
+      <%= @record.title %>
+      <div class="small text-muted">
+        <%= t('.label_publication_date_text') %> <%= @record.publication_date %> |
+        <%= t('.label_files_text') %> <%= @record.files.size %>
+      </div>
+      <div class="small text-muted"><%= @record.description %></div>
+    </div>
     <div class="card-body">
       <%= form_with url: download_zenodo_record_files_path, local: true do |f| %>
         <%= hidden_field_tag 'project_id', Current.settings.user_settings.active_project %>
         <%= hidden_field_tag :id, @record_id %>
-        <table class="table">
+        <table class="table table-striped">
           <thead>
             <tr>
               <th></th>

--- a/application/config/locales/connectors/zenodo/en.yml
+++ b/application/config/locales/connectors/zenodo/en.yml
@@ -25,11 +25,20 @@ en:
         column_record_filename_text: "File"
         column_record_size_text: "Size"
         button_submit_text: "Add Files to Active Project"
+        label_publication_date_text: "Publication date:"
+        label_files_text: "Files:"
     landing_page:
       index:
         page_title: "OnDemand Loop - Zenodo"
         button_submit_text: "Search"
         field_search_placeholder: "Query to search in Zenodo records"
+        column_title_text: "Title"
+        label_publication_date_text: "Publication date:"
+        label_files_text: "Files:"
+        paginator_bar_a11y_label: "Search result pagination"
+        paginator_page_text: "page %{page}"
+        table_results_caption: "Search results"
+        msg_no_items_found_text: "No items found."
   helpers:
     zenodo:
       badge_key_missing_text: "Access Token missing"

--- a/application/test/controllers/zenodo/landing_page_controller_test.rb
+++ b/application/test/controllers/zenodo/landing_page_controller_test.rb
@@ -2,7 +2,9 @@ require 'test_helper'
 
 class Zenodo::LandingPageControllerTest < ActionDispatch::IntegrationTest
   test 'search delegates to service' do
-    Zenodo::SearchService.any_instance.stubs(:search).returns(OpenStruct.new(items: []))
+    Zenodo::SearchService.any_instance.expects(:search)
+                         .with('test', page: 1, per_page: 10)
+                         .returns(OpenStruct.new(items: []))
     get view_zenodo_landing_path, params: {query: 'test'}
     assert_response :success
   end

--- a/application/test/fixtures/zenodo/record_response.json
+++ b/application/test/fixtures/zenodo/record_response.json
@@ -1,9 +1,25 @@
 {
   "id": 11,
   "conceptrecid": "10",
-  "metadata": {"title": "Record Title"},
+  "metadata": {
+    "title": "Record Title",
+    "description": "Record description",
+    "publication_date": "2025-01-02"
+  },
   "files": [
-    {"id": "1", "key": "data/file1.txt", "size": 100, "links": {"self": "https://zenodo.org/record/11/files/data%2Ffile1.txt"}},
-    {"id": "2", "key": "image.png", "size": 200, "links": {"self": "https://zenodo.org/record/11/files/image.png"}}
+    {
+      "id": "1",
+      "key": "data/file1.txt",
+      "size": 100,
+      "checksum": "md5:abc",
+      "links": {"self": "https://zenodo.org/record/11/files/data%2Ffile1.txt"}
+    },
+    {
+      "id": "2",
+      "key": "image.png",
+      "size": 200,
+      "checksum": "md5:def",
+      "links": {"self": "https://zenodo.org/record/11/files/image.png"}
+    }
   ]
 }

--- a/application/test/fixtures/zenodo/search_response.json
+++ b/application/test/fixtures/zenodo/search_response.json
@@ -1,8 +1,31 @@
 {
   "hits": {
     "hits": [
-      {"id": "1", "metadata": {"title": "Record One"}},
-      {"id": "2", "metadata": {"title": "Record Two"}}
+      {
+        "id": "1",
+        "metadata": {
+          "title": "Record One",
+          "description": "Desc one",
+          "publication_date": "2024-01-01"
+        },
+        "files": [
+          {
+            "id": "f1",
+            "key": "file1.txt",
+            "size": 100,
+            "links": {"self": "https://zenodo.org/record/1/files/file1.txt"}
+          }
+        ]
+      },
+      {
+        "id": "2",
+        "metadata": {
+          "title": "Record Two",
+          "description": "Desc two",
+          "publication_date": "2024-02-01"
+        },
+        "files": []
+      }
     ]
   }
 }

--- a/application/test/fixtures/zenodo/search_response.json
+++ b/application/test/fixtures/zenodo/search_response.json
@@ -13,6 +13,7 @@
             "id": "f1",
             "key": "file1.txt",
             "size": 100,
+            "checksum": "md5:111",
             "links": {"self": "https://zenodo.org/record/1/files/file1.txt"}
           }
         ]

--- a/application/test/helpers/zenodo/landing_page_helper_test.rb
+++ b/application/test/helpers/zenodo/landing_page_helper_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class ZenodoLandingPageHelperTest < ActionView::TestCase
+  include Zenodo::LandingPageHelper
+
+  test 'prev and next links rendered when page available' do
+    page = Page.new((1..30).to_a, 2, 10)
+    stubs(:view_zenodo_landing_path).returns('/prev')
+    html = link_to_search_prev_page('q', page, {})
+    assert_includes html, '/prev'
+
+    stubs(:view_zenodo_landing_path).returns('/next')
+    html = link_to_search_next_page('q', page, {})
+    assert_includes html, '/next'
+  end
+
+  test 'prev link nil on first page' do
+    page = Page.new((1..10).to_a, 1, 10)
+    assert_nil link_to_search_prev_page('q', page, {})
+  end
+
+  test 'next link nil on last page' do
+    page = Page.new((1..10).to_a, 1, 10)
+    assert_nil link_to_search_next_page('q', page, {})
+  end
+end
+

--- a/application/test/helpers/zenodo/landing_page_helper_test.rb
+++ b/application/test/helpers/zenodo/landing_page_helper_test.rb
@@ -9,10 +9,12 @@ class ZenodoLandingPageHelperTest < ActionView::TestCase
     stubs(:view_zenodo_landing_path).returns('/prev')
     html = link_to_search_prev_page('q', page, {})
     assert_includes html, '/prev'
+    assert_includes html, 'btn btn-sm btn-outline-dark'
 
     stubs(:view_zenodo_landing_path).returns('/next')
     html = link_to_search_next_page('q', page, {})
     assert_includes html, '/next'
+    assert_includes html, 'btn btn-sm btn-outline-dark'
   end
 
   test 'prev link nil on first page' do

--- a/application/test/models/zenodo/record_response_test.rb
+++ b/application/test/models/zenodo/record_response_test.rb
@@ -9,13 +9,16 @@ class Zenodo::RecordResponseTest < ActiveSupport::TestCase
     @resp = Zenodo::RecordResponse.new(json)
   end
 
-  test 'parses files and title' do
+  test 'parses metadata and files' do
     assert_equal '11', @resp.id
     assert_equal '10', @resp.concept_id
     assert_equal 'Record Title', @resp.title
+    assert_equal 'Record description', @resp.description
+    assert_equal '2025-01-02', @resp.publication_date
     assert_equal 2, @resp.files.size
     first = @resp.files.first
     assert_equal '1', first.id
     assert_equal 'data/file1.txt', first.filename
+    assert_equal 'md5:abc', first.checksum
   end
 end

--- a/application/test/models/zenodo/search_response_test.rb
+++ b/application/test/models/zenodo/search_response_test.rb
@@ -9,7 +9,11 @@ class Zenodo::SearchResponseTest < ActiveSupport::TestCase
     resp = Zenodo::SearchResponse.new(json, 1, 2)
     assert_equal 2, resp.items.size
     assert_equal 'Record One', resp.items.first.title
-    assert_equal '1', resp.items.first.id
+    first = resp.items.first
+    assert_equal '1', first.id
+    assert_equal 'Desc one', first.description
+    assert_equal '2024-01-01', first.publication_date
+    assert_equal 1, first.files.size
     assert_equal 1, resp.page
     assert_equal 2, resp.per_page
     assert_equal 2, resp.total_count

--- a/application/test/models/zenodo/search_response_test.rb
+++ b/application/test/models/zenodo/search_response_test.rb
@@ -14,6 +14,7 @@ class Zenodo::SearchResponseTest < ActiveSupport::TestCase
     assert_equal 'Desc one', first.description
     assert_equal '2024-01-01', first.publication_date
     assert_equal 1, first.files.size
+    assert_equal 'md5:111', first.files.first.checksum
     assert_equal 1, resp.page
     assert_equal 2, resp.per_page
     assert_equal 2, resp.total_count

--- a/application/test/models/zenodo/search_response_test.rb
+++ b/application/test/models/zenodo/search_response_test.rb
@@ -10,5 +10,11 @@ class Zenodo::SearchResponseTest < ActiveSupport::TestCase
     assert_equal 2, resp.items.size
     assert_equal 'Record One', resp.items.first.title
     assert_equal '1', resp.items.first.id
+    assert_equal 1, resp.page
+    assert_equal 2, resp.per_page
+    assert_equal 2, resp.total_count
+    assert_equal 1, resp.total_pages
+    assert resp.first_page?
+    assert resp.last_page?
   end
 end


### PR DESCRIPTION
## Summary
- update Zenodo search response to include pagination
- add helper and view updates for paginated table of search results
- extend controller to pass per_page
- add I18n strings for pagination
- add unit tests for new helper and pagination behavior

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_685dc39d8d048321b19c41ec054e6903