### PR TITLE
Add skeleton user guide

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,28 +1,15 @@
 # OnDemand Loop User Guide
 
-## Introduction
-
-## Getting Started
-
-## Creating Projects
-
-## Exploring Remote Repositories
-
-## Downloading Files
-
-## Uploading Files
-
-## Using the File Browser
-
-## Viewing Download and Upload Status
-
-## Managing Integrations
-
-## Troubleshooting
-
-## FAQs
-
-## Glossary
-
-## Support and Resources
-
+* [Introduction](user_guide/introduction.md)
+* [Getting Started](user_guide/getting_started.md)
+* [Creating Projects](user_guide/creating_projects.md)
+* [Exploring Remote Repositories](user_guide/exploring_remote_repositories.md)
+* [Downloading Files](user_guide/downloading_files.md)
+* [Uploading Files](user_guide/uploading_files.md)
+* [Using the File Browser](user_guide/using_the_file_browser.md)
+* [Viewing Download and Upload Status](user_guide/viewing_download_and_upload_status.md)
+* [Managing Integrations](user_guide/managing_integrations.md)
+* [Troubleshooting](user_guide/troubleshooting.md)
+* [FAQs](user_guide/faqs.md)
+* [Glossary](user_guide/glossary.md)
+* [Support and Resources](user_guide/support_and_resources.md)

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,28 @@
+# OnDemand Loop User Guide
+
+## Introduction
+
+## Getting Started
+
+## Creating Projects
+
+## Exploring Remote Repositories
+
+## Downloading Files
+
+## Uploading Files
+
+## Using the File Browser
+
+## Viewing Download and Upload Status
+
+## Managing Integrations
+
+## Troubleshooting
+
+## FAQs
+
+## Glossary
+
+## Support and Resources
+

--- a/docs/user_guide/creating_projects.md
+++ b/docs/user_guide/creating_projects.md
@@ -1,0 +1,7 @@
+# Creating Projects
+
+Projects group your downloads and uploads. Use the **Projects** link in the navigation bar to see existing projects.
+
+* Click **Create Project** to make a new project. A default name is generated automatically.
+* Click the star icon next to a project to set it as the active project. New downloads or uploads are added to the active project.
+* Use the pencil icon to rename the project or open the folder icon to browse the project directory inside OOD.

--- a/docs/user_guide/downloading_files.md
+++ b/docs/user_guide/downloading_files.md
@@ -1,0 +1,6 @@
+# Downloading Files
+
+1. Navigate to a dataset or record using the Explore bar or the Repositories menu.
+2. On the file list page, check the files you wish to fetch and click **Add Files**.
+3. The selected files are added to the current project as download tasks.
+4. Use the **Downloads** link in the navigation bar to monitor progress. Each file shows status badges and you can cancel active transfers.

--- a/docs/user_guide/exploring_remote_repositories.md
+++ b/docs/user_guide/exploring_remote_repositories.md
@@ -1,0 +1,7 @@
+# Exploring Remote Repositories
+
+You can browse Dataverse installations or Zenodo directly from the **Repositories** menu. Choose the service to open its landing page and search for datasets or records.
+
+Alternatively use the **Explore** option in the navigation bar. This reveals the resolver bar where you can paste a DOI or dataset URL. Press **Connect** to open the matching dataset or record page.
+
+On each dataset or record page you will see basic metadata and a list of files. Select the files you need to download them into a project.

--- a/docs/user_guide/faqs.md
+++ b/docs/user_guide/faqs.md
@@ -1,0 +1,9 @@
+# FAQs
+
+**How do I change the active project?**
+
+Open the **Projects** page and click the star icon next to the project you want to activate.
+
+**Do downloads overwrite existing files?**
+
+Files are saved under the project download directory. Existing files with the same name will be overwritten.

--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -1,0 +1,6 @@
+# Getting Started
+
+1. Open your web browser and navigate to `https://<ood-server>/pun/sys/loop`.
+2. Sign in using your regular Open OnDemand credentials.
+3. Familiarize yourself with the navigation bar. From left to right it links to **Projects**, **Downloads**, **Uploads**, and **Repositories** (Dataverse and optional Zenodo). The **Explore** link toggles a bar where you can paste a DOI or repository URL.
+4. The first time you visit, an empty project is created automatically so you can immediately begin adding downloads.

