### PR TITLE
Use FluentUrl for URL construction

### DIFF
--- a/application/app/connectors/dataverse/download_connector_processor.rb
+++ b/application/app/connectors/dataverse/download_connector_processor.rb
@@ -14,7 +14,13 @@ module Dataverse
 
     def download
       project = Project.find(file.project_id)
-      download_url = "#{connector_metadata.dataverse_url}/api/access/datafile/#{connector_metadata.id}?format=original"
+      download_url = FluentUrl.new(connector_metadata.dataverse_url)
+                             .add_path('api')
+                             .add_path('access')
+                             .add_path('datafile')
+                             .add_path(connector_metadata.id.to_s)
+                             .add_param(:format, 'original')
+                             .to_s
       download_location = File.join(project.download_dir, file.filename)
       temp_location ="#{download_location}.part"
       FileUtils.mkdir_p(File.dirname(download_location))

--- a/application/app/connectors/dataverse/upload_connector_processor.rb
+++ b/application/app/connectors/dataverse/upload_connector_processor.rb
@@ -16,7 +16,13 @@ module Dataverse
     end
 
     def upload
-      upload_url = "#{connector_metadata.dataverse_url}/api/datasets/:persistentId/add?persistentId=#{connector_metadata.dataset_id}"
+      upload_url = FluentUrl.new(connector_metadata.dataverse_url)
+                             .add_path('api')
+                             .add_path('datasets')
+                             .add_path(':persistentId')
+                             .add_path('add')
+                             .add_param(:persistentId, connector_metadata.dataset_id)
+                             .to_s
       source_location = file.file_location
       temp_location ="#{source_location}.part"
       headers = { "X-Dataverse-key" => connector_metadata.api_key&.value }

--- a/application/app/connectors/zenodo/upload_connector_processor.rb
+++ b/application/app/connectors/zenodo/upload_connector_processor.rb
@@ -20,7 +20,9 @@ module Zenodo
       # Step 2: Prepare file upload
       source_location = file.file_location
       file_name = File.basename(file.filename)
-      upload_url = "#{bucket_url}/#{file_name}"
+      upload_url = FluentUrl.new(bucket_url)
+                       .add_path(file_name)
+                       .to_s
 
       connector_metadata.upload_url = upload_url
       file.upload_bundle.update({ metadata: connector_metadata.to_h })


### PR DESCRIPTION
## Summary
- replace string concat URL generation with FluentUrl in connectors

## Testing
- `./scripts/loop_test.sh` *(fails: rbenv version `3.1.5` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686cd3b0c7a08321990bd9a1b29c8638