### PR TITLE
Support Zenodo draft creation from record

### DIFF
--- a/application/app/connectors/zenodo/actions/deposition_fetch.rb
+++ b/application/app/connectors/zenodo/actions/deposition_fetch.rb
@@ -10,12 +10,21 @@ module Zenodo::Actions
     def update(upload_bundle, request_params)
       connector_metadata = upload_bundle.connector_metadata
       connector_metadata.api_key
-      deposition_service = Zenodo::DepositionService.new(connector_metadata.zenodo_url, api_key: connector_metadata.api_key.value)
-      deposition = deposition_service.find_deposition(connector_metadata.deposition_id)
+      api_key = connector_metadata.api_key.value
+
+      if connector_metadata.deposition_id.present?
+        deposition_service = Zenodo::DepositionService.new(connector_metadata.zenodo_url, api_key: api_key)
+        deposition = deposition_service.find_deposition(connector_metadata.deposition_id)
+      else
+        record_service = Zenodo::RecordService.new(connector_metadata.zenodo_url)
+        deposition = record_service.get_or_create_deposition(connector_metadata.record_id, api_key: api_key)
+      end
+
       return error(I18n.t('connectors.zenodo.actions.fetch_deposition.message_deposition_not_found', url: upload_bundle.repo_url)) unless deposition
 
       connector_metadata.title = deposition.title
       connector_metadata.bucket_url = deposition.bucket_url
+      connector_metadata.deposition_id ||= deposition.id
       connector_metadata.draft = deposition.draft?
       upload_bundle.update({ metadata: connector_metadata.to_h })
 

--- a/application/app/connectors/zenodo/upload_bundle_connector_metadata.rb
+++ b/application/app/connectors/zenodo/upload_bundle_connector_metadata.rb
@@ -31,7 +31,11 @@ module Zenodo
     end
 
     def fetch_deposition?
-      api_key? && draft.nil?
+      api_key? && draft.nil? && deposition_id.present?
+    end
+
+    def create_draft?
+      api_key? && draft.nil? && deposition_id.nil? && record_id.present?
     end
 
     def draft?

--- a/application/app/services/zenodo/record_service.rb
+++ b/application/app/services/zenodo/record_service.rb
@@ -17,5 +17,22 @@ module Zenodo
       return nil unless response.success?
       RecordResponse.new(response.body)
     end
+
+    def get_or_create_deposition(record_id, api_key:)
+      headers = { 'Content-Type' => 'application/json', ApiService::AUTH_HEADER => "Bearer #{api_key}" }
+      url = FluentUrl.new('')
+              .add_path('api')
+              .add_path('records')
+              .add_path(record_id)
+              .add_path('draft')
+              .to_s
+      response = @http_client.post(url, headers: headers)
+
+      return nil if response.not_found?
+      raise ApiService::UnauthorizedException if response.unauthorized?
+      raise "Error retrieving deposition: #{response.status} - #{response.body}" unless response.success?
+
+      DepositionResponse.new(response.body)
+    end
   end
 end

--- a/application/app/views/connectors/zenodo/_upload_bundle_actions_bar.html.erb
+++ b/application/app/views/connectors/zenodo/_upload_bundle_actions_bar.html.erb
@@ -18,7 +18,19 @@
               <%= upload_bundle.connector_metadata.title %>
             </a>
           <% end %>
-          <% if upload_bundle.connector_metadata.fetch_deposition? %>
+          <% if upload_bundle.connector_metadata.create_draft? %>
+            <%= render layout: "shared/button_to", locals: {
+              url:  project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id),
+              method: 'PUT',
+              label: t('connectors.zenodo.upload_bundle_actions_bar.button_create_draft_title'),
+              title: t('connectors.zenodo.upload_bundle_actions_bar.button_create_draft_title'),
+              class: 'btn btn-outline-primary btn-badge position-relative me-1',
+              icon: "bi bi-database-add",
+            } do %>
+              <%= hidden_field_tag :anchor, tab_anchor_for(upload_bundle) %>
+              <%= hidden_field_tag :form, 'deposition_fetch' %>
+            <% end %>
+          <% elsif upload_bundle.connector_metadata.fetch_deposition? %>
             <%= render layout: "shared/button_to", locals: {
               url:  project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id),
               method: 'PUT',

--- a/application/test/connectors/zenodo/actions/deposition_fetch_test.rb
+++ b/application/test/connectors/zenodo/actions/deposition_fetch_test.rb
@@ -28,4 +28,19 @@ class Zenodo::Actions::DepositionFetchTest < ActiveSupport::TestCase
     result = @action.update(@bundle, {})
     refute result.success?
   end
+
+  test 'update creates deposition from record when needed' do
+    meta = OpenStruct.new(zenodo_url: 'http://zenodo.org', record_id: '11', deposition_id: nil, api_key: OpenStruct.new(value: 'KEY'))
+    @bundle.stubs(:connector_metadata).returns(meta)
+    @bundle.stubs(:repo_url).returns('http://zenodo.org/record/11')
+
+    dep = OpenStruct.new(id: '99', title: 't', bucket_url: 'b', draft?: true)
+    r_service = mock('record_service')
+    r_service.expects(:get_or_create_deposition).with('11', api_key: 'KEY').returns(dep)
+    Zenodo::RecordService.stubs(:new).returns(r_service)
+
+    result = @action.update(@bundle, {})
+    assert result.success?
+    assert_equal '99', @bundle.metadata[:deposition_id]
+  end
 end

--- a/application/test/services/zenodo/record_service_test.rb
+++ b/application/test/services/zenodo/record_service_test.rb
@@ -20,4 +20,26 @@ class Zenodo::RecordServiceTest < ActiveSupport::TestCase
     service = Zenodo::RecordService.new('https://zenodo.org', http_client: client)
     assert_nil service.find_record('99')
   end
+
+  test 'get_or_create_deposition returns deposition response' do
+    client = HttpClientMock.new(file_path: fixture_path('zenodo/deposition_response.json'))
+    service = Zenodo::RecordService.new('https://zenodo.org', http_client: client)
+    dep = service.get_or_create_deposition('11', api_key: 'KEY')
+    assert_instance_of Zenodo::DepositionResponse, dep
+    assert_equal '/api/records/11/draft', client.called_path
+  end
+
+  test 'get_or_create_deposition handles not found' do
+    client = HttpClientMock.new(file_path: fixture_path('zenodo/deposition_response.json'), status_code: 404)
+    service = Zenodo::RecordService.new('https://zenodo.org', http_client: client)
+    assert_nil service.get_or_create_deposition('11', api_key: 'KEY')
+  end
+
+  test 'get_or_create_deposition raises unauthorized' do
+    client = HttpClientMock.new(file_path: fixture_path('zenodo/deposition_response.json'), status_code: 401)
+    service = Zenodo::RecordService.new('https://zenodo.org', http_client: client)
+    assert_raises(Zenodo::ApiService::UnauthorizedException) do
+      service.get_or_create_deposition('11', api_key: 'KEY')
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- enable creating a deposition from a Zenodo record
- expose draft creation in upload bundle metadata and actions bar
- update deposition fetch action to use new service
- add tests for record service and deposition fetch logic

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687c209a3a0083219e286127bbec4063