### PR TITLE
Dynamic text for add-files buttons

### DIFF
--- a/application/app/helpers/application_helper.rb
+++ b/application/app/helpers/application_helper.rb
@@ -61,4 +61,19 @@ module ApplicationHelper
     # Return a span with the appropriate class and status text
     content_tag(:span, t("status.#{status}"), class: "badge file-status #{color}", title: title, role: 'status', "aria-label" => aria_label)
   end
+
+  # Returns the label and optional title for add-files buttons.
+  # The +translation_prefix+ should correspond to the i18n scope containing
+  # button_add_files_active_project_text, button_add_files_new_project_text,
+  # and button_add_files_new_project_title keys.
+  def add_files_button_info(translation_prefix)
+    if Current.settings.user_settings.active_project.present?
+      [t("#{translation_prefix}.button_add_files_active_project_text"), nil]
+    else
+      [
+        t("#{translation_prefix}.button_add_files_new_project_text"),
+        t("#{translation_prefix}.button_add_files_new_project_title")
+      ]
+    end
+  end
 end

--- a/application/app/helpers/application_helper.rb
+++ b/application/app/helpers/application_helper.rb
@@ -62,18 +62,4 @@ module ApplicationHelper
     content_tag(:span, t("status.#{status}"), class: "badge file-status #{color}", title: title, role: 'status', "aria-label" => aria_label)
   end
 
-  # Returns the label and optional title for add-files buttons.
-  # The +translation_prefix+ should correspond to the i18n scope containing
-  # button_add_files_active_project_text, button_add_files_new_project_text,
-  # and button_add_files_new_project_title keys.
-  def add_files_button_info(translation_prefix)
-    if Current.settings.user_settings.active_project.present?
-      [t("#{translation_prefix}.button_add_files_active_project_text"), nil]
-    else
-      [
-        t("#{translation_prefix}.button_add_files_new_project_text"),
-        t("#{translation_prefix}.button_add_files_new_project_title")
-      ]
-    end
-  end
 end

--- a/application/app/views/dataverse/datasets/_dataset_files.html.erb
+++ b/application/app/views/dataverse/datasets/_dataset_files.html.erb
@@ -42,7 +42,12 @@
         </table>
       </div>
       <div class="text-center">
-        <%= submit_tag t('dataverse.datasets.dataset_files.button_add_files_text'), class: "btn btn-primary", id: "submit_button", data: {"utils--checkbox-target" => "submitButton"} %>
+        <% add_files_label = if Current.settings.user_settings.active_project.present?
+                             t('dataverse.datasets.dataset_files.button_add_files_active_project_text')
+                           else
+                             t('dataverse.datasets.dataset_files.button_add_files_new_project_text')
+                           end %>
+        <%= submit_tag add_files_label, class: "btn btn-primary", id: "submit_button", data: {"utils--checkbox-target" => "submitButton"} %>
       </div>
     <% end %>
   <% else %>

--- a/application/app/views/dataverse/datasets/_dataset_files.html.erb
+++ b/application/app/views/dataverse/datasets/_dataset_files.html.erb
@@ -42,9 +42,17 @@
         </table>
       </div>
       <div class="text-center">
-        <% add_files_label, add_files_title = add_files_button_info('dataverse.datasets.dataset_files') %>
-        <%= submit_tag add_files_label, class: "btn btn-primary", id: "submit_button",
-                     data: {"utils--checkbox-target" => "submitButton"}, title: add_files_title %>
+        <% if Current.settings.user_settings.active_project.present? %>
+          <%= submit_tag t('dataverse.datasets.dataset_files.button_add_files_active_project_text'),
+                         class: "btn btn-primary", id: "submit_button",
+                         data: {"utils--checkbox-target" => "submitButton"},
+                         title: t('dataverse.datasets.dataset_files.button_add_files_active_project_title') %>
+        <% else %>
+          <%= submit_tag t('dataverse.datasets.dataset_files.button_add_files_new_project_text'),
+                         class: "btn btn-primary", id: "submit_button",
+                         data: {"utils--checkbox-target" => "submitButton"},
+                         title: t('dataverse.datasets.dataset_files.button_add_files_new_project_title') %>
+        <% end %>
       </div>
     <% end %>
   <% else %>

