### PR TITLE
Refactor Zenodo URL builders to use FluentUrl

### DIFF
--- a/application/app/services/zenodo/concerns/zenodo_url_builder.rb
+++ b/application/app/services/zenodo/concerns/zenodo_url_builder.rb
@@ -34,7 +34,7 @@ module Zenodo::Concerns::ZenodoUrlBuilder
   end
 
   def deposition_url
-    raise 'record_id is missing' unless deposition_id
+    raise 'deposition_id is missing' unless deposition_id
 
     FluentUrl.new(zenodo_url)
       .add_path('deposit')
@@ -43,7 +43,7 @@ module Zenodo::Concerns::ZenodoUrlBuilder
   end
 
   def deposition_edit_url
-    raise 'record_id is missing' unless deposition_id
+    raise 'deposition_id is missing' unless deposition_id
 
     FluentUrl.new(zenodo_url)
       .add_path('deposit')

--- a/application/app/services/zenodo/concerns/zenodo_url_builder.rb
+++ b/application/app/services/zenodo/concerns/zenodo_url_builder.rb
@@ -6,35 +6,54 @@ module Zenodo::Concerns::ZenodoUrlBuilder
   def record_url
     raise 'record_id is missing' unless record_id
 
-    "#{zenodo_url}/record/#{record_id}"
+    FluentUrl.new(zenodo_url)
+      .add_path('record')
+      .add_path(record_id)
+      .to_s
   end
 
   def file_url
     raise 'record_id is missing' unless record_id
     raise 'file_name is missing' unless file_name
 
-    "#{zenodo_url}/record/#{record_id}/files/#{file_name}"
+    FluentUrl.new(zenodo_url)
+      .add_path('record')
+      .add_path(record_id)
+      .add_path('files')
+      .add_path(file_name)
+      .to_s
   end
 
   def concept_url
     raise 'concept_id is missing' unless concept_id
 
-    "#{zenodo_url}/record/#{concept_id}"
+    FluentUrl.new(zenodo_url)
+      .add_path('record')
+      .add_path(concept_id)
+      .to_s
   end
 
   def deposition_url
     raise 'record_id is missing' unless deposition_id
 
-    "#{zenodo_url}/deposit/#{deposition_id}"
+    FluentUrl.new(zenodo_url)
+      .add_path('deposit')
+      .add_path(deposition_id)
+      .to_s
   end
 
   def deposition_edit_url
     raise 'record_id is missing' unless deposition_id
 
-    "#{zenodo_url}/deposit/#{deposition_id}#/files"
+    FluentUrl.new(zenodo_url)
+      .add_path('deposit')
+      .add_path(deposition_id)
+      .to_s + '#/files'
   end
 
   def user_depositions_url
-    "#{zenodo_url}/deposit"
+    FluentUrl.new(zenodo_url)
+      .add_path('deposit')
+      .to_s
   end
 end

--- a/application/app/services/zenodo/deposition_service.rb
+++ b/application/app/services/zenodo/deposition_service.rb
@@ -14,7 +14,13 @@ module Zenodo
       headers = { 'Content-Type' => 'application/json', AUTH_HEADER => "Bearer #{@api_key}" }
       body = { metadata: request.to_h }
 
-      response = @http_client.post('/api/deposit/depositions', body: body.to_json, headers: headers)
+      url = FluentUrl.new('')
+              .add_path('api')
+              .add_path('deposit')
+              .add_path('depositions')
+              .to_s
+
+      response = @http_client.post(url, body: body.to_json, headers: headers)
 
       return nil if response.not_found?
       raise UnauthorizedException if response.unauthorized?
@@ -27,7 +33,12 @@ module Zenodo
       raise ApiKeyRequiredException unless @api_key
 
       headers = { 'Content-Type' => 'application/json', AUTH_HEADER => "Bearer #{@api_key}" }
-      url = "/api/deposit/depositions/#{deposition_id}"
+      url = FluentUrl.new('')
+              .add_path('api')
+              .add_path('deposit')
+              .add_path('depositions')
+              .add_path(deposition_id)
+              .to_s
 
       response = @http_client.get(url, headers: headers)
 

--- a/application/app/services/zenodo/record_service.rb
+++ b/application/app/services/zenodo/record_service.rb
@@ -8,7 +8,11 @@ module Zenodo
     end
 
     def find_record(record_id)
-      url = "/api/records/#{record_id}"
+      url = FluentUrl.new('')
+              .add_path('api')
+              .add_path('records')
+              .add_path(record_id)
+              .to_s
       response = @http_client.get(url)
       return nil unless response.success?
       RecordResponse.new(response.body)

--- a/application/app/services/zenodo/search_service.rb
+++ b/application/app/services/zenodo/search_service.rb
@@ -6,8 +6,14 @@ module Zenodo
     end
 
     def search(query, page: 1, per_page: 10)
