### PR TITLE
Add browse links to repo settings

### DIFF
--- a/application/app/helpers/repository_settings_helper.rb
+++ b/application/app/helpers/repository_settings_helper.rb
@@ -1,0 +1,6 @@
+module RepositorySettingsHelper
+  def browse_repository_path(repo_url, entry)
+    resolver = ConnectorClassDispatcher.repo_controller_resolver(entry.type)
+    resolver.get_controller_url(repo_url).redirect_url
+  end
+end

--- a/application/app/views/repository_settings/_repository.html.erb
+++ b/application/app/views/repository_settings/_repository.html.erb
@@ -18,19 +18,34 @@
       <strong class="d-inline-block"><%= repo_url %></strong>
     </a>
 
-    <%= render layout: "shared/button_to", locals: {
-      url: repository_settings_path,
-      method: 'DELETE',
-      title: t('.button_delete_repository_title'),
-      class: 'btn-sm btn-outline-dark icon-hover-danger',
-      icon: 'bi bi-trash-fill',
-      modal_id: 'modal-delete-confirmation',
-      modal_title: t('.modal_delete_confirmation_title'),
-      modal_subtitle: repo_url,
-      modal_content: t('.modal_delete_confirmation_content')
-    } do %>
-      <%= hidden_field_tag :repo_url, repo_url %>
-    <% end %>
+    <div class="d-flex align-items-center gap-2">
+      <%= link_to repo_url, target: '_blank', class: 'btn btn-sm btn-outline-secondary',
+                    title: t('.link_open_repository_title') do %>
+        <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
+        <span class="visually-hidden"><%= t('.link_open_repository_title') %></span>
+      <% end %>
+
+      <%= link_to browse_repository_path(repo_url, entry),
+                  class: 'btn btn-sm btn-outline-dark icon-hover-danger',
+                  title: t('.button_browse_repository_title') do %>
+        <i class="bi bi-folder2-open" aria-hidden="true"></i>
+        <span class="visually-hidden"><%= t('.button_browse_repository_label') %></span>
+      <% end %>
+
+      <%= render layout: "shared/button_to", locals: {
+        url: repository_settings_path,
+        method: 'DELETE',
+        title: t('.button_delete_repository_title'),
+        class: 'btn-sm btn-outline-dark icon-hover-danger',
+        icon: 'bi bi-trash-fill',
+        modal_id: 'modal-delete-confirmation',
+        modal_title: t('.modal_delete_confirmation_title'),
+        modal_subtitle: repo_url,
+        modal_content: t('.modal_delete_confirmation_content')
+      } do %>
+        <%= hidden_field_tag :repo_url, repo_url %>
+      <% end %>
+    </div>
 
   </div>
   <div class="collapse" id="repo-<%= repo_url.parameterize %>">

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -253,6 +253,9 @@ en:
       breadcrumbs_text: "Repository Settings"
       page_title: "OnDemand Loop - Repository Settings"
     repository:
+      link_open_repository_title: "Open repository"
+      button_browse_repository_label: "Browse"
+      button_browse_repository_title: "Browse repository"
       button_delete_repository_title: "Delete repository"
       modal_delete_confirmation_title: "Delete Repository"
       modal_delete_confirmation_content: "This will remove the repository settings from the app. No local or remote file will be affected"


### PR DESCRIPTION
## Summary
- add helper `browse_repository_path` to build connector URL
- show open and browse actions in repository settings list
- add translation entries for new buttons

## Testing
- `bundle install`
- `bin/rails test`

------
https://chatgpt.com/codex/tasks/task_e_68741e8c8c1c8321a953aa55a1491d7b