### PR TITLE
Add repository settings controller and views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,6 @@ application/vendor/bundle
 .idea
 /application/app/assets/builds/*
 !/application/app/assets/builds/.keep
-/application/bun.lock
 
 /application/node_modules
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ application/vendor/bundle
 .idea
 /application/app/assets/builds/*
 !/application/app/assets/builds/.keep
+/application/bun.lock
 
 /application/node_modules
 

--- a/application/app/assets/stylesheets/navigation.scss
+++ b/application/app/assets/stylesheets/navigation.scss
@@ -1,4 +1,8 @@
 nav {
+  li.nav-item a.active {
+    background-color: #495057;
+  }
+
   .icon-wrapper {
     width: 25px;
     height: 25px;

--- a/application/app/connectors/connector_class_dispatcher.rb
+++ b/application/app/connectors/connector_class_dispatcher.rb
@@ -24,6 +24,10 @@ class ConnectorClassDispatcher
     self.load(upload_bundle.type, 'UploadBundleConnectorMetadata', upload_bundle)
   end
 
+  def self.repository_settings_processor(type)
+    self.load(type, 'RepositorySettingsProcessor', nil)
+  end
+
   def self.download_processor(download_file)
     self.load(download_file.type, 'DownloadConnectorProcessor', download_file)
   end

--- a/application/app/connectors/dataverse/actions/connector_edit.rb
+++ b/application/app/connectors/dataverse/actions/connector_edit.rb
@@ -15,8 +15,8 @@ module Dataverse::Actions
         metadata[:auth_key] = repo_key
         upload_bundle.update({ metadata: metadata })
       else
-        server_domain = upload_bundle.connector_metadata.server_domain
-        RepoRegistry.repo_db.update(server_domain, metadata: {auth_key: repo_key})
+        dataverse_url = upload_bundle.connector_metadata.dataverse_url
+        RepoRegistry.repo_db.update(dataverse_url, metadata: {auth_key: repo_key})
       end
 
       ConnectorResult.new(

--- a/application/app/connectors/dataverse/actions/dataset_create.rb
+++ b/application/app/connectors/dataverse/actions/dataset_create.rb
@@ -3,11 +3,11 @@ module Dataverse::Actions
     def edit(upload_bundle, request_params)
       connector_metadata = upload_bundle.connector_metadata
       repo_db = RepoRegistry.repo_db
-      dataverse_data = repo_db.get(connector_metadata.server_domain)
+      dataverse_data = repo_db.get(connector_metadata.dataverse_url)
       if dataverse_data.metadata.subjects.nil?
         dv_metadata_service = Dataverse::MetadataService.new(connector_metadata.dataverse_url)
         subjects = dv_metadata_service.get_citation_metadata.subjects
-        repo_db.update(connector_metadata.server_domain, metadata: { subjects: subjects })
+        repo_db.update(connector_metadata.dataverse_url, metadata: { subjects: subjects })
       else
         subjects = dataverse_data.metadata.subjects
       end

--- a/application/app/connectors/dataverse/actions/dataset_create.rb
+++ b/application/app/connectors/dataverse/actions/dataset_create.rb
@@ -3,7 +3,7 @@ module Dataverse::Actions
     def edit(upload_bundle, request_params)
       connector_metadata = upload_bundle.connector_metadata
       repo_db = RepoRegistry.repo_db
-      dataverse_data = repo_db.get(connezctor_metadata.server_domain)
+      dataverse_data = repo_db.get(connector_metadata.server_domain)
       if dataverse_data.metadata.subjects.nil?
         dv_metadata_service = Dataverse::MetadataService.new(connector_metadata.dataverse_url)
         subjects = dv_metadata_service.get_citation_metadata.subjects

--- a/application/app/connectors/dataverse/actions/dataset_create.rb
+++ b/application/app/connectors/dataverse/actions/dataset_create.rb
@@ -3,7 +3,7 @@ module Dataverse::Actions
     def edit(upload_bundle, request_params)
       connector_metadata = upload_bundle.connector_metadata
       repo_db = RepoRegistry.repo_db
-      dataverse_data = repo_db.get(connector_metadata.server_domain)
+      dataverse_data = repo_db.get(connezctor_metadata.server_domain)
       if dataverse_data.metadata.subjects.nil?
         dv_metadata_service = Dataverse::MetadataService.new(connector_metadata.dataverse_url)
         subjects = dv_metadata_service.get_citation_metadata.subjects

--- a/application/app/connectors/dataverse/actions/dataset_form_tabs.rb
+++ b/application/app/connectors/dataverse/actions/dataset_form_tabs.rb
@@ -28,11 +28,11 @@ module Dataverse::Actions
     def subjects(upload_bundle)
       connector_metadata = upload_bundle.connector_metadata
       repo_db = RepoRegistry.repo_db
-      dataverse_data = repo_db.get(connector_metadata.server_domain)
+      dataverse_data = repo_db.get(connector_metadata.dataverse_url)
       if dataverse_data.metadata.subjects.nil?
         dv_metadata_service = Dataverse::MetadataService.new(connector_metadata.dataverse_url)
         subjects = dv_metadata_service.get_citation_metadata.subjects
-        repo_db.update(connector_metadata.server_domain, metadata: { subjects: subjects })
+        repo_db.update(connector_metadata.dataverse_url, metadata: { subjects: subjects })
       else
         subjects = dataverse_data.metadata.subjects
       end

--- a/application/app/connectors/dataverse/repository_settings_processor.rb
+++ b/application/app/connectors/dataverse/repository_settings_processor.rb
@@ -12,7 +12,7 @@ module Dataverse
       repo_url = request_params[:repo_url]
       RepoRegistry.repo_db.update(repo_url, metadata: { auth_key: request_params[:auth_key] })
       ConnectorResult.new(
-        message: { notice: I18n.t('connectors.dataverse.actions.repository_settings_create.message_success', domain: repo_url) },
+        message: { notice: I18n.t('connectors.dataverse.actions.repository_settings_update.message_success', url: repo_url, type: repo.type) },
         success: true
       )
     end

--- a/application/app/connectors/dataverse/repository_settings_processor.rb
+++ b/application/app/connectors/dataverse/repository_settings_processor.rb
@@ -1,0 +1,20 @@
+module Dataverse
+  class RepositorySettingsProcessor
+    def initialize(object = nil)
+      # Needed to implement expected interface in ConnectorClassDispatcher
+    end
+
+    def params_schema
+      [:repo_url, :auth_key]
+    end
+
+    def update(repo, request_params)
+      repo_url = request_params[:repo_url]
+      RepoRegistry.repo_db.update(repo_url, metadata: { auth_key: request_params[:auth_key] })
+      ConnectorResult.new(
+        message: { notice: I18n.t('connectors.dataverse.actions.repository_settings_create.message_success', domain: repo_url) },
+        success: true
+      )
+    end
+  end
+end

--- a/application/app/connectors/dataverse/repository_settings_processor.rb
+++ b/application/app/connectors/dataverse/repository_settings_processor.rb
@@ -9,10 +9,9 @@ module Dataverse
     end
 
     def update(repo, request_params)
-      repo_url = request_params[:repo_url]
-      RepoRegistry.repo_db.update(repo_url, metadata: { auth_key: request_params[:auth_key] })
+      RepoRegistry.repo_db.update(repo.repo_url, metadata: { auth_key: request_params[:auth_key] })
       ConnectorResult.new(
-        message: { notice: I18n.t('connectors.dataverse.actions.repository_settings_update.message_success', url: repo_url, type: repo.type) },
+        message: { notice: I18n.t('connectors.dataverse.actions.repository_settings_update.message_success', url: repo.repo_url, type: repo.type) },
         success: true
       )
     end

--- a/application/app/connectors/dataverse/upload_bundle_connector_metadata.rb
+++ b/application/app/connectors/dataverse/upload_bundle_connector_metadata.rb
@@ -25,7 +25,7 @@ module Dataverse
     def api_key
       return OpenStruct.new({ bundle?: true, server?: false, value: @metadata[:auth_key] }) if @metadata[:auth_key]
 
-      repo_info = RepoRegistry.repo_db.get(server_domain)
+      repo_info = RepoRegistry.repo_db.get(dataverse_url)
       OpenStruct.new({ bundle?: false, server?: true, value: repo_info.metadata.auth_key }) if repo_info && repo_info.metadata.auth_key
     end
 

--- a/application/app/connectors/dataverse/upload_bundle_connector_metadata.rb
+++ b/application/app/connectors/dataverse/upload_bundle_connector_metadata.rb
@@ -17,10 +17,6 @@ module Dataverse
       nil
     end
 
-    def server_domain
-      @server_domain ||= URI.parse(dataverse_url).host
-    end
-
     # TODO: Improve this logic
     def api_key
       return OpenStruct.new({ bundle?: true, server?: false, value: @metadata[:auth_key] }) if @metadata[:auth_key]

--- a/application/app/connectors/zenodo/actions/connector_edit.rb
+++ b/application/app/connectors/zenodo/actions/connector_edit.rb
@@ -17,8 +17,8 @@ module Zenodo::Actions
         metadata[:auth_key] = repo_key
         upload_bundle.update({ metadata: metadata })
       else
-        server_domain = upload_bundle.connector_metadata.server_domain
-        RepoRegistry.repo_db.update(server_domain, metadata: {auth_key: repo_key})
+        zenodo_url = upload_bundle.connector_metadata.zenodo_url
+        RepoRegistry.repo_db.update(zenodo_url, metadata: {auth_key: repo_key})
       end
 
       ConnectorResult.new(

--- a/application/app/connectors/zenodo/actions/upload_bundle_create.rb
+++ b/application/app/connectors/zenodo/actions/upload_bundle_create.rb
@@ -41,7 +41,6 @@ module Zenodo::Actions
         bundle.type = ConnectorType::ZENODO
         bundle.creation_date = now
         bundle.metadata = {
-          server_domain: url_data.domain,
           zenodo_url: url_data.zenodo_url,
           title: title,
           record_id: url_data.record_id,

--- a/application/app/connectors/zenodo/actions/upload_bundle_create.rb
+++ b/application/app/connectors/zenodo/actions/upload_bundle_create.rb
@@ -19,7 +19,7 @@ module Zenodo::Actions
         title = record.title
         concept_id = record.concept_id
       elsif url_data.deposition?
-        repo_info = RepoRegistry.repo_db.get(url_data.domain)
+        repo_info = RepoRegistry.repo_db.get(url_data.zenodo_url)
         if repo_info.metadata.auth_key.present?
           deposition_service = Zenodo::DepositionService.new(url_data.zenodo_url, api_key: repo_info.metadata.auth_key)
           deposition = deposition_service.find_deposition(url_data.deposition_id)

--- a/application/app/connectors/zenodo/repository_settings_processor.rb
+++ b/application/app/connectors/zenodo/repository_settings_processor.rb
@@ -9,10 +9,9 @@ module Zenodo
     end
 
     def update(repo, request_params)
-      repo_url = request_params[:repo_url]
-      RepoRegistry.repo_db.update(repo_url, metadata: { auth_key: request_params[:auth_key] })
+      RepoRegistry.repo_db.update(repo.repo_url, metadata: { auth_key: request_params[:auth_key] })
       ConnectorResult.new(
-        message: { notice: I18n.t('connectors.zenodo.actions.repository_settings_update.message_success', url: repo_url, type: repo.type) },
+        message: { notice: I18n.t('connectors.zenodo.actions.repository_settings_update.message_success', url: repo.repo_url, type: repo.type) },
         success: true
       )
     end

--- a/application/app/connectors/zenodo/repository_settings_processor.rb
+++ b/application/app/connectors/zenodo/repository_settings_processor.rb
@@ -12,7 +12,7 @@ module Zenodo
       repo_url = request_params[:repo_url]
       RepoRegistry.repo_db.update(repo_url, metadata: { auth_key: request_params[:auth_key] })
       ConnectorResult.new(
-        message: { notice: I18n.t('connectors.zenodo.actions.repository_settings_create.message_success', domain: repo_url) },
+        message: { notice: I18n.t('connectors.zenodo.actions.repository_settings_update.message_success', url: repo_url, type: repo.type) },
         success: true
       )
     end

--- a/application/app/connectors/zenodo/repository_settings_processor.rb
+++ b/application/app/connectors/zenodo/repository_settings_processor.rb
@@ -1,0 +1,20 @@
+module Zenodo
+  class RepositorySettingsProcessor
+    def initialize(object = nil)
+      # Needed to implement expected interface in ConnectorClassDispatcher
+    end
+
+    def params_schema
+      [:repo_url, :auth_key]
+    end
+
+    def update(repo, request_params)
+      repo_url = request_params[:repo_url]
+      RepoRegistry.repo_db.update(repo_url, metadata: { auth_key: request_params[:auth_key] })
+      ConnectorResult.new(
+        message: { notice: I18n.t('connectors.zenodo.actions.repository_settings_create.message_success', domain: repo_url) },
+        success: true
+      )
+    end
+  end
+end

--- a/application/app/connectors/zenodo/upload_bundle_connector_metadata.rb
+++ b/application/app/connectors/zenodo/upload_bundle_connector_metadata.rb
@@ -18,7 +18,7 @@ module Zenodo
     def api_key
       return OpenStruct.new({ bundle?: true, server?: false, value: @metadata[:auth_key] }) if @metadata[:auth_key]
 
-      repo_info = RepoRegistry.repo_db.get(server_domain)
+      repo_info = RepoRegistry.repo_db.get(zenodo_url)
       OpenStruct.new({ bundle?: false, server?: true, value: repo_info.metadata.auth_key }) if repo_info && repo_info.metadata.auth_key
     end
 

--- a/application/app/controllers/repository_settings_controller.rb
+++ b/application/app/controllers/repository_settings_controller.rb
@@ -32,7 +32,7 @@ class RepositorySettingsController < ApplicationController
   end
 
   def destroy
-    domain = params[:domain]
+    domain = params[:domain].to_s.strip
     repo = RepoRegistry.repo_db.get(domain)
     unless repo
       redirect_to repository_settings_path, alert: t('.message_not_found', domain: domain) and return

--- a/application/app/controllers/repository_settings_controller.rb
+++ b/application/app/controllers/repository_settings_controller.rb
@@ -20,25 +20,25 @@ class RepositorySettingsController < ApplicationController
   end
 
   def update
-    domain = params[:domain]
-    repo = RepoRegistry.repo_db.get(domain)
+    repo_url = params[:repo_url]
+    repo = RepoRegistry.repo_db.get(repo_url)
     unless repo
-      redirect_to repository_settings_path, alert: t('.message_not_found', domain: domain) and return
+      redirect_to repository_settings_path, alert: t('.message_not_found', domain: repo_url) and return
     end
 
     metadata = params.fetch(:metadata, {}).permit!.to_h
-    RepoRegistry.repo_db.update(domain, metadata: metadata)
-    redirect_to repository_settings_path, notice: t('.message_success', domain: domain)
+    RepoRegistry.repo_db.update(repo_url, metadata: metadata)
+    redirect_to repository_settings_path, notice: t('.message_success', domain: repo_url)
   end
 
   def destroy
-    domain = params[:domain].to_s.strip
-    repo = RepoRegistry.repo_db.get(domain)
+    repo_url = params[:repo_url].to_s.strip
+    repo = RepoRegistry.repo_db.get(repo_url)
     unless repo
-      redirect_to repository_settings_path, alert: t('.message_not_found', domain: domain) and return
+      redirect_to repository_settings_path, alert: t('.message_not_found', domain: repo_url) and return
     end
 
-    RepoRegistry.repo_db.delete(domain)
-    redirect_to repository_settings_path, notice: t('.message_deleted', domain: domain, type: repo.type.to_s)
+    RepoRegistry.repo_db.delete(repo_url)
+    redirect_to repository_settings_path, notice: t('.message_deleted', domain: repo_url, type: repo.type.to_s)
   end
 end

--- a/application/app/controllers/repository_settings_controller.rb
+++ b/application/app/controllers/repository_settings_controller.rb
@@ -1,0 +1,17 @@
+class RepositorySettingsController < ApplicationController
+  def index
+    @repositories = RepoRegistry.repo_db.all
+  end
+
+  def update
+    domain = params[:domain]
+    repo = RepoRegistry.repo_db.get(domain)
+    unless repo
+      redirect_to repository_settings_path, alert: t('.repo_not_found', domain: domain) and return
+    end
+
+    metadata = params.fetch(:metadata, {}).permit!.to_h
+    RepoRegistry.repo_db.update(domain, metadata: metadata)
+    redirect_to repository_settings_path, notice: t('.repo_updated', domain: domain)
+  end
+end

--- a/application/app/controllers/repository_settings_controller.rb
+++ b/application/app/controllers/repository_settings_controller.rb
@@ -26,9 +26,11 @@ class RepositorySettingsController < ApplicationController
       redirect_to repository_settings_path, alert: t('.message_not_found', domain: repo_url) and return
     end
 
-    metadata = params.fetch(:metadata, {}).permit!.to_h
-    RepoRegistry.repo_db.update(repo_url, metadata: metadata)
-    redirect_to repository_settings_path, notice: t('.message_success', domain: repo_url)
+    processor = ConnectorClassDispatcher.repository_settings_processor(repo.type)
+    processor_params = params.permit(*processor.params_schema).to_h
+    result = processor.update(repo, processor_params)
+
+    redirect_to repository_settings_path, **result.message
   end
 
   def destroy

--- a/application/app/controllers/repository_settings_controller.rb
+++ b/application/app/controllers/repository_settings_controller.rb
@@ -3,6 +3,18 @@ class RepositorySettingsController < ApplicationController
     @repositories = RepoRegistry.repo_db.all
   end
 
+  def create
+    repo_url = params[:repo_url]
+    repo_resolver = Repo::RepoResolverService.new(RepoRegistry.resolvers)
+    result = repo_resolver.resolve(repo_url)
+
+    if result.unknown?
+      redirect_to repository_settings_path, alert: t('.invalid_repo', url: repo_url) and return
+    end
+
+    redirect_to repository_settings_path, notice: t('.repo_added', type: result.type.to_s)
+  end
+
   def update
     domain = params[:domain]
     repo = RepoRegistry.repo_db.get(domain)

--- a/application/app/controllers/repository_settings_controller.rb
+++ b/application/app/controllers/repository_settings_controller.rb
@@ -30,4 +30,15 @@ class RepositorySettingsController < ApplicationController
     RepoRegistry.repo_db.update(domain, metadata: metadata)
     redirect_to repository_settings_path, notice: t('.message_success', domain: domain)
   end
+
+  def destroy
+    domain = params[:domain]
+    repo = RepoRegistry.repo_db.get(domain)
+    unless repo
+      redirect_to repository_settings_path, alert: t('.message_not_found', domain: domain) and return
+    end
+
+    RepoRegistry.repo_db.delete(domain)
+    redirect_to repository_settings_path, notice: t('.message_deleted', domain: domain, type: repo.type.to_s)
+  end
 end

--- a/application/app/helpers/repository_settings_helper.rb
+++ b/application/app/helpers/repository_settings_helper.rb
@@ -1,0 +1,6 @@
+module RepositorySettingsHelper
+  def browse_repository_path(repo_url, entry)
+    resolver = ConnectorClassDispatcher.repo_controller_resolver(entry.type)
+    resolver.get_controller_url(repo_url).redirect_url
+  end
+end

--- a/application/app/services/repo/repo_db.rb
+++ b/application/app/services/repo/repo_db.rb
@@ -55,7 +55,11 @@ module Repo
     end
 
     def delete(domain)
-      @data.delete(domain)
+      return unless @data.key?(domain)
+
+      entry = @data.delete(domain)
+      persist!
+      log_info('Entry deleted', { domain: domain, type: entry&.type })
     end
 
     def size

--- a/application/app/services/repo/repo_db.rb
+++ b/application/app/services/repo/repo_db.rb
@@ -26,40 +26,40 @@ module Repo
       @data = load_data
     end
 
-    def get(domain)
-      @data[domain]
+    def get(repo_url)
+      @data[repo_url]
     end
 
-    def set(domain, type:, metadata: nil)
+    def set(repo_url, type:, metadata: nil)
       raise ArgumentError, "Invalid type: #{type}" unless type.is_a?(ConnectorType)
 
-      metadata = @data[domain]&[:metadata] || {} if metadata.nil?
-      @data[domain] = Entry.new(
+      metadata = @data[repo_url]&.metadata.to_h if metadata.nil?
+      @data[repo_url] = Entry.new(
         type: type.to_s,
         last_updated: Time.now.to_s,
         metadata: metadata
       )
       persist!
-      log_info('Entry added', {domain: domain, type: type})
+      log_info('Entry added', {repo_url: repo_url, type: type})
     end
 
-    def update(domain, metadata:)
-      raise ArgumentError, "Unknown domain: #{domain}" unless @data.key?(domain)
+    def update(repo_url, metadata:)
+      raise ArgumentError, "Unknown repo url: #{repo_url}" unless @data.key?(repo_url)
 
-      entry = @data[domain]
+      entry = @data[repo_url]
       entry.last_updated = Time.now.to_s
       entry[:metadata] ||= {}
       entry[:metadata] = entry[:metadata].merge(metadata)
       persist!
-      log_info('Entry updated', { domain: domain, type: entry.type })
+      log_info('Entry updated', { repo_url: repo_url, type: entry.type })
     end
 
-    def delete(domain)
-      return unless @data.key?(domain)
+    def delete(repo_url)
+      return unless @data.key?(repo_url)
 
-      entry = @data.delete(domain)
+      entry = @data.delete(repo_url)
       persist!
-      log_info('Entry deleted', { domain: domain, type: entry&.type })
+      log_info('Entry deleted', { repo_url: repo_url, type: entry&.type })
     end
 
     def size

--- a/application/app/services/repo/repo_db.rb
+++ b/application/app/services/repo/repo_db.rb
@@ -97,16 +97,16 @@ module Repo
       return {} unless File.exist?(db_path)
 
       raw = YAML.load_file(db_path) || {}
-      raw.map do |url, v|
+      raw.each_with_object({}) do |(url, v), data|
         v = v.symbolize_keys
-        [url, Entry.new(
+        data[url] = Entry.new(
           repo_url: url,
           type: v[:type],
           creation_date: v[:creation_date],
           last_updated: v[:last_updated],
           metadata: v[:metadata] || {}
-        )]
-      end.to_h
+        )
+      end
     end
 
     def persist!

--- a/application/app/services/repo/repo_db.rb
+++ b/application/app/services/repo/repo_db.rb
@@ -3,6 +3,7 @@
 module Repo
   class RepoDb
     include LoggingCommon
+    include DateTimeCommon
 
     class Entry < Struct.new(:type, :creation_date, :last_updated, :metadata, keyword_init: true)
       def type
@@ -35,7 +36,7 @@ module Repo
 
       existing = @data[repo_url]
       metadata = existing&.metadata.to_h if metadata.nil?
-      creation_date = existing&.creation_date || Time.now.to_s
+      creation_date = existing&.creation_date || now
       @data[repo_url] = Entry.new(
         type: type.to_s,
         creation_date: creation_date,

--- a/application/app/services/repo/repo_resolver_context.rb
+++ b/application/app/services/repo/repo_resolver_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Repo
   class RepoResolverContext
     attr_reader :input, :parsed_input, :http_client, :repo_db
@@ -23,7 +25,7 @@ module Repo
     end
 
     def resolved?
-      type.present?
+      object_url.present? && type.present?
     end
 
     def unknown?

--- a/application/app/services/repo/resolvers/dataverse_resolver.rb
+++ b/application/app/services/repo/resolvers/dataverse_resolver.rb
@@ -24,9 +24,10 @@ module Repo
 
         domain = repo_url.domain
         return unless domain
+        repo_base_url = repo_url.dataverse_url
 
-        log_info('Checking RepoCache', {domain: domain})
-        repo_info = context.repo_db.get(domain)
+        log_info('Checking RepoCache', {repo_url: repo_base_url})
+        repo_info = context.repo_db.get(repo_base_url)
         if repo_info
           context.type = repo_info.type
           return
@@ -34,13 +35,13 @@ module Repo
 
         log_info('Checking DataverseHub', {domain: domain})
         if known_dataverse_installation?(domain)
-          success(context, domain)
+          success(context, repo_base_url)
           return
         end
 
         log_info('Checking Dataverse API', {dataverse_url: repo_url.dataverse_url})
         if responds_to_api?(context.http_client, repo_url)
-          success(context, domain)
+          success(context, repo_base_url)
           return
         end
       end
@@ -70,9 +71,9 @@ module Repo
         false
       end
 
-      def success(context, domain)
+      def success(context, repo_base_url)
         context.type = ConnectorType::DATAVERSE
-        context.repo_db.set(domain, type: ConnectorType::DATAVERSE)
+        context.repo_db.set(repo_base_url, type: ConnectorType::DATAVERSE)
       end
 
     end

--- a/application/app/services/repo/resolvers/zenodo_resolver.rb
+++ b/application/app/services/repo/resolvers/zenodo_resolver.rb
@@ -23,7 +23,7 @@ module Repo
         return unless ZENODO_DOMAINS.include?(repo_url.domain)
 
         context.type = ConnectorType::ZENODO
-        context.repo_db.set(repo_url.domain, type: ConnectorType::ZENODO)
+        context.repo_db.set(repo_url.zenodo_url, type: ConnectorType::ZENODO)
 
         log_info("ZenodoResolver matched URL: #{context.object_url}")
       end

--- a/application/app/views/connectors/dataverse/_repo_settings.html.erb
+++ b/application/app/views/connectors/dataverse/_repo_settings.html.erb
@@ -1,4 +1,5 @@
-<%= form_with url: repository_setting_path(domain), method: :put, local: true do |f| %>
+<%= form_with url: repository_settings_path, method: :put, local: true do |f| %>
+  <%= hidden_field_tag :domain, domain %>
   <div class="mb-3">
     <%= f.label :auth_key, t('connectors.dataverse.connector_edit_form.field_api_key_label'), class: 'form-label fw-bold' %>
     <%= f.text_field :auth_key, value: metadata.auth_key, class: 'form-control', placeholder: t('connectors.dataverse.connector_edit_form.field_api_key_placeholder') %>

--- a/application/app/views/connectors/dataverse/_repo_settings.html.erb
+++ b/application/app/views/connectors/dataverse/_repo_settings.html.erb
@@ -1,0 +1,11 @@
+<%= form_with url: repository_setting_path(domain: domain), method: :put, local: true do |f| %>
+  <div class="mb-3">
+    <%= f.label :auth_key, t('connectors.dataverse.connector_edit_form.field_api_key_label'), class: 'form-label fw-bold' %>
+    <%= f.text_field :auth_key, value: metadata.auth_key, class: 'form-control', placeholder: t('connectors.dataverse.connector_edit_form.field_api_key_placeholder') %>
+  </div>
+  <div class="d-flex justify-content-end gap-2">
+    <button type="submit" class="btn btn-sm btn-primary">
+      <i class="bi bi-save-fill me-1"></i><%= t('connectors.dataverse.connector_edit_form.submit') %>
+    </button>
+  </div>
+<% end %>

--- a/application/app/views/connectors/dataverse/_repo_settings.html.erb
+++ b/application/app/views/connectors/dataverse/_repo_settings.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="d-flex justify-content-end gap-2">
     <button type="submit" class="btn btn-sm btn-primary">
-      <i class="bi bi-save-fill me-1"></i><%= t('connectors.dataverse.connector_edit_form.submit') %>
+      <i class="bi bi-save-fill me-1" aria-hidden="true"></i><%= t('connectors.dataverse.connector_edit_form.submit') %>
     </button>
   </div>
 <% end %>

--- a/application/app/views/connectors/dataverse/_repo_settings.html.erb
+++ b/application/app/views/connectors/dataverse/_repo_settings.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: repository_setting_path(domain: domain), method: :put, local: true do |f| %>
+<%= form_with url: repository_setting_path(domain), method: :put, local: true do |f| %>
   <div class="mb-3">
     <%= f.label :auth_key, t('connectors.dataverse.connector_edit_form.field_api_key_label'), class: 'form-label fw-bold' %>
     <%= f.text_field :auth_key, value: metadata.auth_key, class: 'form-control', placeholder: t('connectors.dataverse.connector_edit_form.field_api_key_placeholder') %>

--- a/application/app/views/connectors/dataverse/_repo_settings.html.erb
+++ b/application/app/views/connectors/dataverse/_repo_settings.html.erb
@@ -1,5 +1,5 @@
 <%= form_with url: repository_settings_path, method: :put, local: true do |f| %>
-  <%= hidden_field_tag :domain, domain %>
+  <%= hidden_field_tag :repo_url, repo_url %>
   <div class="mb-3">
     <%= f.label :auth_key, t('connectors.dataverse.connector_edit_form.field_api_key_label'), class: 'form-label fw-bold' %>
     <%= f.text_field :auth_key, value: metadata.auth_key, class: 'form-control', placeholder: t('connectors.dataverse.connector_edit_form.field_api_key_placeholder') %>

--- a/application/app/views/connectors/zenodo/_repo_settings.html.erb
+++ b/application/app/views/connectors/zenodo/_repo_settings.html.erb
@@ -1,5 +1,5 @@
 <%= form_with url: repository_settings_path, method: :put, local: true do |f| %>
-  <%= hidden_field_tag :domain, domain %>
+  <%= hidden_field_tag :repo_url, repo_url %>
   <div class="mb-3">
     <%= f.label :auth_key, t('connectors.zenodo.connector_edit_form.field_api_key_label'), class: 'form-label fw-bold' %>
     <%= f.text_field :auth_key, value: metadata.auth_key, class: 'form-control', placeholder: t('connectors.zenodo.connector_edit_form.field_api_key_placeholder') %>

--- a/application/app/views/connectors/zenodo/_repo_settings.html.erb
+++ b/application/app/views/connectors/zenodo/_repo_settings.html.erb
@@ -1,4 +1,5 @@
-<%= form_with url: repository_setting_path(domain), method: :put, local: true do |f| %>
+<%= form_with url: repository_settings_path, method: :put, local: true do |f| %>
+  <%= hidden_field_tag :domain, domain %>
   <div class="mb-3">
     <%= f.label :auth_key, t('connectors.zenodo.connector_edit_form.field_api_key_label'), class: 'form-label fw-bold' %>
     <%= f.text_field :auth_key, value: metadata.auth_key, class: 'form-control', placeholder: t('connectors.zenodo.connector_edit_form.field_api_key_placeholder') %>

--- a/application/app/views/connectors/zenodo/_repo_settings.html.erb
+++ b/application/app/views/connectors/zenodo/_repo_settings.html.erb
@@ -1,0 +1,11 @@
+<%= form_with url: repository_setting_path(domain: domain), method: :put, local: true do |f| %>
+  <div class="mb-3">
+    <%= f.label :auth_key, t('connectors.zenodo.connector_edit_form.field_api_key_label'), class: 'form-label fw-bold' %>
+    <%= f.text_field :auth_key, value: metadata.auth_key, class: 'form-control', placeholder: t('connectors.zenodo.connector_edit_form.field_api_key_placeholder') %>
+  </div>
+  <div class="d-flex justify-content-end gap-2">
+    <button type="submit" class="btn btn-sm btn-primary">
+      <i class="bi bi-save-fill me-1"></i><%= t('connectors.zenodo.connector_edit_form.submit') %>
+    </button>
+  </div>
+<% end %>

--- a/application/app/views/connectors/zenodo/_repo_settings.html.erb
+++ b/application/app/views/connectors/zenodo/_repo_settings.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="d-flex justify-content-end gap-2">
     <button type="submit" class="btn btn-sm btn-primary">
-      <i class="bi bi-save-fill me-1"></i><%= t('connectors.zenodo.connector_edit_form.submit') %>
+      <i class="bi bi-save-fill me-1" aria-hidden="true"></i><%= t('connectors.zenodo.connector_edit_form.submit') %>
     </button>
   </div>
 <% end %>

--- a/application/app/views/connectors/zenodo/_repo_settings.html.erb
+++ b/application/app/views/connectors/zenodo/_repo_settings.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: repository_setting_path(domain: domain), method: :put, local: true do |f| %>
+<%= form_with url: repository_setting_path(domain), method: :put, local: true do |f| %>
   <div class="mb-3">
     <%= f.label :auth_key, t('connectors.zenodo.connector_edit_form.field_api_key_label'), class: 'form-label fw-bold' %>
     <%= f.text_field :auth_key, value: metadata.auth_key, class: 'form-control', placeholder: t('connectors.zenodo.connector_edit_form.field_api_key_placeholder') %>

--- a/application/app/views/download_status/_actions.html.erb
+++ b/application/app/views/download_status/_actions.html.erb
@@ -1,4 +1,4 @@
-<div class="text-end sticky-top bg-white z-index-999" aria-label="<%= t('.actions_bar_title_a11y_label') %>">
+<div class="text-end bg-white z-index-999" aria-label="<%= t('.actions_bar_title_a11y_label') %>">
   <%= link_to(files_app_url(Configuration.download_root), class: 'btn btn-outline-dark btn-sm', target: '_blank',
               title: t('.button_downloads_directory_title')) do %>
     <i class="bi bi-folder-fill" aria-hidden="true"></i><span class="ps-1"><%= t('.button_downloads_directory_title') %></span>

--- a/application/app/views/layouts/nav/_navigation.html.erb
+++ b/application/app/views/layouts/nav/_navigation.html.erb
@@ -39,6 +39,15 @@
                 </a>
               </li>
             <% end %>
+            <li><hr class="dropdown-divider"></li>
+            <li role="menuitem">
+              <%= nav_link_to repository_settings_path, class: 'dropdown-item d-flex align-items-center gap-2' do %>
+                <span class="icon-wrapper bg-white text-dark rounded d-inline-flex align-items-center justify-content-center p-1">
+                  <i class="bi bi-gear-fill" aria-hidden="true"></i>
+                </span>
+                <%= t('repository_settings.index.breadcrumbs_text') %>
+              <% end %>
+            </li>
           </ul>
         </li>
       </ul>

--- a/application/app/views/layouts/nav/_navigation.html.erb
+++ b/application/app/views/layouts/nav/_navigation.html.erb
@@ -83,7 +83,7 @@
             <li role="menuitem">
               <a class="dropdown-item d-flex align-items-center gap-2" href="<%= restart_url %>">
                 <span class="icon-wrapper icon-wrapper bg-white text-dark rounded d-inline-flex align-items-center justify-content-center p-1">
-                  <i class="bi bi-arrow-clockwise" aria-hidden="true"></i>
+                  <i class="bi bi-bootstrap-reboot" aria-hidden="true"></i>
                 </span>
                 <%= t(".link_restart_text") %>
               </a>

--- a/application/app/views/projects/_actions.html.erb
+++ b/application/app/views/projects/_actions.html.erb
@@ -1,15 +1,19 @@
-<div class="text-end">
-  <%= link_to(files_app_url(Configuration.download_root), class: 'btn btn-outline-dark btn-sm', target: '_blank',
-              title: t(".button_downloads_root_directory_text")) do %>
-    <i class="bi bi-folder-fill" aria-hidden="true"></i>
-    <span class="ps-1"><%= t(".button_downloads_root_directory_text") %></span>
-  <% end %>
+<div class="d-flex justify-content-between align-items-center mt-3" aria-label="<%= t('.actions_bar_title_a11y_label') %>">
+  <div class="d-flex align-items-center gap-2">
+    <h2 class="mb-0 me-2 fs-4 h5"><%= t('.actions_bar_title') %></h2>
+  </div>
+  <div class="d-flex align-items-center gap-2">
+    <%= render partial: "shared/button_to", locals: {
+      url: projects_path,
+      label: t(".button_create_project_text"),
+      icon: "bi bi-plus-square-fill"
+    } %>
 
-  <%= render partial: "shared/button_to", locals: {
-    url: projects_path,
-    label: t(".button_create_project_text"),
-    icon: "bi bi-plus-square-fill"
-  } %>
-
-  <hr class="mt-2">
+    <%= link_to(files_app_url(Configuration.download_root), class: 'btn btn-outline-dark btn-sm', target: '_blank',
+                title: t(".button_downloads_root_directory_text")) do %>
+      <i class="bi bi-folder-fill" aria-hidden="true"></i>
+      <span class="ps-1"><%= t(".button_downloads_root_directory_text") %></span>
+    <% end %>
+  </div>
 </div>
+<hr class="mt-2">

--- a/application/app/views/projects/_actions.html.erb
+++ b/application/app/views/projects/_actions.html.erb
@@ -11,5 +11,5 @@
     icon: "bi bi-plus-square-fill"
   } %>
 
-  <hr>
+  <hr class="mt-2">
 </div>

--- a/application/app/views/repository_settings/_actions.html.erb
+++ b/application/app/views/repository_settings/_actions.html.erb
@@ -1,12 +1,15 @@
-<div class="text-end bg-white z-index-999" aria-label="<%= t('.actions_bar_title_a11y_label') %>">
-  <%= render partial: 'shared/inline_field_submit', locals: {
-    url: repository_settings_path,
-    type: 'form',
-    field_name: 'repo_url',
-    label: t('.button_add_repository_label'),
-    placeholder: t('.button_add_repository_placeholder'),
-    title: t('.button_add_repository_title'),
-    icon: 'bi bi-plus-square-fill'
-  } %>
+<div class="d-flex justify-content-between align-items-center mt-3" aria-label="<%= t('.actions_bar_title_a11y_label') %>">
+  <div class="d-flex align-items-center gap-2">
+    <h2 class="mb-0 me-2 fs-4 h5">Repositories</h2>
+  </div>
+<%= render partial: 'shared/inline_field_submit', locals: {
+  url: repository_settings_path,
+  type: 'form',
+  field_name: 'repo_url',
+  label: t('.button_add_repository_label'),
+  placeholder: t('.button_add_repository_placeholder'),
+  title: t('.button_add_repository_title'),
+  icon: 'bi bi bi-box-seam-fill',
+} %>
 </div>
-<hr>
+<hr class="mt-2">

--- a/application/app/views/repository_settings/_actions.html.erb
+++ b/application/app/views/repository_settings/_actions.html.erb
@@ -1,0 +1,12 @@
+<div class="text-end bg-white z-index-999" aria-label="<%= t('.actions_bar_title_a11y_label') %>">
+  <%= render partial: 'shared/inline_field_submit', locals: {
+    url: repository_settings_path,
+    type: 'form',
+    field_name: 'repo_url',
+    label: t('.button_add_repository_label'),
+    placeholder: t('.button_add_repository_placeholder'),
+    title: t('.button_add_repository_title'),
+    icon: 'bi bi-plus-square-fill'
+  } %>
+</div>
+<hr>

--- a/application/app/views/repository_settings/_actions.html.erb
+++ b/application/app/views/repository_settings/_actions.html.erb
@@ -9,7 +9,7 @@
   label: t('.button_add_repository_label'),
   placeholder: t('.button_add_repository_placeholder'),
   title: t('.button_add_repository_title'),
-  icon: 'bi bi bi-box-seam-fill',
+  icon: 'bi bi-file-earmark-plus-fill',
 } %>
 </div>
 <hr class="mt-2">

--- a/application/app/views/repository_settings/_repository.html.erb
+++ b/application/app/views/repository_settings/_repository.html.erb
@@ -1,0 +1,13 @@
+<li class="card mb-3 shadow-sm rounded">
+  <div class="card-header bg-light">
+    <a class="d-flex align-items-center text-decoration-none text-secondary" data-bs-toggle="collapse" href="#repo-<%= domain.parameterize %>" role="button" aria-expanded="false" aria-controls="repo-<%= domain.parameterize %>">
+      <span class="me-2"><%= connector_icon(entry.type) %></span>
+      <strong><%= domain %></strong>
+    </a>
+  </div>
+  <div class="collapse" id="repo-<%= domain.parameterize %>">
+    <div class="card-body">
+      <%= render partial: "/connectors/#{entry.type.to_s.downcase}/repo_settings", locals: { domain: domain, metadata: entry.metadata } %>
+    </div>
+  </div>
+</li>

--- a/application/app/views/repository_settings/_repository.html.erb
+++ b/application/app/views/repository_settings/_repository.html.erb
@@ -1,5 +1,5 @@
 <li class="card mb-3 shadow-sm rounded">
-  <div class="card-header bg-light">
+  <div class="card-header bg-light d-flex justify-content-between align-items-center">
 
     <a class="d-flex align-items-center text-decoration-none text-secondary"
        data-bs-toggle="collapse"
@@ -17,6 +17,19 @@
       </span>
       <strong class="d-inline-block"><%= domain %></strong>
     </a>
+
+    <%= render partial: "shared/button_to", locals: {
+      url: repository_settings_path,
+      method: 'DELETE',
+      title: t('.button_delete_repository_title'),
+      class: 'btn-sm btn-outline-dark icon-hover-danger',
+      icon: 'bi bi-trash-fill',
+      params: { domain: domain },
+      modal_id: 'modal-delete-confirmation',
+      modal_title: t('.modal_delete_confirmation_title'),
+      modal_subtitle: domain,
+      modal_content: t('.modal_delete_confirmation_content')
+    } %>
 
   </div>
   <div class="collapse" id="repo-<%= domain.parameterize %>">

--- a/application/app/views/repository_settings/_repository.html.erb
+++ b/application/app/views/repository_settings/_repository.html.erb
@@ -7,15 +7,15 @@
        data-utils--icon-toggle-icon-on-value="bi-plus-square"
        data-utils--icon-toggle-icon-off-value="bi-dash-square"
        data-action="click->utils--icon-toggle#toggle"
-       href="#repo-<%= domain.parameterize %>"
+       href="#repo-<%= repo_url.parameterize %>"
        role="button"
        aria-expanded="false"
-       aria-controls="repo-<%= domain.parameterize %>">
+       aria-controls="repo-<%= repo_url.parameterize %>">
       <i data-utils--icon-toggle-target="icon" class="bi bi-plus-square me-2 transition" style="line-height: 1;" aria-hidden="true"></i>
       <span class="me-2 d-inline-flex align-items-center" style="line-height: 1;">
         <%= connector_icon(entry.type) %>
       </span>
-      <strong class="d-inline-block"><%= domain %></strong>
+      <strong class="d-inline-block"><%= repo_url %></strong>
     </a>
 
     <%= render layout: "shared/button_to", locals: {
@@ -26,16 +26,16 @@
       icon: 'bi bi-trash-fill',
       modal_id: 'modal-delete-confirmation',
       modal_title: t('.modal_delete_confirmation_title'),
-      modal_subtitle: domain,
+      modal_subtitle: repo_url,
       modal_content: t('.modal_delete_confirmation_content')
     } do %>
-      <%= hidden_field_tag :domain, domain %>
+      <%= hidden_field_tag :repo_url, repo_url %>
     <% end %>
 
   </div>
-  <div class="collapse" id="repo-<%= domain.parameterize %>">
+  <div class="collapse" id="repo-<%= repo_url.parameterize %>">
     <div class="card-body">
-      <%= render partial: "/connectors/#{entry.type.to_s.downcase}/repo_settings", locals: { domain: domain, metadata: entry.metadata } %>
+      <%= render partial: "/connectors/#{entry.type.to_s.downcase}/repo_settings", locals: { repo_url: repo_url, metadata: entry.metadata } %>
     </div>
   </div>
 </li>

--- a/application/app/views/repository_settings/_repository.html.erb
+++ b/application/app/views/repository_settings/_repository.html.erb
@@ -18,19 +18,34 @@
       <strong class="d-inline-block"><%= repo_url %></strong>
     </a>
 
-    <%= render layout: "shared/button_to", locals: {
-      url: repository_settings_path,
-      method: 'DELETE',
-      title: t('.button_delete_repository_title'),
-      class: 'btn-sm btn-outline-dark icon-hover-danger',
-      icon: 'bi bi-trash-fill',
-      modal_id: 'modal-delete-confirmation',
-      modal_title: t('.modal_delete_confirmation_title'),
-      modal_subtitle: repo_url,
-      modal_content: t('.modal_delete_confirmation_content')
-    } do %>
-      <%= hidden_field_tag :repo_url, repo_url %>
-    <% end %>
+    <div class="d-flex align-items-center gap-2">
+      <%= link_to repo_url, target: '_blank', class: 'btn btn-sm btn-outline-secondary',
+                    title: t('.link_open_repository_title') do %>
+        <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
+        <span class="visually-hidden"><%= t('.link_open_repository_title') %></span>
+      <% end %>
+
+      <%= link_to browse_repository_path(repo_url, entry),
+                  class: 'btn btn-sm btn-outline-dark icon-hover-danger',
+                  title: t('.button_browse_repository_title') do %>
+        <i class="bi bi-folder2-open" aria-hidden="true"></i>
+        <span class="visually-hidden"><%= t('.button_browse_repository_label') %></span>
+      <% end %>
+
+      <%= render layout: "shared/button_to", locals: {
+        url: repository_settings_path,
+        method: 'DELETE',
+        title: t('.button_delete_repository_title'),
+        class: 'btn-sm btn-outline-dark icon-hover-danger',
+        icon: 'bi bi-trash-fill',
+        modal_id: 'modal-delete-confirmation',
+        modal_title: t('.modal_delete_confirmation_title'),
+        modal_subtitle: repo_url,
+        modal_content: t('.modal_delete_confirmation_content')
+      } do %>
+        <%= hidden_field_tag :repo_url, repo_url %>
+      <% end %>
+    </div>
 
   </div>
   <div class="collapse" id="repo-<%= repo_url.parameterize %>">

--- a/application/app/views/repository_settings/_repository.html.erb
+++ b/application/app/views/repository_settings/_repository.html.erb
@@ -19,16 +19,17 @@
     </a>
 
     <div class="d-flex align-items-center gap-2">
-      <%= link_to repo_url, target: '_blank', class: 'btn btn-sm btn-outline-secondary',
-                    title: t('.link_open_repository_title') do %>
+      <%= link_to repo_url, target: '_blank',
+                  class: 'btn btn-sm btn-outline-dark',
+                  title: t('.link_open_repository_title') do %>
         <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
         <span class="visually-hidden"><%= t('.link_open_repository_title') %></span>
       <% end %>
 
       <%= link_to browse_repository_path(repo_url, entry),
-                  class: 'btn btn-sm btn-outline-dark icon-hover-danger',
+                  class: 'btn btn-sm btn-outline-dark',
                   title: t('.button_browse_repository_title') do %>
-        <i class="bi bi-folder2-open" aria-hidden="true"></i>
+        <i class="bi bi-display" aria-hidden="true"></i>
         <span class="visually-hidden"><%= t('.button_browse_repository_label') %></span>
       <% end %>
 

--- a/application/app/views/repository_settings/_repository.html.erb
+++ b/application/app/views/repository_settings/_repository.html.erb
@@ -1,9 +1,23 @@
 <li class="card mb-3 shadow-sm rounded">
   <div class="card-header bg-light">
-    <a class="d-flex align-items-center text-decoration-none text-secondary" data-bs-toggle="collapse" href="#repo-<%= domain.parameterize %>" role="button" aria-expanded="false" aria-controls="repo-<%= domain.parameterize %>">
-      <span class="me-2"><%= connector_icon(entry.type) %></span>
-      <strong><%= domain %></strong>
+
+    <a class="d-flex align-items-center text-decoration-none text-secondary"
+       data-bs-toggle="collapse"
+       data-controller="utils--icon-toggle"
+       data-utils--icon-toggle-icon-on-value="bi-plus-square"
+       data-utils--icon-toggle-icon-off-value="bi-dash-square"
+       data-action="click->utils--icon-toggle#toggle"
+       href="#repo-<%= domain.parameterize %>"
+       role="button"
+       aria-expanded="false"
+       aria-controls="repo-<%= domain.parameterize %>">
+      <i data-utils--icon-toggle-target="icon" class="bi bi-plus-square me-2 transition" style="line-height: 1;" aria-hidden="true"></i>
+      <span class="me-2 d-inline-flex align-items-center" style="line-height: 1;">
+        <%= connector_icon(entry.type) %>
+      </span>
+      <strong class="d-inline-block"><%= domain %></strong>
     </a>
+
   </div>
   <div class="collapse" id="repo-<%= domain.parameterize %>">
     <div class="card-body">

--- a/application/app/views/repository_settings/_repository.html.erb
+++ b/application/app/views/repository_settings/_repository.html.erb
@@ -18,18 +18,19 @@
       <strong class="d-inline-block"><%= domain %></strong>
     </a>
 
-    <%= render partial: "shared/button_to", locals: {
+    <%= render layout: "shared/button_to", locals: {
       url: repository_settings_path,
       method: 'DELETE',
       title: t('.button_delete_repository_title'),
       class: 'btn-sm btn-outline-dark icon-hover-danger',
       icon: 'bi bi-trash-fill',
-      params: { domain: domain },
       modal_id: 'modal-delete-confirmation',
       modal_title: t('.modal_delete_confirmation_title'),
       modal_subtitle: domain,
       modal_content: t('.modal_delete_confirmation_content')
-    } %>
+    } do %>
+      <%= hidden_field_tag :domain, domain %>
+    <% end %>
 
   </div>
   <div class="collapse" id="repo-<%= domain.parameterize %>">

--- a/application/app/views/repository_settings/index.html.erb
+++ b/application/app/views/repository_settings/index.html.erb
@@ -6,8 +6,8 @@
       <%= render partial: 'actions' %>
 
       <ul class="list-group">
-        <% @repositories.each do |domain, entry| %>
-          <%= render partial: 'repository', locals: { domain: domain, entry: entry } %>
+        <% @repositories.each do |repo_url, entry| %>
+          <%= render partial: 'repository', locals: { repo_url: repo_url, entry: entry } %>
         <% end %>
       </ul>
     </div>

--- a/application/app/views/repository_settings/index.html.erb
+++ b/application/app/views/repository_settings/index.html.erb
@@ -1,9 +1,10 @@
 <% content_for :title, t('.page_title') %>
 <div class="container-md content" role="main">
   <%= render partial: '/shared/breadcrumbs', locals: { links: [{text: t('.breadcrumbs_text')}]} %>
-  <%= render partial: 'actions' %>
   <div class="row">
     <div class="col-md-12">
+      <%= render partial: 'actions' %>
+
       <ul class="list-group">
         <% @repositories.each do |domain, entry| %>
           <%= render partial: 'repository', locals: { domain: domain, entry: entry } %>

--- a/application/app/views/repository_settings/index.html.erb
+++ b/application/app/views/repository_settings/index.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, t('.page_title') %>
+<div class="container-md content" role="main">
+  <%= render partial: '/shared/breadcrumbs', locals: { links: [{text: t('.breadcrumbs_text')}]} %>
+  <div class="row">
+    <div class="col-md-12">
+      <ul class="list-group">
+        <% @repositories.each do |domain, entry| %>
+          <%= render partial: 'repository', locals: { domain: domain, entry: entry } %>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/application/app/views/repository_settings/index.html.erb
+++ b/application/app/views/repository_settings/index.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, t('.page_title') %>
 <div class="container-md content" role="main">
   <%= render partial: '/shared/breadcrumbs', locals: { links: [{text: t('.breadcrumbs_text')}]} %>
+  <%= render partial: 'actions' %>
   <div class="row">
     <div class="col-md-12">
       <ul class="list-group">

--- a/application/app/views/upload_status/_actions.html.erb
+++ b/application/app/views/upload_status/_actions.html.erb
@@ -1,4 +1,4 @@
-<div class="text-end sticky-top bg-white z-index-999" aria-label="<%= t('.actions_bar_title_a11y_label') %>">
+<div class="text-end bg-white z-index-999" aria-label="<%= t('.actions_bar_title_a11y_label') %>">
   <%= link_to(upload_status_path, class: 'btn btn-outline-dark btn-sm', role: 'button', title: t('.button_reload_title')) do %>
     <i class="bi bi-arrow-clockwise bold" aria-hidden="true"></i><span class="ps-1"><%= t('.button_reload_title') %></span>
   <% end %>

--- a/application/config/locales/connectors/dataverse/en.yml
+++ b/application/config/locales/connectors/dataverse/en.yml
@@ -11,6 +11,8 @@ en:
           message_success: "Dataset created: %{id} > %{title}"
         dataset_select:
           message_success: "Dataset selected: %{title}"
+        repository_settings_create:
+          message_success: "Repository %{domain} updated"
         upload_bundle_create:
           message_collection_not_found: "Dataverse collection not found: %{url}. Only public and published collections are supported"
           message_dataset_not_found: "Dataverse dataset not found: %{url}.<br />Only public and published datasets are supported"

--- a/application/config/locales/connectors/dataverse/en.yml
+++ b/application/config/locales/connectors/dataverse/en.yml
@@ -11,8 +11,8 @@ en:
           message_success: "Dataset created: %{id} > %{title}"
         dataset_select:
           message_success: "Dataset selected: %{title}"
-        repository_settings_create:
-          message_success: "Repository %{domain} updated"
+        repository_settings_update:
+          message_success: "Repository updated: %{url} type: %{type}"
         upload_bundle_create:
           message_collection_not_found: "Dataverse collection not found: %{url}. Only public and published collections are supported"
           message_dataset_not_found: "Dataverse dataset not found: %{url}.<br />Only public and published datasets are supported"

--- a/application/config/locales/connectors/zenodo/en.yml
+++ b/application/config/locales/connectors/zenodo/en.yml
@@ -8,8 +8,8 @@ en:
         fetch_deposition:
           message_deposition_not_found: "Zenodo deposition not found for record: %{url}"
           message_success: "Successfully fetched deposition: %{name}"
-        repository_settings_create:
-          message_success: "Repository %{domain} updated"
+        repository_settings_update:
+          message_success: "Repository updated: %{url} type: %{type}"
         upload_bundle_create:
           message_url_not_supported: "Zenodo URL not supported: %{url}. Only deposition URLs are currently supported"
           message_record_not_found: "Zenodo record not found: %{url}. Only published records are supported"

--- a/application/config/locales/connectors/zenodo/en.yml
+++ b/application/config/locales/connectors/zenodo/en.yml
@@ -8,6 +8,8 @@ en:
         fetch_deposition:
           message_deposition_not_found: "Zenodo deposition not found for record: %{url}"
           message_success: "Successfully fetched deposition: %{name}"
+        repository_settings_create:
+          message_success: "Repository %{domain} updated"
         upload_bundle_create:
           message_url_not_supported: "Zenodo URL not supported: %{url}. Only deposition URLs are currently supported"
           message_record_not_found: "Zenodo record not found: %{url}. Only published records are supported"

--- a/application/config/locales/controllers/en.yml
+++ b/application/config/locales/controllers/en.yml
@@ -33,6 +33,9 @@ en:
     update:
       message_not_found: "Repository %{domain} not found"
       message_success: "Repository %{domain} updated"
+    destroy:
+      message_not_found: "Repository %{domain} not found"
+      message_deleted: "Repository %{domain} (%{type}) deleted"
   upload_bundles:
     create:
       invalid_project: "Invalid project id: %{id}"

--- a/application/config/locales/controllers/en.yml
+++ b/application/config/locales/controllers/en.yml
@@ -27,11 +27,12 @@ en:
       url_not_supported: "URL not supported: %{input} points to %{url}"
   repository_settings:
     create:
-      invalid_repo: "URL not supported: %{url}"
-      repo_added: "Repository added: %{type}"
+      message_invalid_request: "Please provide a repository URL"
+      message_invalid_url: "URL not supported: %{url}"
+      message_success: "Repository added: %{url} type: %{type}"
     update:
-      repo_not_found: "Repository %{domain} not found"
-      repo_updated: "Repository %{domain} updated"
+      message_not_found: "Repository %{domain} not found"
+      message_success: "Repository %{domain} updated"
   upload_bundles:
     create:
       invalid_project: "Invalid project id: %{id}"

--- a/application/config/locales/controllers/en.yml
+++ b/application/config/locales/controllers/en.yml
@@ -26,6 +26,9 @@ en:
       blank_url_error: "Please provide repo URL"
       url_not_supported: "URL not supported: %{input} points to %{url}"
   repository_settings:
+    create:
+      invalid_repo: "URL not supported: %{url}"
+      repo_added: "Repository added: %{type}"
     update:
       repo_not_found: "Repository %{domain} not found"
       repo_updated: "Repository %{domain} updated"

--- a/application/config/locales/controllers/en.yml
+++ b/application/config/locales/controllers/en.yml
@@ -25,6 +25,10 @@ en:
     resolve:
       blank_url_error: "Please provide repo URL"
       url_not_supported: "URL not supported: %{input} points to %{url}"
+  repository_settings:
+    update:
+      repo_not_found: "Repository %{domain} not found"
+      repo_updated: "Repository %{domain} updated"
   upload_bundles:
     create:
       invalid_project: "Invalid project id: %{id}"

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -252,3 +252,7 @@ en:
     index:
       breadcrumbs_text: "Repository Settings"
       page_title: "OnDemand Loop - Repository Settings"
+    repository_header:
+      button_delete_repository_title: "Delete repository"
+      modal_delete_confirmation_title: "Delete Repository"
+      modal_delete_confirmation_content: "This will remove the repository from the app."

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -129,6 +129,8 @@ en:
       breadcrumbs_text: "Projects"
       page_title: "OnDemand Loop - Project detail"
     actions:
+      actions_bar_title: "Projects"
+      actions_bar_title_a11y_label: "Project List"
       button_create_project_text: "Create Project"
       button_downloads_root_directory_text: "Downloads Root Directory"
     download_files:
@@ -253,7 +255,7 @@ en:
       breadcrumbs_text: "Repository Settings"
       page_title: "OnDemand Loop - Repository Settings"
     repository:
-      link_open_repository_title: "Open repository"
+      link_open_repository_title: "Open remote repository site"
       button_browse_repository_label: "Browse"
       button_browse_repository_title: "Browse repository"
       button_delete_repository_title: "Delete repository"

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -252,7 +252,7 @@ en:
     index:
       breadcrumbs_text: "Repository Settings"
       page_title: "OnDemand Loop - Repository Settings"
-    repository_header:
+    repository:
       button_delete_repository_title: "Delete repository"
       modal_delete_confirmation_title: "Delete Repository"
-      modal_delete_confirmation_content: "This will remove the repository from the app."
+      modal_delete_confirmation_content: "This will remove the repository settings from the app. No local or remote file will be affected"

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -244,6 +244,11 @@ en:
       breadcrumbs_text: "Uploads"
       page_title: "OnDemand Loop - Uploads Management"
   repository_settings:
+    actions:
+      actions_bar_title_a11y_label: "Repositories actions bar"
+      button_add_repository_label: "Add Repository"
+      button_add_repository_placeholder: "Repository URL"
+      button_add_repository_title: "Add Repository"
     index:
       breadcrumbs_text: "Repository Settings"
       page_title: "OnDemand Loop - Repository Settings"

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -243,3 +243,7 @@ en:
     index:
       breadcrumbs_text: "Uploads"
       page_title: "OnDemand Loop - Uploads Management"
+  repository_settings:
+    index:
+      breadcrumbs_text: "Repository Settings"
+      page_title: "OnDemand Loop - Repository Settings"

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -253,6 +253,9 @@ en:
       breadcrumbs_text: "Repository Settings"
       page_title: "OnDemand Loop - Repository Settings"
     repository:
+      link_open_repository_title: "Open repository"
+      button_browse_repository_label: "Browse"
+      button_browse_repository_title: "Browse repository"
       button_delete_repository_title: "Delete repository"
       modal_delete_confirmation_title: "Delete Repository"
       modal_delete_confirmation_content: "This will remove the repository settings from the app. No local or remote file will be affected"

--- a/application/config/routes.rb
+++ b/application/config/routes.rb
@@ -55,6 +55,8 @@ Rails.application.routes.draw do
   # REPO RESOLVER ROUTES
   post '/view/repo/resolve' => 'repo_resolver#resolve', as: :repo_resolver
 
+  resources :repository_settings, path: 'repositories/settings', param: :domain, only: [:index, :update]
+
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/application/config/routes.rb
+++ b/application/config/routes.rb
@@ -30,6 +30,16 @@ Rails.application.routes.draw do
     end
   end
 
+  # REPO RESOLVER ROUTES
+  post '/view/repo/resolve' => 'repo_resolver#resolve', as: :repo_resolver
+
+  # REPOSITORY SETTINGS ROUTES
+  resources :repository_settings, path: 'repositories/settings', only: [:index, :create] do
+    collection do
+      put :update
+    end
+  end
+
   #FILE ACTIVITY
   get '/detached_process/status', to: 'detached_process#status'
   # FILE BROWSER
@@ -51,11 +61,6 @@ Rails.application.routes.draw do
   post "/view/zenodo/download/record" => "zenodo/records#download", as: :download_zenodo_record_files
   get "/view/zenodo" => "zenodo/landing_page#index", as: :view_zenodo_landing
   get "/view/zenodo/records/:id" => "zenodo/records#show", as: :view_zenodo_record, format: false
-
-  # REPO RESOLVER ROUTES
-  post '/view/repo/resolve' => 'repo_resolver#resolve', as: :repo_resolver
-
-  resources :repository_settings, path: 'repositories/settings', param: :domain, only: [:index, :create, :update]
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/application/config/routes.rb
+++ b/application/config/routes.rb
@@ -55,7 +55,7 @@ Rails.application.routes.draw do
   # REPO RESOLVER ROUTES
   post '/view/repo/resolve' => 'repo_resolver#resolve', as: :repo_resolver
 
-  resources :repository_settings, path: 'repositories/settings', param: :domain, only: [:index, :update]
+  resources :repository_settings, path: 'repositories/settings', param: :domain, only: [:index, :create, :update]
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/application/config/routes.rb
+++ b/application/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
   resources :repository_settings, path: 'repositories/settings', only: [:index, :create] do
     collection do
       put :update
+      delete :destroy
     end
   end
 

--- a/application/test/connectors/connector_class_dispatcher_test.rb
+++ b/application/test/connectors/connector_class_dispatcher_test.rb
@@ -50,6 +50,11 @@ class ConnectorClassDispatcherTest < ActiveSupport::TestCase
     assert_instance_of Dataverse::DisplayRepoControllerResolver, result
   end
 
+  test 'repository_settings_processor should return Dataverse::RepositorySettingsProcessor for dataverse type' do
+    result = ConnectorClassDispatcher.repository_settings_processor(ConnectorType::DATAVERSE)
+    assert_instance_of Dataverse::RepositorySettingsProcessor, result
+  end
+
   test 'raises ConnectorNotSupported for unknown connector type' do
     file = OpenStruct.new(type: :unknown)
     error = assert_raises(ConnectorClassDispatcher::ConnectorNotSupported) do

--- a/application/test/connectors/dataverse/actions/dataset_form_tabs_test.rb
+++ b/application/test/connectors/dataverse/actions/dataset_form_tabs_test.rb
@@ -38,7 +38,7 @@ class Dataverse::Actions::DatasetFormTabsTest < ActiveSupport::TestCase
     @bundle.stubs(:connector_metadata).returns(meta)
     repo = mock('repo')
     repo.stubs(:metadata).returns(OpenStruct.new(subjects: nil))
-    RepoRegistry.repo_db.stubs(:get).with('demo.dv').returns(repo)
+    RepoRegistry.repo_db.stubs(:get).with('https://demo.dv').returns(repo)
     RepoRegistry.repo_db.stubs(:update)
 
     md_service = mock('md')

--- a/application/test/connectors/dataverse/repository_settings_processor_test.rb
+++ b/application/test/connectors/dataverse/repository_settings_processor_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class Dataverse::RepositorySettingsProcessorTest < ActiveSupport::TestCase
+  def setup
+    @processor = Dataverse::RepositorySettingsProcessor.new
+    @tempfile = Tempfile.new('repo_db')
+    RepoRegistry.repo_db = Repo::RepoDb.new(db_path: @tempfile.path)
+    RepoRegistry.repo_db.set('https://demo.org', type: ConnectorType::DATAVERSE)
+  end
+
+  def teardown
+    @tempfile.unlink
+  end
+
+  test 'params schema includes repo_url and auth_key' do
+    assert_includes @processor.params_schema, :repo_url
+    assert_includes @processor.params_schema, :auth_key
+  end
+
+  test 'update stores key and returns message' do
+    repo = RepoRegistry.repo_db.get('https://demo.org')
+    result = @processor.update(repo, { repo_url: 'https://demo.org', auth_key: 'k' })
+    assert_equal 'k', RepoRegistry.repo_db.get('https://demo.org').metadata.auth_key
+    assert_equal({ notice: I18n.t('connectors.dataverse.actions.repository_settings_create.message_success', domain: 'https://demo.org') }, result.message)
+  end
+end

--- a/application/test/connectors/dataverse/repository_settings_processor_test.rb
+++ b/application/test/connectors/dataverse/repository_settings_processor_test.rb
@@ -21,6 +21,6 @@ class Dataverse::RepositorySettingsProcessorTest < ActiveSupport::TestCase
     repo = RepoRegistry.repo_db.get('https://demo.org')
     result = @processor.update(repo, { repo_url: 'https://demo.org', auth_key: 'k' })
     assert_equal 'k', RepoRegistry.repo_db.get('https://demo.org').metadata.auth_key
-    assert_equal({ notice: I18n.t('connectors.dataverse.actions.repository_settings_create.message_success', domain: 'https://demo.org') }, result.message)
+    assert_equal({ notice: I18n.t('connectors.dataverse.actions.repository_settings_update.message_success', url: 'https://demo.org', type: repo.type) }, result.message)
   end
 end

--- a/application/test/connectors/dataverse/upload_bundle_connector_metadata_test.rb
+++ b/application/test/connectors/dataverse/upload_bundle_connector_metadata_test.rb
@@ -17,10 +17,6 @@ class Dataverse::UploadBundleConnectorMetadataTest < ActiveSupport::TestCase
     @meta = Dataverse::UploadBundleConnectorMetadata.new(@bundle)
   end
 
-  test 'server_domain parsed from url' do
-    assert_equal 'demo.dataverse.org', @meta.server_domain
-  end
-
   test 'api_key detected' do
     assert @meta.api_key?
   end

--- a/application/test/connectors/zenodo/actions/upload_bundle_create_test.rb
+++ b/application/test/connectors/zenodo/actions/upload_bundle_create_test.rb
@@ -19,7 +19,7 @@ class Zenodo::Actions::UploadBundleCreateTest < ActiveSupport::TestCase
     Zenodo::ZenodoUrl.stubs(:parse).returns(url_data)
 
     repo_info = OpenStruct.new(metadata: OpenStruct.new(auth_key: 'KEY'))
-    RepoRegistry.repo_db.stubs(:get).with('zenodo.org').returns(repo_info)
+    RepoRegistry.repo_db.stubs(:get).with('https://zenodo.org').returns(repo_info)
 
     dep = OpenStruct.new(title: 'title', bucket_url: 'b', draft?: false)
     service = mock('service')

--- a/application/test/connectors/zenodo/repository_settings_processor_test.rb
+++ b/application/test/connectors/zenodo/repository_settings_processor_test.rb
@@ -21,6 +21,6 @@ class Zenodo::RepositorySettingsProcessorTest < ActiveSupport::TestCase
     repo = RepoRegistry.repo_db.get('https://zenodo.org')
     result = @processor.update(repo, { repo_url: 'https://zenodo.org', auth_key: 'k' })
     assert_equal 'k', RepoRegistry.repo_db.get('https://zenodo.org').metadata.auth_key
-    assert_equal({ notice: I18n.t('connectors.zenodo.actions.repository_settings_create.message_success', domain: 'https://zenodo.org') }, result.message)
+    assert_equal({ notice: I18n.t('connectors.zenodo.actions.repository_settings_update.message_success', url: 'https://zenodo.org', type: repo.type) }, result.message)
   end
 end

--- a/application/test/connectors/zenodo/repository_settings_processor_test.rb
+++ b/application/test/connectors/zenodo/repository_settings_processor_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class Zenodo::RepositorySettingsProcessorTest < ActiveSupport::TestCase
+  def setup
+    @processor = Zenodo::RepositorySettingsProcessor.new
+    @tempfile = Tempfile.new('repo_db')
+    RepoRegistry.repo_db = Repo::RepoDb.new(db_path: @tempfile.path)
+    RepoRegistry.repo_db.set('https://zenodo.org', type: ConnectorType::ZENODO)
+  end
+
+  def teardown
+    @tempfile.unlink
+  end
+
+  test 'params schema includes repo_url and auth_key' do
+    assert_includes @processor.params_schema, :repo_url
+    assert_includes @processor.params_schema, :auth_key
+  end
+
+  test 'update stores key and returns message' do
+    repo = RepoRegistry.repo_db.get('https://zenodo.org')
+    result = @processor.update(repo, { repo_url: 'https://zenodo.org', auth_key: 'k' })
+    assert_equal 'k', RepoRegistry.repo_db.get('https://zenodo.org').metadata.auth_key
+    assert_equal({ notice: I18n.t('connectors.zenodo.actions.repository_settings_create.message_success', domain: 'https://zenodo.org') }, result.message)
+  end
+end

--- a/application/test/controllers/repository_settings_controller_test.rb
+++ b/application/test/controllers/repository_settings_controller_test.rb
@@ -53,4 +53,17 @@ class RepositorySettingsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to repository_settings_url
     assert_equal I18n.t('repository_settings.update.message_not_found', domain: 'missing.org'), flash[:alert]
   end
+
+  test 'destroy should delete repository' do
+    delete repository_settings_url, params: { domain: 'demo.org' }
+    assert_redirected_to repository_settings_url
+    assert_equal I18n.t('repository_settings.destroy.message_deleted', domain: 'demo.org', type: 'dataverse'), flash[:notice]
+    assert_nil RepoRegistry.repo_db.get('demo.org')
+  end
+
+  test 'destroy should show error when repository missing' do
+    delete repository_settings_url, params: { domain: 'missing.org' }
+    assert_redirected_to repository_settings_url
+    assert_equal I18n.t('repository_settings.destroy.message_not_found', domain: 'missing.org'), flash[:alert]
+  end
 end

--- a/application/test/controllers/repository_settings_controller_test.rb
+++ b/application/test/controllers/repository_settings_controller_test.rb
@@ -5,7 +5,7 @@ class RepositorySettingsControllerTest < ActionDispatch::IntegrationTest
   def setup
     @tempfile = Tempfile.new('repo_db')
     RepoRegistry.repo_db = Repo::RepoDb.new(db_path: @tempfile.path)
-    RepoRegistry.repo_db.set('demo.org', type: ConnectorType::DATAVERSE, metadata: {auth_key: 'old'})
+    RepoRegistry.repo_db.set('https://demo.org', type: ConnectorType::DATAVERSE, metadata: {auth_key: 'old'})
   end
 
   def teardown
@@ -42,27 +42,27 @@ class RepositorySettingsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'update should update repository metadata' do
-    put repository_settings_url, params: { domain: 'demo.org', metadata: {auth_key: 'new'} }
+    put repository_settings_url, params: { repo_url: 'https://demo.org', metadata: {auth_key: 'new'} }
     assert_redirected_to repository_settings_url
-    assert_equal I18n.t('repository_settings.update.message_success', domain: 'demo.org'), flash[:notice]
-    assert_equal 'new', RepoRegistry.repo_db.get('demo.org').metadata.auth_key
+    assert_equal I18n.t('repository_settings.update.message_success', domain: 'https://demo.org'), flash[:notice]
+    assert_equal 'new', RepoRegistry.repo_db.get('https://demo.org').metadata.auth_key
   end
 
   test 'update should show error when repository missing' do
-    put repository_settings_url, params: { domain: 'missing.org', metadata: {auth_key: 'x'} }
+    put repository_settings_url, params: { repo_url: 'missing.org', metadata: {auth_key: 'x'} }
     assert_redirected_to repository_settings_url
     assert_equal I18n.t('repository_settings.update.message_not_found', domain: 'missing.org'), flash[:alert]
   end
 
   test 'destroy should delete repository' do
-    delete repository_settings_url, params: { domain: 'demo.org' }
+    delete repository_settings_url, params: { repo_url: 'https://demo.org' }
     assert_redirected_to repository_settings_url
-    assert_equal I18n.t('repository_settings.destroy.message_deleted', domain: 'demo.org', type: 'dataverse'), flash[:notice]
-    assert_nil RepoRegistry.repo_db.get('demo.org')
+    assert_equal I18n.t('repository_settings.destroy.message_deleted', domain: 'https://demo.org', type: 'dataverse'), flash[:notice]
+    assert_nil RepoRegistry.repo_db.get('https://demo.org')
   end
 
   test 'destroy should show error when repository missing' do
-    delete repository_settings_url, params: { domain: 'missing.org' }
+    delete repository_settings_url, params: { repo_url: 'missing.org' }
     assert_redirected_to repository_settings_url
     assert_equal I18n.t('repository_settings.destroy.message_not_found', domain: 'missing.org'), flash[:alert]
   end

--- a/application/test/controllers/repository_settings_controller_test.rb
+++ b/application/test/controllers/repository_settings_controller_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+require 'tempfile'
+
+class RepositorySettingsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @tempfile = Tempfile.new('repo_db')
+    RepoRegistry.repo_db = Repo::RepoDb.new(db_path: @tempfile.path)
+    RepoRegistry.repo_db.set('demo.org', type: ConnectorType::DATAVERSE, metadata: {auth_key: 'old'})
+  end
+
+  def teardown
+    @tempfile.unlink
+  end
+
+  test 'should get index' do
+    get repository_settings_url
+    assert_response :success
+  end
+
+  test 'should update repository metadata' do
+    put repository_setting_url('demo.org'), params: { metadata: {auth_key: 'new'} }
+    assert_redirected_to repository_settings_url
+    assert_equal I18n.t('repository_settings.update.repo_updated', domain: 'demo.org'), flash[:notice]
+    assert_equal 'new', RepoRegistry.repo_db.get('demo.org').metadata.auth_key
+  end
+
+  test 'should show error when repository missing' do
+    put repository_setting_url('missing.org'), params: { metadata: {auth_key: 'x'} }
+    assert_redirected_to repository_settings_url
+    assert_equal I18n.t('repository_settings.update.repo_not_found', domain: 'missing.org'), flash[:alert]
+  end
+end

--- a/application/test/lib/url_parser_test.rb
+++ b/application/test/lib/url_parser_test.rb
@@ -53,13 +53,26 @@ class UrlParserTest < ActiveSupport::TestCase
     assert_equal({}, parser.params)
   end
 
-  test 'should handle URL with only domain' do
+  test 'should handle URL with no path' do
     url = 'https://example.com'
     parser = UrlParser.parse(url)
 
     assert parser
     assert_equal 'https', parser.scheme
     assert_equal 'example.com', parser.domain
+    assert_nil parser.port
+    assert_equal '/', parser.path
+    assert_equal({}, parser.params)
+    assert_equal [], parser.path_segments
+  end
+
+  test 'should handle URL with domain and no protocol' do
+    url = 'www.example.com'
+    parser = UrlParser.parse(url)
+
+    assert parser
+    assert_equal 'https', parser.scheme
+    assert_equal 'www.example.com', parser.domain
     assert_nil parser.port
     assert_equal '/', parser.path
     assert_equal({}, parser.params)

--- a/application/test/services/repo/repo_db_test.rb
+++ b/application/test/services/repo/repo_db_test.rb
@@ -18,6 +18,7 @@ class Repo::RepoDbTest < ActiveSupport::TestCase
     entry = @db.get('https://demo.org')
 
     assert entry
+    assert_equal 'https://demo.org', entry.repo_url
     assert_equal @type, entry.type
     assert_equal 'abc123', entry.metadata.token
     assert_not_nil entry.creation_date
@@ -30,6 +31,7 @@ class Repo::RepoDbTest < ActiveSupport::TestCase
     @db.update('https://demo.org', metadata: { token: 'xyz789', user: 'alice' })
 
     entry = @db.get('https://demo.org')
+    assert_equal 'https://demo.org', entry.repo_url
     assert_equal 'xyz789', entry.metadata.token
     assert_equal 'alice', entry.metadata.user
     assert_equal original_created, entry.creation_date
@@ -57,6 +59,9 @@ class Repo::RepoDbTest < ActiveSupport::TestCase
     all = @db.all
     assert_kind_of Hash, all
     assert_equal %w[https://demo.org https://example.com].sort, all.keys.sort
+    all.each do |url, e|
+      assert_equal url, e.repo_url
+    end
   end
 
   test 'should persist and reload from file' do
@@ -67,6 +72,7 @@ class Repo::RepoDbTest < ActiveSupport::TestCase
     entry = reloaded.get('https://demo.org')
 
     assert entry
+    assert_equal 'https://demo.org', entry.repo_url
     assert_equal 'abc123', entry.metadata.token
     assert_equal created, entry.creation_date
   end

--- a/application/test/services/repo/repo_db_test.rb
+++ b/application/test/services/repo/repo_db_test.rb
@@ -20,16 +20,19 @@ class Repo::RepoDbTest < ActiveSupport::TestCase
     assert entry
     assert_equal @type, entry.type
     assert_equal 'abc123', entry.metadata.token
+    assert_not_nil entry.creation_date
     assert_not_nil entry.last_updated
   end
 
   test 'should update metadata' do
     @db.set('https://demo.org', type: @type, metadata: { token: 'abc123' })
+    original_created = @db.get('https://demo.org').creation_date
     @db.update('https://demo.org', metadata: { token: 'xyz789', user: 'alice' })
 
     entry = @db.get('https://demo.org')
     assert_equal 'xyz789', entry.metadata.token
     assert_equal 'alice', entry.metadata.user
+    assert_equal original_created, entry.creation_date
   end
 
   test 'should raise error when updating unknown domain' do
@@ -58,12 +61,14 @@ class Repo::RepoDbTest < ActiveSupport::TestCase
 
   test 'should persist and reload from file' do
     @db.set('https://demo.org', type: @type, metadata: { token: 'abc123' })
+    created = @db.get('https://demo.org').creation_date
 
     reloaded = Repo::RepoDb.new(db_path: @tempfile.path)
     entry = reloaded.get('https://demo.org')
 
     assert entry
     assert_equal 'abc123', entry.metadata.token
+    assert_equal created, entry.creation_date
   end
 
   test 'should not persist invalid type' do

--- a/application/test/services/repo/repo_db_test.rb
+++ b/application/test/services/repo/repo_db_test.rb
@@ -14,8 +14,8 @@ class Repo::RepoDbTest < ActiveSupport::TestCase
   end
 
   test 'should add and retrieve an entry' do
-    @db.set('demo.org', type: @type, metadata: { token: 'abc123' })
-    entry = @db.get('demo.org')
+    @db.set('https://demo.org', type: @type, metadata: { token: 'abc123' })
+    entry = @db.get('https://demo.org')
 
     assert entry
     assert_equal @type, entry.type
@@ -24,43 +24,43 @@ class Repo::RepoDbTest < ActiveSupport::TestCase
   end
 
   test 'should update metadata' do
-    @db.set('demo.org', type: @type, metadata: { token: 'abc123' })
-    @db.update('demo.org', metadata: { token: 'xyz789', user: 'alice' })
+    @db.set('https://demo.org', type: @type, metadata: { token: 'abc123' })
+    @db.update('https://demo.org', metadata: { token: 'xyz789', user: 'alice' })
 
-    entry = @db.get('demo.org')
+    entry = @db.get('https://demo.org')
     assert_equal 'xyz789', entry.metadata.token
     assert_equal 'alice', entry.metadata.user
   end
 
   test 'should raise error when updating unknown domain' do
-    assert_raises(ArgumentError, 'Unknown domain: unknown.org') do
-      @db.update('unknown.org', metadata: { token: 'xyz789' })
+    assert_raises(ArgumentError, 'Unknown repo url: https://unknown.org') do
+      @db.update('https://unknown.org', metadata: { token: 'xyz789' })
     end
   end
 
   test 'should delete an entry' do
-    @db.set('demo.org', type: @type, metadata: { token: 'abc123' })
-    @db.delete('demo.org')
+    @db.set('https://demo.org', type: @type, metadata: { token: 'abc123' })
+    @db.delete('https://demo.org')
 
-    assert_nil @db.get('demo.org')
+    assert_nil @db.get('https://demo.org')
     assert_equal 0, @db.size
   end
 
   test 'should return correct size and all entries' do
-    @db.set('demo.org', type: @type)
-    @db.set('example.com', type: @type)
+    @db.set('https://demo.org', type: @type)
+    @db.set('https://example.com', type: @type)
 
     assert_equal 2, @db.size
     all = @db.all
     assert_kind_of Hash, all
-    assert_equal %w[demo.org example.com].sort, all.keys.sort
+    assert_equal %w[https://demo.org https://example.com].sort, all.keys.sort
   end
 
   test 'should persist and reload from file' do
-    @db.set('demo.org', type: @type, metadata: { token: 'abc123' })
+    @db.set('https://demo.org', type: @type, metadata: { token: 'abc123' })
 
     reloaded = Repo::RepoDb.new(db_path: @tempfile.path)
-    entry = reloaded.get('demo.org')
+    entry = reloaded.get('https://demo.org')
 
     assert entry
     assert_equal 'abc123', entry.metadata.token
@@ -68,7 +68,7 @@ class Repo::RepoDbTest < ActiveSupport::TestCase
 
   test 'should not persist invalid type' do
     assert_raises(ArgumentError) do
-      @db.set('demo.org', type: 'invalid')
+      @db.set('https://demo.org', type: 'invalid')
     end
   end
 end

--- a/application/test/services/repo/resolvers/dataverse_resolver_test.rb
+++ b/application/test/services/repo/resolvers/dataverse_resolver_test.rb
@@ -21,7 +21,7 @@ class Repo::Resolvers::DataverseResolverTest < ActiveSupport::TestCase
     resolver.resolve(context)
 
     assert_equal ConnectorType::DATAVERSE, context.type
-    assert @repo_db.get('dv.org')
+    assert @repo_db.get('https://dv.org')
   end
 
   test 'resolve falls back to API when domain unknown' do
@@ -38,7 +38,7 @@ class Repo::Resolvers::DataverseResolverTest < ActiveSupport::TestCase
     resolver.resolve(context)
 
     assert_equal ConnectorType::DATAVERSE, context.type
-    assert @repo_db.get('unknown.org')
+    assert @repo_db.get('https://unknown.org')
   end
 
   test 'resolve handles api failures gracefully' do


### PR DESCRIPTION
## Summary
- create `RepositorySettingsController` for managing repo metadata
- list repositories in new view with collapsible panels
- add connector-specific forms to edit metadata
- link new page from the Repositories menu
- localize new interface strings
- add tests for controller
- revert updates to ES translations

## Testing
- `bundle exec rake test` *(fails: rbenv version `3.1.5` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6871955a88688321b13f8cd6b7bdc309