--- a/application/app/views/dataverse/datasets/_dataset_files.html.erb
+++ b/application/app/views/dataverse/datasets/_dataset_files.html.erb
@@ -42,12 +42,14 @@
         </table>
       </div>
       <div class="text-center">
-        <% add_files_label = if Current.settings.user_settings.active_project.present?
-                             t('dataverse.datasets.dataset_files.button_add_files_active_project_text')
-                           else
-                             t('dataverse.datasets.dataset_files.button_add_files_new_project_text')
-                           end %>
-        <%= submit_tag add_files_label, class: "btn btn-primary", id: "submit_button", data: {"utils--checkbox-target" => "submitButton"} %>
+        <% add_files_label, add_files_title = if Current.settings.user_settings.active_project.present?
+                                               [t('dataverse.datasets.dataset_files.button_add_files_active_project_text'), nil]
+                                             else
+                                               [t('dataverse.datasets.dataset_files.button_add_files_new_project_text'),
+                                                t('dataverse.datasets.dataset_files.button_add_files_new_project_title')]
+                                             end %>
+        <%= submit_tag add_files_label, class: "btn btn-primary", id: "submit_button",
+                     data: {"utils--checkbox-target" => "submitButton"}, title: add_files_title %>
       </div>
     <% end %>
   <% else %>

--- a/application/app/views/dataverse/datasets/_dataset_files.html.erb
+++ b/application/app/views/dataverse/datasets/_dataset_files.html.erb
@@ -42,12 +42,7 @@
         </table>
       </div>
       <div class="text-center">
-        <% add_files_label, add_files_title = if Current.settings.user_settings.active_project.present?
-                                               [t('dataverse.datasets.dataset_files.button_add_files_active_project_text'), nil]
-                                             else
-                                               [t('dataverse.datasets.dataset_files.button_add_files_new_project_text'),
-                                                t('dataverse.datasets.dataset_files.button_add_files_new_project_title')]
-                                             end %>
+        <% add_files_label, add_files_title = add_files_button_info('dataverse.datasets.dataset_files') %>
         <%= submit_tag add_files_label, class: "btn btn-primary", id: "submit_button",
                      data: {"utils--checkbox-target" => "submitButton"}, title: add_files_title %>
       </div>

--- a/application/app/views/zenodo/records/_record_files.html.erb
+++ b/application/app/views/zenodo/records/_record_files.html.erb
@@ -42,9 +42,17 @@
         </table>
       </div>
       <div class="text-center">
-        <% add_files_label, add_files_title = add_files_button_info('zenodo.records.record_files') %>
-        <%= submit_tag add_files_label, class: 'btn btn-primary',
-                     data: {'utils--checkbox-target' => 'submitButton'}, title: add_files_title %>
+        <% if Current.settings.user_settings.active_project.present? %>
+          <%= submit_tag t('zenodo.records.record_files.button_add_files_active_project_text'),
+                         class: 'btn btn-primary',
+                         data: {'utils--checkbox-target' => 'submitButton'},
+                         title: t('zenodo.records.record_files.button_add_files_active_project_title') %>
+        <% else %>
+          <%= submit_tag t('zenodo.records.record_files.button_add_files_new_project_text'),
+                         class: 'btn btn-primary',
+                         data: {'utils--checkbox-target' => 'submitButton'},
+                         title: t('zenodo.records.record_files.button_add_files_new_project_title') %>
+        <% end %>
       </div>
     <% end %>
   <% else %>

--- a/application/app/views/zenodo/records/_record_files.html.erb
+++ b/application/app/views/zenodo/records/_record_files.html.erb
@@ -42,12 +42,14 @@
         </table>
       </div>
       <div class="text-center">
-        <% add_files_label = if Current.settings.user_settings.active_project.present?
-                             t('.button_add_files_active_project_text')
-                           else
-                             t('.button_add_files_new_project_text')
-                           end %>
-        <%= submit_tag add_files_label, class: 'btn btn-primary', data: {'utils--checkbox-target' => 'submitButton'} %>
+        <% add_files_label, add_files_title = if Current.settings.user_settings.active_project.present?
+                                               [t('.button_add_files_active_project_text'), nil]
+                                             else
+                                               [t('.button_add_files_new_project_text'),
+                                                t('.button_add_files_new_project_title')]
+                                             end %>
+        <%= submit_tag add_files_label, class: 'btn btn-primary',
+                     data: {'utils--checkbox-target' => 'submitButton'}, title: add_files_title %>
       </div>
     <% end %>
   <% else %>

