### PR TITLE
Modify Dataverse resolver to use API only

### DIFF
--- a/application/app/services/repo/repo_db.rb
+++ b/application/app/services/repo/repo_db.rb
@@ -51,14 +51,17 @@ module Repo
       raise ArgumentError, "Invalid type: #{type}" unless type.is_a?(ConnectorType)
 
       existing = @data[repo_url]
-      metadata = existing&.metadata.to_h if metadata.nil?
+      existing_metadata = existing&.metadata.to_h || {}
+      incoming_metadata = metadata&.to_h&.compact_blank || {}
+      merged_metadata = existing_metadata.merge(incoming_metadata).compact_blank
+
       creation_date = existing&.creation_date || now
       @data[repo_url] = Entry.new(
         repo_url: repo_url,
         type: type.to_s,
         creation_date: creation_date,
         last_updated: Time.now.to_s,
-        metadata: metadata
+        metadata: merged_metadata
       )
       persist!
       log_info('Entry added', {repo_url: repo_url, type: type})

--- a/application/test/services/repo/repo_db_test.rb
+++ b/application/test/services/repo/repo_db_test.rb
@@ -82,4 +82,17 @@ class Repo::RepoDbTest < ActiveSupport::TestCase
       @db.set('https://demo.org', type: 'invalid')
     end
   end
+
+  test 'set merges metadata and removes empty values' do
+    @db.set('https://demo.org', type: @type, metadata: { token: 'abc123', api_version: '1.0' })
+    created = @db.get('https://demo.org').creation_date
+
+    @db.set('https://demo.org', type: @type, metadata: { api_version: '2.0', token: nil, extra: '' })
+
+    entry = @db.get('https://demo.org')
+    assert_equal '2.0', entry.metadata.api_version
+    assert_equal 'abc123', entry.metadata.token
+    assert_nil entry.metadata.extra
+    assert_equal created, entry.creation_date
+  end
 end


### PR DESCRIPTION
## Summary
- rely on Dataverse API instead of hub when resolving repos
- keep API version in RepoDb entry metadata
- merge RepoDb metadata with incoming data, ignoring blank values
- update resolver and RepoDb tests
- refactor RepoDb#set using merge/compact_blank

## Testing
- `RBENV_VERSION=3.2.3 bundle exec rake test TEST=test/services/repo/repo_db_test.rb --verbose`
- `RBENV_VERSION=3.2.3 bundle exec rake test TEST=test/services/repo/resolvers/dataverse_resolver_test.rb --verbose`
- `RBENV_VERSION=3.2.3 bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687a2918222483218fbd26abfcb73005