### PR TITLE
Update admin guide with new configuration properties

### DIFF
--- a/docs/guide/content/admin.md
+++ b/docs/guide/content/admin.md
@@ -23,31 +23,89 @@ There are two ways to override the defaults shown below:
     ood_dashboard_path: "/pun/sys/ood"
 ```
 
-- Define an enviroment variable in the system or create a `.env` or `.env.<RAILS_ENV>` (for example `.env.development`) file in the application root directory and set the appropriate environment variables. Environment-specific files takes precedence over `.env` in case of collision.
+- Define an environment variable in the system or create a `.env` or `.env.<RAILS_ENV>` (for example `.env.development`) file in the application root directory and set the appropriate environment variables. Environment-specific files take precedence over `.env` in case of collision.
 
 Sample configuration files can be found in the final section of this guide [Sample Configuration Files](#sample-configuration-files)
 
 ## List of config properties
+- [version](#version)
+- [ood_version](#ood_version)
+- [metadata_root](#metadata_root)
+- [download_root](#download_root)
+- [ruby_binary](#ruby_binary)
+- [files_app_path](#files_app_path)
+- [ood_dashboard_path](#ood_dashboard_path)
 - [connector_status_poll_interval](#connector_status_poll_interval)
+- [locale](#locale)
+- [download_files_retention_period](#download_files_retention_period)
+- [upload_files_retention_period](#upload_files_retention_period)
+- [ui_feedback_delay](#ui_feedback_delay)
 - [detached_controller_interval](#detached_controller_interval)
 - [detached_process_status_interval](#detached_process_status_interval)
-- [download_files_retention_period](#download_files_retention_period)
-- [download_root](#download_root)
-- [files_app_path](#files_app_path)
-- [locale](#locale)
 - [max_download_file_size](#max_download_file_size)
 - [max_upload_file_size](#max_upload_file_size)
-- [metadata_root](#metadata_root)
-- [ood_dashboard_path](#ood_dashboard_path)
-- [ruby_binary](#ruby_binary)
-- [ui_feedback_delay](#ui_feedback_delay)
-- [upload_files_retention_period](#upload_files_retention_period)
 - [zenodo_enabled](#zenodo_enabled)
+- [guide_url](#guide_url)
+
+### version
+- **Purpose:** Path to a file that contains the Loop version string. The content of this file is displayed in the UI.
+- **Default:** `application/VERSION`
+- **Environment Variable:** None
+
+### ood_version
+- **Purpose:** Path to the file containing the Open OnDemand version.
+- **Default:** `/opt/ood/VERSION`
+- **Environment Variable:** `OOD_VERSION` or `ONDEMAND_VERSION`
+
+### metadata_root
+- **Purpose:** Directory where Loop stores metadata such as projects and repository metadata.
+- **Default:** `$HOME/.downloads-for-ondemand`
+- **Environment Variable:** `OOD_LOOP_METADATA_ROOT`
+
+### download_root
+- **Purpose:** Destination directory for files downloaded from remote repositories.
+- **Default:** `$HOME/downloads-ondemand`
+- **Environment Variable:** `OOD_LOOP_DOWNLOAD_ROOT`
+
+### ruby_binary
+- **Purpose:** Path to the Ruby interpreter used when launching background scripts.
+- **Default:** `File.join(RbConfig::CONFIG['bindir'], 'ruby')`
+- **Environment Variable:** `OOD_LOOP_RUBY_BINARY`
+
+### files_app_path
+- **Purpose:** URL path to the Open OnDemand Files app. Used to link directly to downloaded data.
+- **Default:** `/pun/sys/dashboard/files/fs`
+- **Environment Variable:** `OOD_LOOP_FILES_APP_PATH`
+
+### ood_dashboard_path
+- **Purpose:** URL path to the main Open OnDemand dashboard.
+- **Default:** `/pun/sys/dashboard`
+- **Environment Variable:** `OOD_LOOP_OOD_DASHBOARD_PATH`
 
 ### connector_status_poll_interval
 - **Purpose:** Interval in milliseconds used by the UI when polling connector status.
 - **Default:** `5000`
 - **Environment Variable:** `OOD_LOOP_CONNECTOR_STATUS_POLL_INTERVAL`
+
+### locale
+- **Purpose:** Default locale for the application interface.
+- **Default:** `:en` (English)
+- **Environment Variable:** `OOD_LOOP_LOCALE`
+
+### download_files_retention_period
+- **Purpose:** Maximum age in seconds of download status files that will appear in the UI.
+- **Default:** `24 * 60 * 60` (one day)
+- **Environment Variable:** `OOD_LOOP_DOWNLOAD_FILES_RETENTION_PERIOD`
+
+### upload_files_retention_period
+- **Purpose:** Maximum age in seconds of upload status files that will appear in the UI.
+- **Default:** `24 * 60 * 60` (one day)
+- **Environment Variable:** `OOD_LOOP_UPLOAD_FILES_RETENTION_PERIOD`
+
+### ui_feedback_delay
+- **Purpose:** Delay in milliseconds for certain UI feedback messages.
+- **Default:** `1500`
+- **Environment Variable:** `OOD_LOOP_UI_FEEDBACK_DELAY`
 
 ### detached_controller_interval
 - **Purpose:** Interval in seconds that the detached process controller waits between checks.
@@ -59,26 +117,6 @@ Sample configuration files can be found in the final section of this guide [Samp
 - **Default:** `10 * 1000` (10 seconds)
 - **Environment Variable:** `OOD_LOOP_DETACHED_PROCESS_STATUS_INTERVAL`
 
-### download_files_retention_period
-- **Purpose:** Maximum age in seconds of download status files that will appear in the UI.
-- **Default:** `24 * 60 * 60` (one day)
-- **Environment Variable:** `OOD_LOOP_DOWNLOAD_FILES_RETENTION_PERIOD`
-
-### download_root
-- **Purpose:** Destination directory for files downloaded from remote repositories.
-- **Default:** `$HOME/downloads-ondemand`
-- **Environment Variable:** `OOD_LOOP_DOWNLOAD_ROOT`
-
-### files_app_path
-- **Purpose:** URL path to the Open OnDemand Files app. Used to link directly to downloaded data.
-- **Default:** `/pun/sys/dashboard/files/fs`
-- **Environment Variable:** `OOD_LOOP_FILES_APP_PATH`
-
-### locale
-- **Purpose:** Default locale for the application interface.
-- **Default:** `:en` (English)
-- **Environment Variable:** `OOD_LOOP_LOCALE`
-
 ### max_download_file_size
 - **Purpose:** Maximum allowed size in bytes for a single file download.
 - **Default:** `10 * 1024 * 1024 * 1024` (10 GB)
@@ -89,35 +127,15 @@ Sample configuration files can be found in the final section of this guide [Samp
 - **Default:** `1024 * 1024 * 1024` (1 GB)
 - **Environment Variable:** `OOD_LOOP_MAX_UPLOAD_FILE_SIZE`
 
-### metadata_root
-- **Purpose:** Directory where Loop stores metadata such as projects and repository metadata.
-- **Default:** `$HOME/.downloads-for-ondemand`
-- **Environment Variable:** `OOD_LOOP_METADATA_ROOT`
-
-### ood_dashboard_path
-- **Purpose:** URL path to the main Open OnDemand dashboard.
-- **Default:** `/pun/sys/dashboard`
-- **Environment Variable:** `OOD_LOOP_OOD_DASHBOARD_PATH`
-
-### ruby_binary
-- **Purpose:** Path to the Ruby interpreter used when launching background scripts.
-- **Default:** `File.join(RbConfig::CONFIG['bindir'], 'ruby')`
-- **Environment Variable:** `OOD_LOOP_RUBY_BINARY`
-
-### ui_feedback_delay
-- **Purpose:** Delay in milliseconds for certain UI feedback messages.
-- **Default:** `1500`
-- **Environment Variable:** `OOD_LOOP_UI_FEEDBACK_DELAY`
-
-### upload_files_retention_period
-- **Purpose:** Maximum age in seconds of upload status files that will appear in the UI.
-- **Default:** `24 * 60 * 60` (one day)
-- **Environment Variable:** `OOD_LOOP_UPLOAD_FILES_RETENTION_PERIOD`
-
 ### zenodo_enabled
 - **Purpose:** Enables or disables the optional Zenodo connector.
 - **Default:** `false`
 - **Environment Variable:** `OOD_LOOP_ZENODO_ENABLED`
+
+### guide_url
+- **Purpose:** URL of the documentation site linked from the interface.
+- **Default:** `https://iqss.github.io/ondemand-loop/`
+- **Environment Variable:** `OOD_LOOP_GUIDE_URL`
 
 ## Other Environment Variables
 - [LOOP_CONFIG_DIRECTORY](#loop_config_directory)
@@ -154,41 +172,46 @@ The examples below demonstrate how administrators can override defaults using ei
 
 ```yaml
 # /etc/loop/config/loop.d/config.yml
+version: /opt/loop/VERSION
+ood_version: /opt/ood/VERSION
+metadata_root: /var/loop/metadata
+download_root: /var/loop/downloads
+ruby_binary: /usr/local/bin/ruby
+files_app_path: /pun/sys/dashboard/files/custom
+ood_dashboard_path: /pun/sys/dashboard
 connector_status_poll_interval: 6000
+locale: es
+download_files_retention_period: 172800
+upload_files_retention_period: 172800
+ui_feedback_delay: 2000
 detached_controller_interval: 5
 detached_process_status_interval: 2000
-download_files_retention_period: 172800
-download_root: /var/loop/downloads
-files_app_path: /pun/sys/dashboard/files/custom
-locale: es
 max_download_file_size: 15000000000
 max_upload_file_size: 2000000000
-metadata_root: /var/loop/metadata
-ood_dashboard_path: /pun/sys/dashboard
-ruby_binary: /usr/local/bin/ruby
-ui_feedback_delay: 2000
-upload_files_retention_period: 172800
 zenodo_enabled: true
+guide_url: https://example.com/loop
 ```
 
 ### `.env` File example
 
 ```bash
+OOD_VERSION=/opt/ood/VERSION
+OOD_LOOP_METADATA_ROOT=/var/loop/metadata
+OOD_LOOP_DOWNLOAD_ROOT=/var/loop/downloads
+OOD_LOOP_RUBY_BINARY=/usr/local/bin/ruby
+OOD_LOOP_FILES_APP_PATH=/pun/sys/dashboard/files/custom
+OOD_LOOP_OOD_DASHBOARD_PATH=/pun/sys/dashboard
 OOD_LOOP_CONNECTOR_STATUS_POLL_INTERVAL=6000
+OOD_LOOP_LOCALE=es
+OOD_LOOP_DOWNLOAD_FILES_RETENTION_PERIOD=172800
+OOD_LOOP_UPLOAD_FILES_RETENTION_PERIOD=172800
+OOD_LOOP_UI_FEEDBACK_DELAY=2000
 OOD_LOOP_DETACHED_CONTROLLER_INTERVAL=5
 OOD_LOOP_DETACHED_PROCESS_STATUS_INTERVAL=2000
-OOD_LOOP_DOWNLOAD_FILES_RETENTION_PERIOD=172800
-OOD_LOOP_DOWNLOAD_ROOT=/var/loop/downloads
-OOD_LOOP_FILES_APP_PATH=/pun/sys/dashboard/files/custom
-OOD_LOOP_LOCALE=es
 OOD_LOOP_MAX_DOWNLOAD_FILE_SIZE=15000000000
 OOD_LOOP_MAX_UPLOAD_FILE_SIZE=2000000000
-OOD_LOOP_METADATA_ROOT=/var/loop/metadata
-OOD_LOOP_OOD_DASHBOARD_PATH=/pun/sys/dashboard
-OOD_LOOP_RUBY_BINARY=/usr/local/bin/ruby
-OOD_LOOP_UI_FEEDBACK_DELAY=2000
-OOD_LOOP_UPLOAD_FILES_RETENTION_PERIOD=172800
 OOD_LOOP_ZENODO_ENABLED=true
+OOD_LOOP_GUIDE_URL=https://example.com/loop
 LOOP_CONFIG_DIRECTORY=/etc/loop/config
 OOD_LOOP_COMMAND_SERVER_FILE=/var/loop/metadata/command.server.sock
 OOD_LOOP_DETACHED_PROCESS_FILE=/var/loop/metadata/detached.process.lock


### PR DESCRIPTION
## Summary
- add missing configuration fields from `ConfigurationSingleton`
- reorder property docs to match application code
- fix typo and close code block properly
- update sample YAML and `.env` config sections

## Testing
- `../scripts/loop_test.sh`

------
https://chatgpt.com/codex/tasks/task_e_687e96722fc083218ef5f3bb11bb1168