### PR TITLE
Update RepoDb to use full repository URL keys

### DIFF
--- a/application/app/connectors/dataverse/actions/connector_edit.rb
+++ b/application/app/connectors/dataverse/actions/connector_edit.rb
@@ -15,8 +15,8 @@ module Dataverse::Actions
         metadata[:auth_key] = repo_key
         upload_bundle.update({ metadata: metadata })
       else
-        server_domain = upload_bundle.connector_metadata.server_domain
-        RepoRegistry.repo_db.update(server_domain, metadata: {auth_key: repo_key})
+        dataverse_url = upload_bundle.connector_metadata.dataverse_url
+        RepoRegistry.repo_db.update(dataverse_url, metadata: {auth_key: repo_key})
       end
 
       ConnectorResult.new(

--- a/application/app/connectors/dataverse/actions/dataset_create.rb
+++ b/application/app/connectors/dataverse/actions/dataset_create.rb
@@ -3,11 +3,11 @@ module Dataverse::Actions
     def edit(upload_bundle, request_params)
       connector_metadata = upload_bundle.connector_metadata
       repo_db = RepoRegistry.repo_db
-      dataverse_data = repo_db.get(connector_metadata.server_domain)
+      dataverse_data = repo_db.get(connector_metadata.dataverse_url)
       if dataverse_data.metadata.subjects.nil?
         dv_metadata_service = Dataverse::MetadataService.new(connector_metadata.dataverse_url)
         subjects = dv_metadata_service.get_citation_metadata.subjects
-        repo_db.update(connector_metadata.server_domain, metadata: { subjects: subjects })
+        repo_db.update(connector_metadata.dataverse_url, metadata: { subjects: subjects })
       else
         subjects = dataverse_data.metadata.subjects
       end

--- a/application/app/connectors/dataverse/actions/dataset_form_tabs.rb
+++ b/application/app/connectors/dataverse/actions/dataset_form_tabs.rb
@@ -28,11 +28,11 @@ module Dataverse::Actions
     def subjects(upload_bundle)
       connector_metadata = upload_bundle.connector_metadata
       repo_db = RepoRegistry.repo_db
-      dataverse_data = repo_db.get(connector_metadata.server_domain)
+      dataverse_data = repo_db.get(connector_metadata.dataverse_url)
       if dataverse_data.metadata.subjects.nil?
         dv_metadata_service = Dataverse::MetadataService.new(connector_metadata.dataverse_url)
         subjects = dv_metadata_service.get_citation_metadata.subjects
-        repo_db.update(connector_metadata.server_domain, metadata: { subjects: subjects })
+        repo_db.update(connector_metadata.dataverse_url, metadata: { subjects: subjects })
       else
         subjects = dataverse_data.metadata.subjects
       end

--- a/application/app/connectors/dataverse/upload_bundle_connector_metadata.rb
+++ b/application/app/connectors/dataverse/upload_bundle_connector_metadata.rb
@@ -25,7 +25,7 @@ module Dataverse
     def api_key
       return OpenStruct.new({ bundle?: true, server?: false, value: @metadata[:auth_key] }) if @metadata[:auth_key]
 
-      repo_info = RepoRegistry.repo_db.get(server_domain)
+      repo_info = RepoRegistry.repo_db.get(dataverse_url)
       OpenStruct.new({ bundle?: false, server?: true, value: repo_info.metadata.auth_key }) if repo_info && repo_info.metadata.auth_key
     end
 

--- a/application/app/connectors/zenodo/actions/connector_edit.rb
+++ b/application/app/connectors/zenodo/actions/connector_edit.rb
@@ -17,8 +17,8 @@ module Zenodo::Actions
         metadata[:auth_key] = repo_key
         upload_bundle.update({ metadata: metadata })
       else
-        server_domain = upload_bundle.connector_metadata.server_domain
-        RepoRegistry.repo_db.update(server_domain, metadata: {auth_key: repo_key})
+        zenodo_url = upload_bundle.connector_metadata.zenodo_url
+        RepoRegistry.repo_db.update(zenodo_url, metadata: {auth_key: repo_key})
       end
 
       ConnectorResult.new(

--- a/application/app/connectors/zenodo/actions/upload_bundle_create.rb
+++ b/application/app/connectors/zenodo/actions/upload_bundle_create.rb
@@ -19,7 +19,7 @@ module Zenodo::Actions
         title = record.title
         concept_id = record.concept_id
       elsif url_data.deposition?
-        repo_info = RepoRegistry.repo_db.get(url_data.domain)
+        repo_info = RepoRegistry.repo_db.get(url_data.zenodo_url)
         if repo_info.metadata.auth_key.present?
           deposition_service = Zenodo::DepositionService.new(url_data.zenodo_url, api_key: repo_info.metadata.auth_key)
           deposition = deposition_service.find_deposition(url_data.deposition_id)

--- a/application/app/connectors/zenodo/upload_bundle_connector_metadata.rb
+++ b/application/app/connectors/zenodo/upload_bundle_connector_metadata.rb
@@ -18,7 +18,7 @@ module Zenodo
     def api_key
       return OpenStruct.new({ bundle?: true, server?: false, value: @metadata[:auth_key] }) if @metadata[:auth_key]
 
-      repo_info = RepoRegistry.repo_db.get(server_domain)
+      repo_info = RepoRegistry.repo_db.get(zenodo_url)
       OpenStruct.new({ bundle?: false, server?: true, value: repo_info.metadata.auth_key }) if repo_info && repo_info.metadata.auth_key
     end
 

--- a/application/app/controllers/repository_settings_controller.rb
+++ b/application/app/controllers/repository_settings_controller.rb
@@ -20,25 +20,25 @@ class RepositorySettingsController < ApplicationController
   end
 
   def update
-    domain = params[:domain]
-    repo = RepoRegistry.repo_db.get(domain)
+    repo_url = params[:repo_url]
+    repo = RepoRegistry.repo_db.get(repo_url)
     unless repo
-      redirect_to repository_settings_path, alert: t('.message_not_found', domain: domain) and return
+      redirect_to repository_settings_path, alert: t('.message_not_found', domain: repo_url) and return
     end
 
     metadata = params.fetch(:metadata, {}).permit!.to_h
-    RepoRegistry.repo_db.update(domain, metadata: metadata)
-    redirect_to repository_settings_path, notice: t('.message_success', domain: domain)
+    RepoRegistry.repo_db.update(repo_url, metadata: metadata)
+    redirect_to repository_settings_path, notice: t('.message_success', domain: repo_url)
   end
 
   def destroy
-    domain = params[:domain].to_s.strip
-    repo = RepoRegistry.repo_db.get(domain)
+    repo_url = params[:repo_url].to_s.strip
+    repo = RepoRegistry.repo_db.get(repo_url)
     unless repo
-      redirect_to repository_settings_path, alert: t('.message_not_found', domain: domain) and return
+      redirect_to repository_settings_path, alert: t('.message_not_found', domain: repo_url) and return
     end
 
-    RepoRegistry.repo_db.delete(domain)
-    redirect_to repository_settings_path, notice: t('.message_deleted', domain: domain, type: repo.type.to_s)
+    RepoRegistry.repo_db.delete(repo_url)
+    redirect_to repository_settings_path, notice: t('.message_deleted', domain: repo_url, type: repo.type.to_s)
   end
 end

--- a/application/app/services/repo/repo_db.rb
+++ b/application/app/services/repo/repo_db.rb
@@ -26,40 +26,40 @@ module Repo
       @data = load_data
     end
 
-    def get(domain)
-      @data[domain]
+    def get(repo_url)
+      @data[repo_url]
     end
 
-    def set(domain, type:, metadata: nil)
+    def set(repo_url, type:, metadata: nil)
       raise ArgumentError, "Invalid type: #{type}" unless type.is_a?(ConnectorType)
 
-      metadata = @data[domain]&[:metadata] || {} if metadata.nil?
-      @data[domain] = Entry.new(
+      metadata = @data[repo_url]&.metadata.to_h if metadata.nil?
+      @data[repo_url] = Entry.new(
         type: type.to_s,
         last_updated: Time.now.to_s,
         metadata: metadata
       )
       persist!
-      log_info('Entry added', {domain: domain, type: type})
+      log_info('Entry added', {repo_url: repo_url, type: type})
     end
 
-    def update(domain, metadata:)
-      raise ArgumentError, "Unknown domain: #{domain}" unless @data.key?(domain)
+    def update(repo_url, metadata:)
+      raise ArgumentError, "Unknown repo url: #{repo_url}" unless @data.key?(repo_url)
 
-      entry = @data[domain]
+      entry = @data[repo_url]
       entry.last_updated = Time.now.to_s
       entry[:metadata] ||= {}
       entry[:metadata] = entry[:metadata].merge(metadata)
       persist!
-      log_info('Entry updated', { domain: domain, type: entry.type })
+      log_info('Entry updated', { repo_url: repo_url, type: entry.type })
     end
 
-    def delete(domain)
-      return unless @data.key?(domain)
+    def delete(repo_url)
+      return unless @data.key?(repo_url)
 
-      entry = @data.delete(domain)
+      entry = @data.delete(repo_url)
       persist!
-      log_info('Entry deleted', { domain: domain, type: entry&.type })
+      log_info('Entry deleted', { repo_url: repo_url, type: entry&.type })
     end
 
     def size

--- a/application/app/services/repo/resolvers/dataverse_resolver.rb
+++ b/application/app/services/repo/resolvers/dataverse_resolver.rb
@@ -24,9 +24,10 @@ module Repo
 
         domain = repo_url.domain
         return unless domain
+        repo_base_url = repo_url.dataverse_url
 
-        log_info('Checking RepoCache', {domain: domain})
-        repo_info = context.repo_db.get(domain)
+        log_info('Checking RepoCache', {repo_url: repo_base_url})
+        repo_info = context.repo_db.get(repo_base_url)
         if repo_info
           context.type = repo_info.type
           return
@@ -34,13 +35,13 @@ module Repo
 
         log_info('Checking DataverseHub', {domain: domain})
         if known_dataverse_installation?(domain)
-          success(context, domain)
+          success(context, repo_base_url)
           return
         end
 
         log_info('Checking Dataverse API', {dataverse_url: repo_url.dataverse_url})
         if responds_to_api?(context.http_client, repo_url)
-          success(context, domain)
+          success(context, repo_base_url)
           return
         end
       end
@@ -70,9 +71,9 @@ module Repo
         false
       end
 
-      def success(context, domain)
+      def success(context, repo_base_url)
         context.type = ConnectorType::DATAVERSE
-        context.repo_db.set(domain, type: ConnectorType::DATAVERSE)
+        context.repo_db.set(repo_base_url, type: ConnectorType::DATAVERSE)
       end
 
     end

--- a/application/app/services/repo/resolvers/zenodo_resolver.rb
+++ b/application/app/services/repo/resolvers/zenodo_resolver.rb
@@ -23,7 +23,7 @@ module Repo
         return unless ZENODO_DOMAINS.include?(repo_url.domain)
 
         context.type = ConnectorType::ZENODO
-        context.repo_db.set(repo_url.domain, type: ConnectorType::ZENODO)
+        context.repo_db.set(repo_url.zenodo_url, type: ConnectorType::ZENODO)
 
         log_info("ZenodoResolver matched URL: #{context.object_url}")
       end

--- a/application/app/views/connectors/dataverse/_repo_settings.html.erb
+++ b/application/app/views/connectors/dataverse/_repo_settings.html.erb
@@ -1,5 +1,5 @@
 <%= form_with url: repository_settings_path, method: :put, local: true do |f| %>
-  <%= hidden_field_tag :domain, domain %>
+  <%= hidden_field_tag :repo_url, repo_url %>
   <div class="mb-3">
     <%= f.label :auth_key, t('connectors.dataverse.connector_edit_form.field_api_key_label'), class: 'form-label fw-bold' %>
     <%= f.text_field :auth_key, value: metadata.auth_key, class: 'form-control', placeholder: t('connectors.dataverse.connector_edit_form.field_api_key_placeholder') %>

--- a/application/app/views/connectors/zenodo/_repo_settings.html.erb
+++ b/application/app/views/connectors/zenodo/_repo_settings.html.erb
@@ -1,5 +1,5 @@
 <%= form_with url: repository_settings_path, method: :put, local: true do |f| %>
-  <%= hidden_field_tag :domain, domain %>
+  <%= hidden_field_tag :repo_url, repo_url %>
   <div class="mb-3">
     <%= f.label :auth_key, t('connectors.zenodo.connector_edit_form.field_api_key_label'), class: 'form-label fw-bold' %>
     <%= f.text_field :auth_key, value: metadata.auth_key, class: 'form-control', placeholder: t('connectors.zenodo.connector_edit_form.field_api_key_placeholder') %>

--- a/application/app/views/repository_settings/_repository.html.erb
+++ b/application/app/views/repository_settings/_repository.html.erb
@@ -7,15 +7,15 @@
        data-utils--icon-toggle-icon-on-value="bi-plus-square"
        data-utils--icon-toggle-icon-off-value="bi-dash-square"
        data-action="click->utils--icon-toggle#toggle"
-       href="#repo-<%= domain.parameterize %>"
+       href="#repo-<%= repo_url.parameterize %>"
        role="button"
        aria-expanded="false"
-       aria-controls="repo-<%= domain.parameterize %>">
+       aria-controls="repo-<%= repo_url.parameterize %>">
       <i data-utils--icon-toggle-target="icon" class="bi bi-plus-square me-2 transition" style="line-height: 1;" aria-hidden="true"></i>
       <span class="me-2 d-inline-flex align-items-center" style="line-height: 1;">
         <%= connector_icon(entry.type) %>
       </span>
-      <strong class="d-inline-block"><%= domain %></strong>
+      <strong class="d-inline-block"><%= repo_url %></strong>
     </a>
 
     <%= render layout: "shared/button_to", locals: {
@@ -26,16 +26,16 @@
       icon: 'bi bi-trash-fill',
       modal_id: 'modal-delete-confirmation',
       modal_title: t('.modal_delete_confirmation_title'),
-      modal_subtitle: domain,
+      modal_subtitle: repo_url,
       modal_content: t('.modal_delete_confirmation_content')
     } do %>
-      <%= hidden_field_tag :domain, domain %>
+      <%= hidden_field_tag :repo_url, repo_url %>
     <% end %>
 
   </div>
-  <div class="collapse" id="repo-<%= domain.parameterize %>">
+  <div class="collapse" id="repo-<%= repo_url.parameterize %>">
     <div class="card-body">
-      <%= render partial: "/connectors/#{entry.type.to_s.downcase}/repo_settings", locals: { domain: domain, metadata: entry.metadata } %>
+      <%= render partial: "/connectors/#{entry.type.to_s.downcase}/repo_settings", locals: { repo_url: repo_url, metadata: entry.metadata } %>
     </div>
   </div>
 </li>

--- a/application/app/views/repository_settings/index.html.erb
+++ b/application/app/views/repository_settings/index.html.erb
@@ -6,8 +6,8 @@
       <%= render partial: 'actions' %>
 
       <ul class="list-group">
-        <% @repositories.each do |domain, entry| %>
-          <%= render partial: 'repository', locals: { domain: domain, entry: entry } %>
+        <% @repositories.each do |repo_url, entry| %>
+          <%= render partial: 'repository', locals: { repo_url: repo_url, entry: entry } %>
         <% end %>
       </ul>
     </div>

--- a/application/test/connectors/dataverse/actions/dataset_form_tabs_test.rb
+++ b/application/test/connectors/dataverse/actions/dataset_form_tabs_test.rb
@@ -38,7 +38,7 @@ class Dataverse::Actions::DatasetFormTabsTest < ActiveSupport::TestCase
     @bundle.stubs(:connector_metadata).returns(meta)
     repo = mock('repo')
     repo.stubs(:metadata).returns(OpenStruct.new(subjects: nil))
-    RepoRegistry.repo_db.stubs(:get).with('demo.dv').returns(repo)
+    RepoRegistry.repo_db.stubs(:get).with('https://demo.dv').returns(repo)
     RepoRegistry.repo_db.stubs(:update)
 
     md_service = mock('md')

--- a/application/test/connectors/zenodo/actions/upload_bundle_create_test.rb
+++ b/application/test/connectors/zenodo/actions/upload_bundle_create_test.rb
@@ -19,7 +19,7 @@ class Zenodo::Actions::UploadBundleCreateTest < ActiveSupport::TestCase
     Zenodo::ZenodoUrl.stubs(:parse).returns(url_data)
 
     repo_info = OpenStruct.new(metadata: OpenStruct.new(auth_key: 'KEY'))
-    RepoRegistry.repo_db.stubs(:get).with('zenodo.org').returns(repo_info)
+    RepoRegistry.repo_db.stubs(:get).with('https://zenodo.org').returns(repo_info)
 
     dep = OpenStruct.new(title: 'title', bucket_url: 'b', draft?: false)
     service = mock('service')

--- a/application/test/controllers/repository_settings_controller_test.rb
+++ b/application/test/controllers/repository_settings_controller_test.rb
@@ -5,7 +5,7 @@ class RepositorySettingsControllerTest < ActionDispatch::IntegrationTest
   def setup
     @tempfile = Tempfile.new('repo_db')
     RepoRegistry.repo_db = Repo::RepoDb.new(db_path: @tempfile.path)
-    RepoRegistry.repo_db.set('demo.org', type: ConnectorType::DATAVERSE, metadata: {auth_key: 'old'})
+    RepoRegistry.repo_db.set('https://demo.org', type: ConnectorType::DATAVERSE, metadata: {auth_key: 'old'})
   end
 
   def teardown
@@ -42,27 +42,27 @@ class RepositorySettingsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'update should update repository metadata' do
-    put repository_settings_url, params: { domain: 'demo.org', metadata: {auth_key: 'new'} }
+    put repository_settings_url, params: { repo_url: 'https://demo.org', metadata: {auth_key: 'new'} }
     assert_redirected_to repository_settings_url
-    assert_equal I18n.t('repository_settings.update.message_success', domain: 'demo.org'), flash[:notice]
-    assert_equal 'new', RepoRegistry.repo_db.get('demo.org').metadata.auth_key
+    assert_equal I18n.t('repository_settings.update.message_success', domain: 'https://demo.org'), flash[:notice]
+    assert_equal 'new', RepoRegistry.repo_db.get('https://demo.org').metadata.auth_key
   end
 
   test 'update should show error when repository missing' do
-    put repository_settings_url, params: { domain: 'missing.org', metadata: {auth_key: 'x'} }
+    put repository_settings_url, params: { repo_url: 'missing.org', metadata: {auth_key: 'x'} }
     assert_redirected_to repository_settings_url
     assert_equal I18n.t('repository_settings.update.message_not_found', domain: 'missing.org'), flash[:alert]
   end
 
   test 'destroy should delete repository' do
-    delete repository_settings_url, params: { domain: 'demo.org' }
+    delete repository_settings_url, params: { repo_url: 'https://demo.org' }
     assert_redirected_to repository_settings_url
-    assert_equal I18n.t('repository_settings.destroy.message_deleted', domain: 'demo.org', type: 'dataverse'), flash[:notice]
-    assert_nil RepoRegistry.repo_db.get('demo.org')
+    assert_equal I18n.t('repository_settings.destroy.message_deleted', domain: 'https://demo.org', type: 'dataverse'), flash[:notice]
+    assert_nil RepoRegistry.repo_db.get('https://demo.org')
   end
 
   test 'destroy should show error when repository missing' do
-    delete repository_settings_url, params: { domain: 'missing.org' }
+    delete repository_settings_url, params: { repo_url: 'missing.org' }
     assert_redirected_to repository_settings_url
     assert_equal I18n.t('repository_settings.destroy.message_not_found', domain: 'missing.org'), flash[:alert]
   end

--- a/application/test/services/repo/repo_db_test.rb
+++ b/application/test/services/repo/repo_db_test.rb
@@ -14,8 +14,8 @@ class Repo::RepoDbTest < ActiveSupport::TestCase
   end
 
   test 'should add and retrieve an entry' do
-    @db.set('demo.org', type: @type, metadata: { token: 'abc123' })
-    entry = @db.get('demo.org')
+    @db.set('https://demo.org', type: @type, metadata: { token: 'abc123' })
+    entry = @db.get('https://demo.org')
 
     assert entry
     assert_equal @type, entry.type
@@ -24,43 +24,43 @@ class Repo::RepoDbTest < ActiveSupport::TestCase
   end
 
   test 'should update metadata' do
-    @db.set('demo.org', type: @type, metadata: { token: 'abc123' })
-    @db.update('demo.org', metadata: { token: 'xyz789', user: 'alice' })
+    @db.set('https://demo.org', type: @type, metadata: { token: 'abc123' })
+    @db.update('https://demo.org', metadata: { token: 'xyz789', user: 'alice' })
 
-    entry = @db.get('demo.org')
+    entry = @db.get('https://demo.org')
     assert_equal 'xyz789', entry.metadata.token
     assert_equal 'alice', entry.metadata.user
   end
 
   test 'should raise error when updating unknown domain' do
-    assert_raises(ArgumentError, 'Unknown domain: unknown.org') do
-      @db.update('unknown.org', metadata: { token: 'xyz789' })
+    assert_raises(ArgumentError, 'Unknown repo url: https://unknown.org') do
+      @db.update('https://unknown.org', metadata: { token: 'xyz789' })
     end
   end
 
   test 'should delete an entry' do
-    @db.set('demo.org', type: @type, metadata: { token: 'abc123' })
-    @db.delete('demo.org')
+    @db.set('https://demo.org', type: @type, metadata: { token: 'abc123' })
+    @db.delete('https://demo.org')
 
-    assert_nil @db.get('demo.org')
+    assert_nil @db.get('https://demo.org')
     assert_equal 0, @db.size
   end
 
   test 'should return correct size and all entries' do
-    @db.set('demo.org', type: @type)
-    @db.set('example.com', type: @type)
+    @db.set('https://demo.org', type: @type)
+    @db.set('https://example.com', type: @type)
 
     assert_equal 2, @db.size
     all = @db.all
     assert_kind_of Hash, all
-    assert_equal %w[demo.org example.com].sort, all.keys.sort
+    assert_equal %w[https://demo.org https://example.com].sort, all.keys.sort
   end
 
   test 'should persist and reload from file' do
-    @db.set('demo.org', type: @type, metadata: { token: 'abc123' })
+    @db.set('https://demo.org', type: @type, metadata: { token: 'abc123' })
 
     reloaded = Repo::RepoDb.new(db_path: @tempfile.path)
-    entry = reloaded.get('demo.org')
+    entry = reloaded.get('https://demo.org')
 
     assert entry
     assert_equal 'abc123', entry.metadata.token
@@ -68,7 +68,7 @@ class Repo::RepoDbTest < ActiveSupport::TestCase
 
   test 'should not persist invalid type' do
     assert_raises(ArgumentError) do
-      @db.set('demo.org', type: 'invalid')
+      @db.set('https://demo.org', type: 'invalid')
     end
   end
 end

--- a/application/test/services/repo/resolvers/dataverse_resolver_test.rb
+++ b/application/test/services/repo/resolvers/dataverse_resolver_test.rb
@@ -21,7 +21,7 @@ class Repo::Resolvers::DataverseResolverTest < ActiveSupport::TestCase
     resolver.resolve(context)
 
     assert_equal ConnectorType::DATAVERSE, context.type
-    assert @repo_db.get('dv.org')
+    assert @repo_db.get('https://dv.org')
   end
 
   test 'resolve falls back to API when domain unknown' do
@@ -38,7 +38,7 @@ class Repo::Resolvers::DataverseResolverTest < ActiveSupport::TestCase
     resolver.resolve(context)
 
     assert_equal ConnectorType::DATAVERSE, context.type
-    assert @repo_db.get('unknown.org')
+    assert @repo_db.get('https://unknown.org')
   end
 
   test 'resolve handles api failures gracefully' do


### PR DESCRIPTION
## Summary
- store repositories in `RepoDb` keyed by full URL
- update resolvers and connectors to use URL keys
- adjust controller and tests for URL based keys
- tweak repository resolver tests for new behaviour
- cleanup forms to use `repo_url` param

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68740555b01883218ee3c3faa5cf97bc