### PR TITLE
Add integration tests for connector forms

### DIFF
--- a/application/config/locales/connectors/zenodo/en.yml
+++ b/application/config/locales/connectors/zenodo/en.yml
@@ -24,6 +24,8 @@ en:
         field_api_key_help: "Provide the access token required to authenticate with the Zenodo server."
         field_key_scope_label: "Store access token for this upload bundle only"
         field_key_scope_help: "Leave unchecked to store this access token for all bundles using Zenodo."
+        submit: "Save Changes"
+        cancel: "Cancel"
       upload_bundle_actions_bar:
         button_select_deposition_title: "Select Deposition"
         modal_select_deposition_title: "Select Zenodo deposition"


### PR DESCRIPTION
## Summary
- ensure UploadBundlesController renders connector partials

## Testing
- `scripts/loop_test.sh` *(fails: rbenv: version `3.1.5` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687c26ddb12c8321a0ec06d083a5702a