### PR TITLE
Add embargo support for dataverse files

### DIFF
--- a/application/app/services/dataverse/dataverse_restrictions_service.rb
+++ b/application/app/services/dataverse/dataverse_restrictions_service.rb
@@ -22,10 +22,10 @@ module Dataverse
     def validate_dataset_file(file)
       response = { valid?: true, message: nil }
 
-      if file.restricted
+      if !file.public?
         response = {
           valid?: false,
-          message: I18n.t('dataverse.restrictions.dataset_file.restricted_message')
+          message: I18n.t('dataverse.restrictions.dataset_file.unavailable_message')
         }
       elsif file.data_file.nil?
         response = {

--- a/application/config/locales/connectors/dataverse/en.yml
+++ b/application/config/locales/connectors/dataverse/en.yml
@@ -157,10 +157,10 @@ en:
         page_title: "OnDemand Loop - Dataverse Landing page"
 
     restrictions:
-      dataset_file:
-        restricted_message: "File is restricted. Restricted files not supported"
-        missing_file_message: "File data is not present"
-        file_size_message: "Files bigger than %{max_size} are not supported"
+        dataset_file:
+          unavailable_message: "File is not publicly downloadable"
+          missing_file_message: "File data is not present"
+          file_size_message: "Files bigger than %{max_size} are not supported"
   helpers:
     dataverse:
       invalid_hostname: "Invalid Dataverse hostname"

--- a/application/config/locales/connectors/dataverse/en.yml
+++ b/application/config/locales/connectors/dataverse/en.yml
@@ -157,10 +157,10 @@ en:
         page_title: "OnDemand Loop - Dataverse Landing page"
 
     restrictions:
-        dataset_file:
-          unavailable_message: "File is not publicly downloadable"
-          missing_file_message: "File data is not present"
-          file_size_message: "Files bigger than %{max_size} are not supported"
+      dataset_file:
+        unavailable_message: "Restricted or embargoed files cannot be downloaded"
+        missing_file_message: "File data is not present"
+        file_size_message: "Files bigger than %{max_size} are not supported"
   helpers:
     dataverse:
       invalid_hostname: "Invalid Dataverse hostname"

--- a/application/test/fixtures/dataverse/dataset_files_response/valid_response_embargo.json
+++ b/application/test/fixtures/dataverse/dataset_files_response/valid_response_embargo.json
@@ -1,0 +1,57 @@
+{
+  "status": "OK",
+  "totalCount": 2,
+  "data": [
+    {
+      "label": "screenshot.png",
+      "restricted": false,
+      "version": 1,
+      "datasetVersionId": 2,
+      "dataFile": {
+        "id": 4,
+        "persistentId": "",
+        "filename": "screenshot.png",
+        "contentType": "image/png",
+        "friendlyType": "PNG Image",
+        "filesize": 272314,
+        "storageIdentifier": "local://1946f5acedb-fdf849a8d0f3",
+        "rootDataFileId": -1,
+        "md5": "13035cba04a51f54dd8101fe726cda5c",
+        "checksum": {
+          "type": "MD5",
+          "value": "13035cba04a51f54dd8101fe726cda5c"
+        },
+        "tabularData": false,
+        "creationDate": "2025-01-16",
+        "publicationDate": "2025-01-20",
+        "fileAccessRequest": true,
+        "embargo": {"dateAvailable": "2099-09-05", "reason": "Testing Loop"}
+      }
+    },
+    {
+      "label": "396944036-79689c96-38e6-49e4-b22d-773953a40e4c.png",
+      "restricted": false,
+      "version": 1,
+      "datasetVersionId": 2,
+      "dataFile": {
+        "id": 5,
+        "persistentId": "",
+        "filename": "396944036-79689c96-38e6-49e4-b22d-773953a40e4c.png",
+        "contentType": "image/png",
+        "friendlyType": "PNG Image",
+        "filesize": 144887,
+        "storageIdentifier": "local://1949312ad71-5ce5d22b4eb8",
+        "rootDataFileId": -1,
+        "md5": "a8aad87fae7780f0d46f85070065b56c",
+        "checksum": {
+          "type": "MD5",
+          "value": "a8aad87fae7780f0d46f85070065b56c"
+        },
+        "tabularData": false,
+        "creationDate": "2025-01-23",
+        "publicationDate": "2025-01-23",
+        "fileAccessRequest": true
+      }
+    }
+  ]
+}

--- a/application/test/services/dataverse/dataverse_restrictions_service_test.rb
+++ b/application/test/services/dataverse/dataverse_restrictions_service_test.rb
@@ -27,7 +27,7 @@ class Dataverse::DataverseRestrictionsServiceTest < ActiveSupport::TestCase
     response = validation_service.validate_dataset_file(file)
 
     assert_not response.valid?, 'File should be invalid when not public'
-    assert_equal 'File is not publicly downloadable', response.message
+    assert_equal 'Restricted or embargoed files cannot be downloaded', response.message
   end
 
   test 'should validate file within max_size constraint' do

--- a/application/test/services/dataverse/dataverse_restrictions_service_test.rb
+++ b/application/test/services/dataverse/dataverse_restrictions_service_test.rb
@@ -17,24 +17,24 @@ class Dataverse::DataverseRestrictionsServiceTest < ActiveSupport::TestCase
     assert_nil response.message, 'There should be no error message for valid dataset'
   end
 
-  test 'should return invalid file for being restricted' do
+  test 'should return invalid file when not public' do
     file = mock('file')
     data_file = mock('data_file')
-    file.stubs(:restricted).returns(true)
+    file.stubs(:public?).returns(false)
     file.stubs(:data_file).returns(data_file)
 
     validation_service = Dataverse::DataverseRestrictionsService.new
     response = validation_service.validate_dataset_file(file)
 
-    assert_not response.valid?, 'File should be invalid when restricted'
-    assert_equal "File is restricted. Restricted files not supported", response.message
+    assert_not response.valid?, 'File should be invalid when not public'
+    assert_equal 'File is not publicly downloadable', response.message
   end
 
   test 'should validate file within max_size constraint' do
     # Create a mock file with valid file size
     file = mock('file')
     data_file = mock('data_file')
-    file.stubs(:restricted).returns(false)
+    file.stubs(:public?).returns(true)
     file.stubs(:data_file).returns(data_file)
     data_file.stubs(:filesize).returns(9.gigabytes) # Less than max_file_size
 
@@ -49,7 +49,7 @@ class Dataverse::DataverseRestrictionsServiceTest < ActiveSupport::TestCase
     # Create a mock file with size exceeding the limit
     file = mock('file')
     data_file = mock('data_file')
-    file.stubs(:restricted).returns(false)
+    file.stubs(:public?).returns(true)
     file.stubs(:data_file).returns(data_file)
     data_file.stubs(:filesize).returns(11.gigabytes) # More than max_file_size
 
@@ -68,7 +68,7 @@ class Dataverse::DataverseRestrictionsServiceTest < ActiveSupport::TestCase
 
     file = mock('file')
     data_file = mock('data_file')
-    file.stubs(:restricted).returns(false)
+    file.stubs(:public?).returns(true)
     file.stubs(:data_file).returns(data_file)
     data_file.stubs(:filesize).returns(6.gigabytes) # More than 5 GB
 


### PR DESCRIPTION
## Summary
- parse embargo metadata in `Dataverse::DatasetFilesResponse`
- expose `public?` helper on dataset file
- add embargo fixture and tests for the new behaviour
- fix embargo attribute parsing
- test absence of embargo in default fixture

## Testing
- `application/bin/rubocop` *(fails: rbenv: version `3.1.5` is not installed)*
- `application/bin/rails test` *(fails: rbenv: version `3.1.5` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6870ede377d48321a14a76bbfd022158