### PR TITLE
Add issue labeling step after release

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -118,7 +118,7 @@ jobs:
 
   label_issues:
     name: Label Issues With Release Tag
-    needs: [release, comment]
+    needs: [release]
     if: needs.release.result == 'success'
     uses: ./.github/workflows/label_issues_on_release.yml
     with:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -115,3 +115,11 @@ jobs:
             **Notes**: [View GitHub Release Notes](${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.release.outputs.version }})
             **Commit Hash**: `${{ needs.validate.outputs.commit_hash || 'N/A' }}`
             **Run**: [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+  label_issues:
+    name: Label Issues With Release Tag
+    needs: [release, comment]
+    if: needs.release.result == 'success'
+    uses: ./.github/workflows/label_issues_on_release.yml
+    with:
+      release_tag: ${{ needs.release.outputs.version }}

--- a/.github/workflows/label_issues_on_release.yml
+++ b/.github/workflows/label_issues_on_release.yml
@@ -1,13 +1,17 @@
 name: Label Issues With Release Tag
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       release_tag:
         description: 'Release tag to use (e.g. v1.0.0+2025-07-01)'
         required: true
+  workflow_call:
+    inputs:
+      release_tag:
+        description: 'Release tag to use (e.g. v1.0.0+2025-07-01)'
+        required: false
+        type: string
 
 jobs:
   label_completed_issues:
@@ -31,7 +35,7 @@ jobs:
       - name: Label completed issues since last release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag || github.event.inputs.release_tag }}
         run: |
           import os
           from github import Github


### PR DESCRIPTION
## Summary
- call the label issues workflow from the create release workflow
- allow label_issues_on_release workflow to be re-used via `workflow_call`
- support passing a release tag input when called
- fix indentation and remove unused release trigger

## Testing
- `make test` *(fails: docker missing)*

------
https://chatgpt.com/codex/tasks/task_e_687127238328832193aa21c6b9025bb0