--- a/application/app/views/zenodo/records/_record_files.html.erb
+++ b/application/app/views/zenodo/records/_record_files.html.erb
@@ -42,12 +42,7 @@
         </table>
       </div>
       <div class="text-center">
-        <% add_files_label, add_files_title = if Current.settings.user_settings.active_project.present?
-                                               [t('.button_add_files_active_project_text'), nil]
-                                             else
-                                               [t('.button_add_files_new_project_text'),
-                                                t('.button_add_files_new_project_title')]
-                                             end %>
+        <% add_files_label, add_files_title = add_files_button_info('zenodo.records.record_files') %>
         <%= submit_tag add_files_label, class: 'btn btn-primary',
                      data: {'utils--checkbox-target' => 'submitButton'}, title: add_files_title %>
       </div>

--- a/application/app/views/zenodo/records/_record_files.html.erb
+++ b/application/app/views/zenodo/records/_record_files.html.erb
@@ -42,7 +42,12 @@
         </table>
       </div>
       <div class="text-center">
-        <%= submit_tag t('.button_add_files_text'), class: 'btn btn-primary', data: {'utils--checkbox-target' => 'submitButton'} %>
+        <% add_files_label = if Current.settings.user_settings.active_project.present?
+                             t('.button_add_files_active_project_text')
+                           else
+                             t('.button_add_files_new_project_text')
+                           end %>
+        <%= submit_tag add_files_label, class: 'btn btn-primary', data: {'utils--checkbox-target' => 'submitButton'} %>
       </div>
     <% end %>
   <% else %>

--- a/application/config/locales/connectors/dataverse/en.yml
+++ b/application/config/locales/connectors/dataverse/en.yml
@@ -133,6 +133,7 @@ en:
       dataset_files:
         button_add_files_active_project_text: "Add Files to Active Project"
         button_add_files_new_project_text: "Add Files to New Project"
+        button_add_files_new_project_title: "No active project. This action will create a new project and add the selected files into the newly created project"
         col_file_name_text: "File name"
         col_published_text: "Published"
         col_size_text: "Size"

--- a/application/config/locales/connectors/dataverse/en.yml
+++ b/application/config/locales/connectors/dataverse/en.yml
@@ -132,6 +132,7 @@ en:
         breadcrumb_home_title: "Home"
       dataset_files:
         button_add_files_active_project_text: "Add Files to Active Project"
+        button_add_files_active_project_title: "This action will add the selected files into the Active Project"
         button_add_files_new_project_text: "Add Files to New Project"
         button_add_files_new_project_title: "No active project. This action will create a new project and add the selected files into the newly created project"
         col_file_name_text: "File name"

--- a/application/config/locales/connectors/dataverse/en.yml
+++ b/application/config/locales/connectors/dataverse/en.yml
@@ -131,7 +131,8 @@ en:
         breadcrumb_home_text: "Home"
         breadcrumb_home_title: "Home"
       dataset_files:
-        button_add_files_text: "Add Files to Active Project"
+        button_add_files_active_project_text: "Add Files to Active Project"
+        button_add_files_new_project_text: "Add Files to New Project"
         col_file_name_text: "File name"
         col_published_text: "Published"
         col_size_text: "Size"

--- a/application/config/locales/connectors/zenodo/en.yml
+++ b/application/config/locales/connectors/zenodo/en.yml
@@ -55,7 +55,8 @@ en:
         field_publication_date_text: "Publication date:"
         field_files_text: "Files:"
       record_files:
-        button_add_files_text: "Add Files to Active Project"
+        button_add_files_active_project_text: "Add Files to Active Project"
+        button_add_files_new_project_text: "Add Files to New Project"
         col_file_name_text: "File name"
         col_size_text: "Size"
         checkbox_select_all_label: "Select all files"

