### PR TITLE
Add retry option for failed downloads

### DIFF
--- a/application/app/controllers/download_files_controller.rb
+++ b/application/app/controllers/download_files_controller.rb
@@ -8,8 +8,7 @@ class DownloadFilesController < ApplicationController
     file = DownloadFile.find(project_id, file_id)
 
     if file.nil?
-      redirect_back fallback_location: root_path,
-                    alert: t('.file_not_found_for_project', file_id: file_id, project_id: project_id)
+      render json: t('.file_not_found_for_project', file_id: file_id, project_id: project_id), status: :not_found
       return
     end
 

--- a/application/app/views/projects/show/_download_files.html.erb
+++ b/application/app/views/projects/show/_download_files.html.erb
@@ -38,6 +38,18 @@
           <%= render partial: '/shared/file_row_date', locals: { date: file.end_date, title: t('.field_completion_date_title'), classes: 'mx-2'} if file.end_date %>
           <%= render partial: '/shared/file_row_date', locals: { date: file.start_date, title: t('.field_download_start_date_title'), classes: 'mx-2'} if file.status.downloading? %>
 
+          <% if file.status.error? %>
+            <%= render layout: 'shared/button_to', locals: {
+              url: retry_project_download_file_path(project_id: project.id, id: file.id),
+              method: 'POST',
+              title: t('.button_retry_file_title'),
+              class: 'btn-sm btn-outline-secondary',
+              icon: 'bi bi-arrow-clockwise'
+            } do %>
+              <%= hidden_field_tag :anchor, tab_anchor_for(project) %>
+            <% end %>
+          <% end %>
+
           <%= render layout: 'shared/button_to', locals: {
             url: project_download_file_path(project_id: project.id, id: file.id),
             method: 'DELETE',

--- a/application/config/locales/controllers/en.yml
+++ b/application/config/locales/controllers/en.yml
@@ -5,6 +5,7 @@ en:
     file_not_found_for_project: "File: %{file_id} not found for project: %{project_id}"
     file_in_progress: "File: %{filename} cannot be deleted while is being downloaded"
     download_file_deleted_successfully: "Download file deleted: %{filename}"
+    download_file_retried_successfully: "Download file retried: %{filename}"
   file_browser:
     directory_forbidden: "You do not have permission to access this directory."
   projects:

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -92,6 +92,7 @@ en:
       download_files:
         badge_repository_files_tooltip: "Repository Files"
         button_delete_file_title: "Delete File"
+        button_retry_file_title: "Retry Download"
         field_completion_date_title: "Completion date"
         field_download_start_date_title: "Download start date"
         field_schedule_date_title: "Schedule date"

--- a/application/config/routes.rb
+++ b/application/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     # post /projects/:project_id/downloads/files/:id/cancel => cancel download file
     resources :download_files, path: 'downloads/files', only: [ :destroy ] do
       post :cancel, on: :member
+      post :retry, on: :member
     end
 
     # post /projects/:project_id/uploads => create new upload batch


### PR DESCRIPTION
## Summary
- allow retrying failed download files in the controller
- add retry action button in project view
- update locales; remove unused Spanish keys
- adjust controller test for redirect behavior

## Testing
- `bundle exec rake test TEST=test/controllers/download_files_controller_test.rb` *(fails: missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_6877f11dbb688321a1bb39dfa039b824