-      params = { q: query, page: page, size: per_page }
-      response = @http_client.get('/api/records', params: params)
+      url = FluentUrl.new('')
+              .add_path('api')
+              .add_path('records')
+              .add_param('page', page)
+              .add_param('q', query)
+              .add_param('size', per_page)
+              .to_s
+      response = @http_client.get(url)
       return nil unless response.success?
       SearchResponse.new(response.body, page, per_page)
     end

--- a/application/app/services/zenodo/user_service.rb
+++ b/application/app/services/zenodo/user_service.rb
@@ -16,7 +16,13 @@ module Zenodo
         AUTH_HEADER => "Bearer #{@api_key}"
       }
 
-      url = "/api/deposit/depositions?page=#{page}&size=#{per_page}"
+      url = FluentUrl.new('')
+              .add_path('api')
+              .add_path('deposit')
+              .add_path('depositions')
+              .add_param('page', page)
+              .add_param('size', per_page)
+              .to_s
       response = @http_client.get(url, headers: headers)
 
       return [] if response.not_found?
@@ -34,8 +40,13 @@ module Zenodo
         AUTH_HEADER => "Bearer #{@api_key}"
       }
 
-      query = q ? "q=#{CGI.escape(q)}&" : ''
-      url = "/api/records?#{query}all_versions=#{all_versions}&page=#{page}&size=#{per_page}"
+      url = FluentUrl.new('')
+              .add_path('api')
+              .add_path('records')
+              .add_param('all_versions', all_versions)
+              .add_param('page', page)
+      url.add_param('q', q) if q
+      url = url.add_param('size', per_page).to_s
       response = @http_client.get(url, headers: headers)
 
       return [] if response.not_found?
@@ -53,7 +64,10 @@ module Zenodo
         AUTH_HEADER => "Bearer #{@api_key}"
       }
 
-      url = '/api/me'
+      url = FluentUrl.new('')
+              .add_path('api')
+              .add_path('me')
+              .to_s
       response = @http_client.get(url, headers: headers)
 
       return nil if response.not_found?

--- a/application/app/services/zenodo/zenodo_url.rb
+++ b/application/app/services/zenodo/zenodo_url.rb
@@ -32,8 +32,9 @@ module Zenodo
     end
 
     def zenodo_url
-      uri_class = @base.https? ? URI::HTTPS : URI::HTTP
-      uri_class.build(host: @base.domain, port: @base.port).to_s
+      base = "#{@base.scheme}://#{@base.domain}"
+      base += ":#{@base.port}" if @base.port
+      FluentUrl.new(base).to_s
     end
 
     def initialize(base_parser)

--- a/application/test/services/zenodo/concerns/zenodo_url_builder_test.rb
+++ b/application/test/services/zenodo/concerns/zenodo_url_builder_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+class DummyZenodoUrlBuilder
+  include Zenodo::Concerns::ZenodoUrlBuilder
+
+  attr_accessor :zenodo_url, :record_id, :file_name, :concept_id, :deposition_id
+end
+
+class Zenodo::Concerns::ZenodoUrlBuilderTest < ActiveSupport::TestCase
+  def setup
+    @builder = DummyZenodoUrlBuilder.new
+    @builder.zenodo_url = 'https://zenodo.org'
+    @builder.record_id = '1'
+    @builder.file_name = 'file.txt'
+    @builder.concept_id = '10'
+    @builder.deposition_id = '20'
+  end
+
+  test 'record_url builds correct URL' do
+    assert_equal 'https://zenodo.org/record/1', @builder.record_url
+  end
+
+  test 'file_url builds correct URL' do
+    assert_equal 'https://zenodo.org/record/1/files/file.txt', @builder.file_url
+  end
+
+  test 'concept_url builds correct URL' do
+    assert_equal 'https://zenodo.org/record/10', @builder.concept_url
+  end
+
+  test 'deposition_url builds correct URL' do
+    assert_equal 'https://zenodo.org/deposit/20', @builder.deposition_url
+  end
+
+  test 'deposition_edit_url builds correct URL' do
+    assert_equal 'https://zenodo.org/deposit/20#/files', @builder.deposition_edit_url
+  end
+
+  test 'user_depositions_url builds correct URL' do
+    assert_equal 'https://zenodo.org/deposit', @builder.user_depositions_url
+  end
+
+  test 'record_url raises when record_id missing' do
+    @builder.record_id = nil
+    assert_raises(RuntimeError, 'record_id is missing') { @builder.record_url }
+  end
+
+  test 'deposition_url raises when deposition_id missing' do
+    @builder.deposition_id = nil
+    assert_raises(RuntimeError, 'deposition_id is missing') { @builder.deposition_url }
+  end
+end