--- a/application/config/locales/connectors/zenodo/en.yml
+++ b/application/config/locales/connectors/zenodo/en.yml
@@ -57,6 +57,7 @@ en:
       record_files:
         button_add_files_active_project_text: "Add Files to Active Project"
         button_add_files_new_project_text: "Add Files to New Project"
+        button_add_files_new_project_title: "No active project. This action will create a new project and add the selected files into the newly created project"
         col_file_name_text: "File name"
         col_size_text: "Size"
         checkbox_select_all_label: "Select all files"

--- a/application/config/locales/connectors/zenodo/en.yml
+++ b/application/config/locales/connectors/zenodo/en.yml
@@ -56,6 +56,7 @@ en:
         field_files_text: "Files:"
       record_files:
         button_add_files_active_project_text: "Add Files to Active Project"
+        button_add_files_active_project_title: "This action will add the selected files into the Active Project"
         button_add_files_new_project_text: "Add Files to New Project"
         button_add_files_new_project_title: "No active project. This action will create a new project and add the selected files into the newly created project"
         col_file_name_text: "File name"

--- a/application/test/controllers/dataverse/datasets_controller_test.rb
+++ b/application/test/controllers/dataverse/datasets_controller_test.rb
@@ -209,7 +209,8 @@ class Dataverse::DatasetsControllerTest < ActionDispatch::IntegrationTest
     get view_dataverse_dataset_url(@new_id, "doi:10.5072/FK2/GCN7US")
     assert_response :success
     label = I18n.t('dataverse.datasets.dataset_files.button_add_files_new_project_text')
-    assert_select "input[type=submit][value='#{label}']", 1
+    title = I18n.t('dataverse.datasets.dataset_files.button_add_files_new_project_title')
+    assert_select "input[type=submit][value='#{label}'][title='#{title}']", 1
   end
 
   test "should display the dataset incomplete with no data" do

--- a/application/test/controllers/dataverse/datasets_controller_test.rb
+++ b/application/test/controllers/dataverse/datasets_controller_test.rb
@@ -194,7 +194,8 @@ class Dataverse::DatasetsControllerTest < ActionDispatch::IntegrationTest
     get view_dataverse_dataset_url(@new_id, "doi:10.5072/FK2/GCN7US")
     assert_response :success
     label = I18n.t('dataverse.datasets.dataset_files.button_add_files_active_project_text')
-    assert_select "input[type=submit][value='#{label}']", 1
+    title = I18n.t('dataverse.datasets.dataset_files.button_add_files_active_project_title')
+    assert_select "input[type=submit][value='#{label}'][title='#{title}']", 1
   end
 
   test "dataset view shows new project button text when no active project" do

--- a/application/test/controllers/dataverse/datasets_controller_test.rb
+++ b/application/test/controllers/dataverse/datasets_controller_test.rb
@@ -182,6 +182,36 @@ class Dataverse::DatasetsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[type=checkbox][name='file_ids[]']", 2
   end
 
+  test "dataset view shows active project button text when project active" do
+    dataset = Dataverse::DatasetVersionResponse.new(dataset_valid_json)
+    Dataverse::DatasetService.any_instance.stubs(:find_dataset_version_by_persistent_id).returns(dataset)
+    files_page = Dataverse::DatasetFilesResponse.new(files_valid_json)
+    Dataverse::DatasetService.any_instance.stubs(:search_dataset_files_by_persistent_id).returns(files_page)
+    user_settings_mock = mock("UserSettings")
+    user_settings_mock.stubs(:user_settings).returns(OpenStruct.new(active_project: "proj"))
+    Current.stubs(:settings).returns(user_settings_mock)
+
+    get view_dataverse_dataset_url(@new_id, "doi:10.5072/FK2/GCN7US")
+    assert_response :success
+    label = I18n.t('dataverse.datasets.dataset_files.button_add_files_active_project_text')
+    assert_select "input[type=submit][value='#{label}']", 1
+  end
+
+  test "dataset view shows new project button text when no active project" do
+    dataset = Dataverse::DatasetVersionResponse.new(dataset_valid_json)
+    Dataverse::DatasetService.any_instance.stubs(:find_dataset_version_by_persistent_id).returns(dataset)
+    files_page = Dataverse::DatasetFilesResponse.new(files_valid_json)
+    Dataverse::DatasetService.any_instance.stubs(:search_dataset_files_by_persistent_id).returns(files_page)
+    user_settings_mock = mock("UserSettings")
+    user_settings_mock.stubs(:user_settings).returns(OpenStruct.new(active_project: nil))
+    Current.stubs(:settings).returns(user_settings_mock)
+
+    get view_dataverse_dataset_url(@new_id, "doi:10.5072/FK2/GCN7US")
+    assert_response :success
+    label = I18n.t('dataverse.datasets.dataset_files.button_add_files_new_project_text')
+    assert_select "input[type=submit][value='#{label}']", 1
+  end
+
   test "should display the dataset incomplete with no data" do
     dataset = Dataverse::DatasetVersionResponse.new(dataset_incomplete_json_no_data)
     Dataverse::DatasetService.any_instance.stubs(:find_dataset_version_by_persistent_id).returns(dataset)

