### PR TITLE
Implement repository deletion

### DIFF
--- a/application/app/controllers/repository_settings_controller.rb
+++ b/application/app/controllers/repository_settings_controller.rb
@@ -30,4 +30,15 @@ class RepositorySettingsController < ApplicationController
     RepoRegistry.repo_db.update(domain, metadata: metadata)
     redirect_to repository_settings_path, notice: t('.message_success', domain: domain)
   end
+
+  def destroy
+    domain = params[:domain]
+    repo = RepoRegistry.repo_db.get(domain)
+    unless repo
+      redirect_to repository_settings_path, alert: t('.message_not_found', domain: domain) and return
+    end
+
+    RepoRegistry.repo_db.delete(domain)
+    redirect_to repository_settings_path, notice: t('.message_deleted', domain: domain, type: repo.type.to_s)
+  end
 end

--- a/application/app/services/repo/repo_db.rb
+++ b/application/app/services/repo/repo_db.rb
@@ -55,7 +55,11 @@ module Repo
     end
 
     def delete(domain)
-      @data.delete(domain)
+      return unless @data.key?(domain)
+
+      entry = @data.delete(domain)
+      persist!
+      log_info('Entry deleted', { domain: domain, type: entry&.type })
     end
 
     def size

--- a/application/app/views/repository_settings/_repository.html.erb
+++ b/application/app/views/repository_settings/_repository.html.erb
@@ -1,5 +1,5 @@
 <li class="card mb-3 shadow-sm rounded">
-  <div class="card-header bg-light">
+  <div class="card-header bg-light d-flex justify-content-between align-items-center">
 
     <a class="d-flex align-items-center text-decoration-none text-secondary"
        data-bs-toggle="collapse"
@@ -17,6 +17,19 @@
       </span>
       <strong class="d-inline-block"><%= domain %></strong>
     </a>
+
+    <%= render partial: "shared/button_to", locals: {
+      url: repository_settings_path,
+      method: 'DELETE',
+      title: t('.button_delete_repository_title'),
+      class: 'btn-sm btn-outline-dark icon-hover-danger',
+      icon: 'bi bi-trash-fill',
+      params: { domain: domain },
+      modal_id: 'modal-delete-confirmation',
+      modal_title: t('.modal_delete_confirmation_title'),
+      modal_subtitle: domain,
+      modal_content: t('.modal_delete_confirmation_content')
+    } %>
 
   </div>
   <div class="collapse" id="repo-<%= domain.parameterize %>">

--- a/application/config/locales/controllers/en.yml
+++ b/application/config/locales/controllers/en.yml
@@ -33,6 +33,9 @@ en:
     update:
       message_not_found: "Repository %{domain} not found"
       message_success: "Repository %{domain} updated"
+    destroy:
+      message_not_found: "Repository %{domain} not found"
+      message_deleted: "Repository %{domain} (%{type}) deleted"
   upload_bundles:
     create:
       invalid_project: "Invalid project id: %{id}"

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -252,3 +252,7 @@ en:
     index:
       breadcrumbs_text: "Repository Settings"
       page_title: "OnDemand Loop - Repository Settings"
+    repository_header:
+      button_delete_repository_title: "Delete repository"
+      modal_delete_confirmation_title: "Delete Repository"
+      modal_delete_confirmation_content: "This will remove the repository from the app."

--- a/application/config/routes.rb
+++ b/application/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
   resources :repository_settings, path: 'repositories/settings', only: [:index, :create] do
     collection do
       put :update
+      delete :destroy
     end
   end
 

--- a/application/test/controllers/repository_settings_controller_test.rb
+++ b/application/test/controllers/repository_settings_controller_test.rb
@@ -53,4 +53,17 @@ class RepositorySettingsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to repository_settings_url
     assert_equal I18n.t('repository_settings.update.message_not_found', domain: 'missing.org'), flash[:alert]
   end
+
+  test 'destroy should delete repository' do
+    delete repository_settings_url, params: { domain: 'demo.org' }
+    assert_redirected_to repository_settings_url
+    assert_equal I18n.t('repository_settings.destroy.message_deleted', domain: 'demo.org', type: 'dataverse'), flash[:notice]
+    assert_nil RepoRegistry.repo_db.get('demo.org')
+  end
+
+  test 'destroy should show error when repository missing' do
+    delete repository_settings_url, params: { domain: 'missing.org' }
+    assert_redirected_to repository_settings_url
+    assert_equal I18n.t('repository_settings.destroy.message_not_found', domain: 'missing.org'), flash[:alert]
+  end
 end


### PR DESCRIPTION
## Summary
- implement hard delete in `Repo::RepoDb` with logging
- add destroy action to repository settings controller
- update routes and localization
- add delete button in repository header
- test deletion flows

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6872f4ff06988321abe4160a14071ffd