### PR TITLE
Add creation_date to RepoDb entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ application/vendor/bundle
 .idea
 /application/app/assets/builds/*
 !/application/app/assets/builds/.keep
+/application/bun.lock
 
 /application/node_modules
 

--- a/application/test/services/repo/repo_db_test.rb
+++ b/application/test/services/repo/repo_db_test.rb
@@ -20,16 +20,19 @@ class Repo::RepoDbTest < ActiveSupport::TestCase
     assert entry
     assert_equal @type, entry.type
     assert_equal 'abc123', entry.metadata.token
+    assert_not_nil entry.creation_date
     assert_not_nil entry.last_updated
   end
 
   test 'should update metadata' do
     @db.set('https://demo.org', type: @type, metadata: { token: 'abc123' })
+    original_created = @db.get('https://demo.org').creation_date
     @db.update('https://demo.org', metadata: { token: 'xyz789', user: 'alice' })
 
     entry = @db.get('https://demo.org')
     assert_equal 'xyz789', entry.metadata.token
     assert_equal 'alice', entry.metadata.user
+    assert_equal original_created, entry.creation_date
   end
 
   test 'should raise error when updating unknown domain' do
@@ -58,12 +61,14 @@ class Repo::RepoDbTest < ActiveSupport::TestCase
 
   test 'should persist and reload from file' do
     @db.set('https://demo.org', type: @type, metadata: { token: 'abc123' })
+    created = @db.get('https://demo.org').creation_date
 
     reloaded = Repo::RepoDb.new(db_path: @tempfile.path)
     entry = reloaded.get('https://demo.org')
 
     assert entry
     assert_equal 'abc123', entry.metadata.token
+    assert_equal created, entry.creation_date
   end
 
   test 'should not persist invalid type' do


### PR DESCRIPTION
## Summary
- track entry creation date in RepoDb
- ensure creation date is persisted and never overwritten
- ignore bun.lock generated by bun

## Testing
- `bundle install`
- `env RAILS_ENV=test bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687417cd8b508321b805df5ed84b6fcb