### PR TITLE
Update guide introduction

### DIFF
--- a/docs/guide/content/introduction.md
+++ b/docs/guide/content/introduction.md
@@ -1,12 +1,7 @@
 # Introduction
 
-In OnDemand Loop you organize your work in **projects**. Each project holds all downloads from and uploads to a given repository. Projects let you keep related data together and easily switch between different repositories when needed.
+**OnDemand Loop** extends Open OnDemand with an interface for moving data between your HPC cluster and remote repositories. The application is launched from the Open OnDemand dashboard (by default via **Files › OnDemand Loop**) and uses your regular credentials. When you first sign in, Loop creates an empty project so you can immediately begin adding transfers.
 
-With a project active you can:
+Projects keep downloads and uploads organized. Each project groups related files and provides quick links to monitor progress. The navigation bar offers access to your Projects list, global **Downloads** and **Uploads** pages, and the **Repositories** menu. Use **Explore** to paste a DOI or dataset URL when you already know exactly what you need.
 
-- **Explore remote repositories** by entering a URL that OnDemand Loop resolves to the appropriate connector.
-- **Download files** from a dataset into your cluster workspace.
-- **Create upload bundles** to stage local files for sending back to the repository.
-- **Browse local files** and monitor the progress of downloads and uploads.
-
-The rest of the User Guide explains each of these actions step by step so you can effectively manage data transfers through OnDemand Loop.
+Throughout this guide you'll learn how to browse repositories, collect data into projects, upload results, and return to the Open OnDemand dashboard at any time using the **Open OnDemand** link in the navigation bar. Loop performs discrete transfers rather than continuous syncs, ensuring reproducible, auditable steps for your research data.


### PR DESCRIPTION
## Summary
- rewrite introduction with an overview of how to access OnDemand Loop from Open OnDemand
- explain projects and navigation without using step-by-step instructions

## Testing
- `make guide` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cf39de84c83219ac34b11f1576b81