### PR TITLE
Add dataset citation URL support

### DIFF
--- a/application/app/services/dataverse/dataverse_url.rb
+++ b/application/app/services/dataverse/dataverse_url.rb
@@ -60,7 +60,7 @@ module Dataverse
       if segments.length == 2 && segments[0] == 'dataverse'
         @type = 'collection'
         @collection_id = segments[1]
-      elsif segments == ['dataset.xhtml']
+      elsif segments.length == 1 && %w[dataset.xhtml citation citation.xhtml].include?(segments[0])
         @type = 'dataset'
         @dataset_id = @base.params[:persistentId]
         @version = @base.params[:version]

--- a/application/test/services/dataverse/dataverse_url_test.rb
+++ b/application/test/services/dataverse/dataverse_url_test.rb
@@ -57,6 +57,26 @@ class Dataverse::DataverseUrlTest < ActiveSupport::TestCase
     assert_equal 'https://demo.dataverse.org/dataset.xhtml?persistentId=doi%3A10.1234%2FXYZ&version=1.0', dataverse_url.dataset_url(version: '1.0')
   end
 
+  test 'should parse dataset citation URL' do
+    url = 'https://demo.dataverse.org/citation?persistentId=doi:10.7939/DVN/10979'
+    dataverse_url = Dataverse::DataverseUrl.parse(url)
+
+    assert dataverse_url
+    assert dataverse_url.dataset?
+    assert_equal 'doi:10.7939/DVN/10979', dataverse_url.dataset_id
+    assert_nil dataverse_url.version
+  end
+
+  test 'should parse dataset citation.xhtml URL' do
+    url = 'https://demo.dataverse.org/citation.xhtml?persistentId=doi:10.7939/DVN/10979'
+    dataverse_url = Dataverse::DataverseUrl.parse(url)
+
+    assert dataverse_url
+    assert dataverse_url.dataset?
+    assert_equal 'doi:10.7939/DVN/10979', dataverse_url.dataset_id
+    assert_nil dataverse_url.version
+  end
+
   test 'should parse file URL with persistentId and fileId' do
     url = 'https://demo.dataverse.org/file.xhtml?persistentId=doi:10.1234/XYZ/ABC&fileId=123&version=1.0'
     dataverse_url = Dataverse::DataverseUrl.parse(url)


### PR DESCRIPTION
## Summary
- handle `citation` and `citation.xhtml` paths in Dataverse URL parsing
- test dataset citation URLs with demo.dataverse.org

## Testing
- `RBENV_VERSION=3.2.3 bundle exec rake test` *(fails: Could not find rubocop-rails-omakase-1.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_686e440262b08321ae7a760cd323717a