--- a/application/test/controllers/zenodo/records_controller_test.rb
+++ b/application/test/controllers/zenodo/records_controller_test.rb
@@ -38,7 +38,8 @@ class Zenodo::RecordsControllerTest < ActionDispatch::IntegrationTest
     get view_zenodo_record_path('1')
     assert_response :success
     label = I18n.t('zenodo.records.record_files.button_add_files_new_project_text')
-    assert_select "input[type=submit][value='#{label}']", 1
+    title = I18n.t('zenodo.records.record_files.button_add_files_new_project_title')
+    assert_select "input[type=submit][value='#{label}'][title='#{title}']", 1
   end
 
   test 'show redirects when not found' do

--- a/application/test/controllers/zenodo/records_controller_test.rb
+++ b/application/test/controllers/zenodo/records_controller_test.rb
@@ -15,6 +15,32 @@ class Zenodo::RecordsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'record view shows active project button text when project active' do
+    @record = OpenStruct.new(title: 'rec', files: [OpenStruct.new(id: 1, filename: 'f.txt', filesize: 10)])
+    Zenodo::RecordService.any_instance.stubs(:find_record).returns(@record)
+    user_settings_mock = mock('UserSettings')
+    user_settings_mock.stubs(:user_settings).returns(OpenStruct.new(active_project: 'proj'))
+    Current.stubs(:settings).returns(user_settings_mock)
+
+    get view_zenodo_record_path('1')
+    assert_response :success
+    label = I18n.t('zenodo.records.record_files.button_add_files_active_project_text')
+    assert_select "input[type=submit][value='#{label}']", 1
+  end
+
+  test 'record view shows new project button text when no active project' do
+    @record = OpenStruct.new(title: 'rec', files: [OpenStruct.new(id: 1, filename: 'f.txt', filesize: 10)])
+    Zenodo::RecordService.any_instance.stubs(:find_record).returns(@record)
+    user_settings_mock = mock('UserSettings')
+    user_settings_mock.stubs(:user_settings).returns(OpenStruct.new(active_project: nil))
+    Current.stubs(:settings).returns(user_settings_mock)
+
+    get view_zenodo_record_path('1')
+    assert_response :success
+    label = I18n.t('zenodo.records.record_files.button_add_files_new_project_text')
+    assert_select "input[type=submit][value='#{label}']", 1
+  end
+
   test 'show redirects when not found' do
     Zenodo::RecordService.any_instance.stubs(:find_record).returns(nil)
     get view_zenodo_record_path('1')

--- a/application/test/controllers/zenodo/records_controller_test.rb
+++ b/application/test/controllers/zenodo/records_controller_test.rb
@@ -25,7 +25,8 @@ class Zenodo::RecordsControllerTest < ActionDispatch::IntegrationTest
     get view_zenodo_record_path('1')
     assert_response :success
     label = I18n.t('zenodo.records.record_files.button_add_files_active_project_text')
-    assert_select "input[type=submit][value='#{label}']", 1
+    title = I18n.t('zenodo.records.record_files.button_add_files_active_project_title')
+    assert_select "input[type=submit][value='#{label}'][title='#{title}']", 1
   end
 
   test 'record view shows new project button text when no active project' do


### PR DESCRIPTION
## Summary
- show different text for download submit buttons based on active project
- add translations for new and active project labels
- add tests for button text in dataset and record views

## Testing
- `make test` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6881143f0c48832b83954f1d912ff4eb