--- a/application/test/services/zenodo/record_service_test.rb
+++ b/application/test/services/zenodo/record_service_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class Zenodo::RecordServiceTest < ActiveSupport::TestCase
+  include FileFixtureHelper
+
+  def setup
+    @client = HttpClientMock.new(file_path: fixture_path('zenodo/record_response.json'))
+    @service = Zenodo::RecordService.new('https://zenodo.org', http_client: @client)
+  end
+
+  test 'find_record returns parsed record' do
+    record = @service.find_record('11')
+    assert_kind_of Zenodo::RecordResponse, record
+    assert_equal '11', record.id
+    assert_equal '/api/records/11', @client.called_path
+  end
+
+  test 'find_record returns nil when not found' do
+    client = HttpClientMock.new(file_path: fixture_path('zenodo/record_response.json'), status_code: 404)
+    service = Zenodo::RecordService.new('https://zenodo.org', http_client: client)
+    assert_nil service.find_record('99')
+  end
+end

--- a/application/test/services/zenodo/search_service_test.rb
+++ b/application/test/services/zenodo/search_service_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class Zenodo::SearchServiceTest < ActiveSupport::TestCase
+  include FileFixtureHelper
+
+  def setup
+    @client = HttpClientMock.new(file_path: fixture_path('zenodo/search_response.json'))
+    @service = Zenodo::SearchService.new('https://zenodo.org', http_client: @client)
+  end
+
+  test 'search builds URL and parses response' do
+    response = @service.search('query', page: 2, per_page: 5)
+    assert_kind_of Zenodo::SearchResponse, response
+    assert_equal 2, response.page
+    assert_equal '/api/records?page=2&q=query&size=5', @client.called_path
+  end
+
+  test 'search returns nil when request fails' do
+    client = HttpClientMock.new(file_path: fixture_path('zenodo/search_response.json'), status_code: 404)
+    service = Zenodo::SearchService.new('https://zenodo.org', http_client: client)
+    assert_nil service.search('missing')
+  end
+end

--- a/application/test/services/zenodo/user_service_test.rb
+++ b/application/test/services/zenodo/user_service_test.rb
@@ -28,7 +28,7 @@ class Zenodo::UserServiceTest < ActiveSupport::TestCase
     service = Zenodo::UserService.new(@base, http_client: http, api_key: 'KEY')
     records = service.list_user_records(q: 'test query', page: 2, per_page: 10, all_versions: true)
     assert_equal 2, records.length
-    assert_equal '/api/records?q=test+query&all_versions=true&page=2&size=10', http.called_path
+    assert_equal '/api/records?all_versions=true&page=2&q=test%20query&size=10', http.called_path
   end
 
   test 'get_user_profile returns profile info' do

--- a/application/test/services/zenodo/zenodo_url_test.rb
+++ b/application/test/services/zenodo/zenodo_url_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class Zenodo::ZenodoUrlTest < ActiveSupport::TestCase
+  test 'parses scheme, domain and port' do
+    url = 'http://localhost:3000/record/1'
+    zurl = Zenodo::ZenodoUrl.parse(url)
+
+    assert zurl
+    assert_equal 'http', zurl.scheme
+    assert_equal 'localhost', zurl.domain
+    assert_equal 3000, zurl.port
+    assert_equal 'http://localhost:3000/', zurl.zenodo_url
+  end
+
+  test 'parses zenodo root url' do
+    url = 'https://zenodo.org/'
+    zurl = Zenodo::ZenodoUrl.parse(url)
+
+    assert zurl.zenodo?
+    assert_equal 'https://zenodo.org/', zurl.zenodo_url
+  end
+
+  test 'parses record url' do
+    url = 'https://zenodo.org/records/99'
+    zurl = Zenodo::ZenodoUrl.parse(url)
+
+    assert zurl.record?
+    assert_equal '99', zurl.record_id
+  end
+
+  test 'parses file url' do
+    url = 'https://zenodo.org/records/99/files/data/file.txt'
+    zurl = Zenodo::ZenodoUrl.parse(url)
+
+    assert zurl.file?
+    assert_equal '99', zurl.record_id
+    assert_equal 'data/file.txt', zurl.file_name
+  end
+
+  test 'parses deposition url' do
+    url = 'https://zenodo.org/deposit/123'
+    zurl = Zenodo::ZenodoUrl.parse(url)
+
+    assert zurl.deposition?
+    assert_equal '123', zurl.deposition_id
+  end
+end


### PR DESCRIPTION
## Summary
- switch Zenodo services to FluentUrl for building paths
- update unit tests

## Testing
- `bundle exec rails test test/services/zenodo/user_service_test.rb test/services/zenodo/deposition_service_test.rb`
- `bundle exec rails test`

------
https://chatgpt.com/codex/tasks/task_e_686c489ea0bc832194fc592d58506852