--- a/docs/user_guide/glossary.md
+++ b/docs/user_guide/glossary.md
@@ -1,0 +1,7 @@
+# Glossary
+
+**Project** – A workspace that groups related downloads and uploads.
+
+**Upload Bundle** – A collection of files destined for a specific remote dataset.
+
+**Connector** – Code that knows how to talk to a remote repository such as Dataverse or Zenodo.

--- a/docs/user_guide/introduction.md
+++ b/docs/user_guide/introduction.md
@@ -1,0 +1,5 @@
+# Introduction
+
+OnDemand Loop simplifies transferring data between your favorite research repositories and your Open OnDemand (OOD) workspace. The application installs as a standard OOD passenger app and is accessed at `https://<ood-server>/pun/sys/loop`.
+
+The first integration is Dataverse which acts as the reference implementation. Other repositories such as Zenodo are also supported if enabled. OnDemand Loop is designed to keep your datasets synchronized so you can work on your HPC resources and push results back to the originating repository.

--- a/docs/user_guide/managing_integrations.md
+++ b/docs/user_guide/managing_integrations.md
@@ -1,0 +1,3 @@
+# Managing Integrations
+
+Dataverse servers can be browsed from the Dataverse landing page. If you run your own Dataverse, register OnDemand Loop as an external tool using the curl command found in `docs/development.md`. Zenodo support is optional and can be enabled in the configuration file.

--- a/docs/user_guide/support_and_resources.md
+++ b/docs/user_guide/support_and_resources.md
@@ -1,0 +1,3 @@
+# Support and Resources
+
+For development instructions see `docs/development.md` which describes how to run Dataverse locally and install this application as an external tool. If you encounter issues open an issue on the project repository.

--- a/docs/user_guide/troubleshooting.md
+++ b/docs/user_guide/troubleshooting.md
@@ -1,0 +1,5 @@
+# Troubleshooting
+
+If a download or upload fails, check the status pages for an error message. You may remove the failed task and try again.
+
+Ensure that your Dataverse or Zenodo instance is reachable from the OOD server. For local development, remember to accept the self‑signed SSL certificate.

--- a/docs/user_guide/uploading_files.md
+++ b/docs/user_guide/uploading_files.md
@@ -1,0 +1,6 @@
+# Uploading Files
+
+1. Open an existing project from the **Projects** page.
+2. Click **Create Upload Bundle** and provide the target dataset URL (for example a Dataverse draft dataset).
+3. Use the **Add Files** button to choose local files. You can drop files onto the area or open the file browser to select them.
+4. Once files are listed in the bundle, they will be processed automatically. Monitor progress from the **Uploads** page. Cancel or remove files if necessary.

--- a/docs/user_guide/using_the_file_browser.md
+++ b/docs/user_guide/using_the_file_browser.md
@@ -1,0 +1,7 @@
+# Using the File Browser
+
+The file browser component is used when adding files to an upload bundle.
+
+* Navigate folders by double‑clicking directories or use the **Home** button to jump to your home directory.
+* Click the pencil icon to edit the path manually. Confirm to load a new location.
+* Select files to add and click **Open in OnDemand** to view the folder directly in the OOD file app.

--- a/docs/user_guide/viewing_download_and_upload_status.md
+++ b/docs/user_guide/viewing_download_and_upload_status.md
@@ -1,0 +1,5 @@
+# Viewing Download and Upload Status
+
+Use the **Downloads** and **Uploads** links to open pages that list current transfer tasks. Each entry shows progress, creation date and status badges (Pending, Running, Completed, Cancelled, Error).
+
+Refresh automatically occurs every few seconds. You can cancel a running task from these pages.


### PR DESCRIPTION
## Summary
- add initial user guide outline in `docs/user_guide.md`

## Testing
- `make test` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a87685f4832192430cd063f45dc3