### PR TITLE
Add Dataverse URL validation

### DIFF
--- a/application/app/controllers/dataverse/datasets_controller.rb
+++ b/application/app/controllers/dataverse/datasets_controller.rb
@@ -53,8 +53,7 @@ class Dataverse::DatasetsController < ApplicationController
     resolver = Repo::RepoResolverService.new(RepoRegistry.resolvers)
     result = resolver.resolve(@dataverse_url)
     unless result.type == ConnectorType::DATAVERSE
-      flash[:alert] = t('dataverse.datasets.url_not_supported', dataverse_url: @dataverse_url)
-      redirect_to root_path
+      redirect_to root_path, alert: t('dataverse.datasets.url_not_supported', dataverse_url: @dataverse_url)
       return
     end
   end

--- a/application/app/controllers/dataverse/datasets_controller.rb
+++ b/application/app/controllers/dataverse/datasets_controller.rb
@@ -3,6 +3,7 @@ class Dataverse::DatasetsController < ApplicationController
   include Dataverse::CommonHelper
 
   before_action :get_dv_full_hostname
+  before_action :validate_dataverse_url
   before_action :init_service
   before_action :init_project_service, only: [ :download ]
   before_action :find_dataset_by_persistent_id
@@ -46,6 +47,15 @@ class Dataverse::DatasetsController < ApplicationController
 
   def get_dv_full_hostname
     @dataverse_url = current_dataverse_url
+  end
+
+  def validate_dataverse_url
+    resolver = Repo::RepoResolverService.new(RepoRegistry.resolvers)
+    result = resolver.resolve(@dataverse_url)
+    unless result.type == ConnectorType::DATAVERSE
+      redirect_back fallback_location: root_path, alert: t('dataverse.datasets.url_not_supported', dataverse_url: @dataverse_url)
+      return
+    end
   end
 
   def init_service

--- a/application/app/controllers/dataverse/datasets_controller.rb
+++ b/application/app/controllers/dataverse/datasets_controller.rb
@@ -53,7 +53,8 @@ class Dataverse::DatasetsController < ApplicationController
     resolver = Repo::RepoResolverService.new(RepoRegistry.resolvers)
     result = resolver.resolve(@dataverse_url)
     unless result.type == ConnectorType::DATAVERSE
-      redirect_back fallback_location: root_path, alert: t('dataverse.datasets.url_not_supported', dataverse_url: @dataverse_url)
+      flash[:alert] = t('dataverse.datasets.url_not_supported', dataverse_url: @dataverse_url)
+      redirect_to root_path
       return
     end
   end

--- a/application/config/locales/controllers/dataverse/en.yml
+++ b/application/config/locales/controllers/dataverse/en.yml
@@ -17,6 +17,7 @@ en:
       dataverse_service_error: "Dataverse service error. Dataverse: %{dataverse_url} persistentId: %{persistent_id}"
       dataset_files_not_found: "Dataset files not found. Dataverse: %{dataverse_url} persistentId: %{persistent_id} page: %{page}"
       dataset_files_endpoint_requires_authorization: "Dataset files endpoint requires authorization. Dataverse: %{dataverse_url} persistentId: %{persistent_id} page: %{page}"
+      url_not_supported: "Dataverse URL not supported: %{dataverse_url}"
       dataverse_service_error_searching_files: "Dataverse service error while searching files. Dataverse: %{dataverse_url} persistentId: %{persistent_id} page: %{page}"
     landing_page:
       index:

--- a/application/config/locales/controllers/dataverse/en.yml
+++ b/application/config/locales/controllers/dataverse/en.yml
@@ -6,6 +6,7 @@ en:
         dataverse_not_found: "Dataverse not found. Dataverse: %{dataverse_url} Id: %{id}"
         dataverse_requires_authorization: "Dataverse requires authorization. Dataverse: %{dataverse_url} Id: %{id}"
         dataverse_service_error: "Dataverse service error. Dataverse: %{dataverse_url} Id: %{id}"
+      url_not_supported: "Dataverse URL not supported: %{dataverse_url}"
     datasets:
       download:
         error_generating_project: "Error generating project: %{errors}"

--- a/application/test/controllers/dataverse/collections_controller_test.rb
+++ b/application/test/controllers/dataverse/collections_controller_test.rb
@@ -7,6 +7,20 @@ class Dataverse::CollectionsControllerTest < ActionDispatch::IntegrationTest
     @dataverse = Dataverse::CollectionResponse.new(dataverse_json)
     search_json = load_file_fixture(File.join('dataverse', 'search_response', 'valid_response.json'))
     @search_response = Dataverse::SearchResponse.new(search_json, 1, 20)
+    resolver = mock('resolver')
+    resolver.stubs(:resolve).returns(OpenStruct.new(type: ConnectorType::DATAVERSE))
+    Repo::RepoResolverService.stubs(:new).returns(resolver)
+  end
+
+  test "should redirect if dataverse url is not supported" do
+    resolver = mock('resolver')
+    resolver.stubs(:resolve).returns(OpenStruct.new(type: nil))
+    Repo::RepoResolverService.stubs(:new).returns(resolver)
+
+    get view_dataverse_url('invalid.host', ':root')
+
+    assert_redirected_to root_path
+    assert_equal I18n.t('dataverse.collections.url_not_supported', dataverse_url: 'https://invalid.host'), flash[:alert]
   end
 
   test "should redirect to root path after not finding a dataverse" do


### PR DESCRIPTION
## Summary
- validate Dataverse URL with RepoResolverService before acting
- handle invalid Dataverse URL with flash error
- update controller specs and translations
- remove bun.lock from repo

## Testing
- `RBENV_VERSION=3.2.3 bundle exec rake test TEST=test/controllers/dataverse/datasets_controller_test.rb`
- `RBENV_VERSION=3.2.3 bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_6867026d2178832182aa48bd76805f9e