### PR TITLE
Validate Dataverse external tool callbacks

### DIFF
--- a/application/app/services/dataverse/external_tool_service.rb
+++ b/application/app/services/dataverse/external_tool_service.rb
@@ -9,6 +9,8 @@ module Dataverse
       decoded = Base64.decode64(callback)
       parsed_url = URI.parse(decoded)
 
+      raise ArgumentError, 'Invalid callback URL' unless valid_callback_url?(parsed_url)
+
       log_info("requesting #{parsed_url}", { parsed_url: parsed_url })
       response = @http_client.get(parsed_url)
       external_tool_response = response.success? ? ExternalToolResponse.new(response.body) : nil
@@ -19,6 +21,15 @@ module Dataverse
         response: external_tool_response,
         dataverse_uri: dataverse_url,
       }
+    end
+
+    private
+
+    def valid_callback_url?(uri)
+      return false unless uri.scheme =~ /^https?$/
+      return false if uri.host.nil? || uri.host.empty?
+
+      uri.path.start_with?('/api/') || uri.path.start_with?('/external/')
     end
   end
 end

--- a/application/test/services/dataverse/external_tool_service_test.rb
+++ b/application/test/services/dataverse/external_tool_service_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'base64'
 
 class Dataverse::ExternalToolServiceTest < ActiveSupport::TestCase
 
@@ -20,6 +21,18 @@ class Dataverse::ExternalToolServiceTest < ActiveSupport::TestCase
     assert_equal 'dataverse.test.com', result[:dataverse_uri].host
     assert_equal '8080', result[:dataverse_uri].port.to_s
     assert http_client_mock.called?
+  end
+
+  test 'process_callback should raise error for invalid callback URL' do
+    http_client_mock = HttpClientMock.new(file_path: fixture_path('/dataverse/external_tool/valid_response.json'))
+    target = Dataverse::ExternalToolService.new(http_client: http_client_mock)
+    callback = Base64.strict_encode64('http://malicious.com/hack')
+
+    assert_raises ArgumentError do
+      target.process_callback(callback)
+    end
+
+    assert_not http_client_mock.called?
   end
 end
 


### PR DESCRIPTION
## Summary
- validate dataset external tool callback URLs before performing HTTP request
- test invalid callback handling

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6866432bfabc83218f74c65f2125a1a7