### PR TITLE
Add DataverseUrl builder factory methods

### DIFF
--- a/application/app/services/dataverse/concerns/dataverse_url_builder.rb
+++ b/application/app/services/dataverse/concerns/dataverse_url_builder.rb
@@ -1,20 +1,35 @@
 module Dataverse::Concerns::DataverseUrlBuilder
   extend ActiveSupport::Concern
 
-  def collection_url
-    raise 'collection_id is missing' unless collection_id
+  # Module-level helpers to build URLs from components
+  def collection_url(dataverse_url, id)
     FluentUrl.new(dataverse_url)
       .add_path('dataverse')
-      .add_path(collection_id)
+      .add_path(id)
       .to_s
   end
+  module_function :collection_url
 
-  def dataset_url(version: nil)
-    raise 'dataset_id (DOI) is missing' unless dataset_id
+  def dataset_url(dataverse_url, id, version: nil)
     url = FluentUrl.new(dataverse_url)
               .add_path('dataset.xhtml')
-              .add_param('persistentId', dataset_id)
+              .add_param('persistentId', id)
     url.add_param('version', version) if version
     url.to_s
+  end
+  module_function :dataset_url
+
+  included do
+    def collection_url(id = nil)
+      id ||= respond_to?(:collection_id) ? collection_id : nil
+      raise 'collection_id is missing' unless id
+      Dataverse::Concerns::DataverseUrlBuilder.collection_url(dataverse_url, id)
+    end
+
+    def dataset_url(id = nil, version: nil)
+      id ||= respond_to?(:dataset_id) ? dataset_id : nil
+      raise 'dataset_id (DOI) is missing' unless id
+      Dataverse::Concerns::DataverseUrlBuilder.dataset_url(dataverse_url, id, version: version)
+    end
   end
 end

--- a/application/app/services/dataverse/dataverse_url.rb
+++ b/application/app/services/dataverse/dataverse_url.rb
@@ -8,6 +8,23 @@ module Dataverse
 
     attr_reader :type, :collection_id, :dataset_id, :file_id, :version
 
+    def self.dataverse_from_parts(domain, scheme: 'https', port: nil)
+      base = build_base_url(domain, scheme: scheme, port: port)
+      parse(base)
+    end
+
+    def self.collection_from_parts(domain, collection_id, scheme: 'https', port: nil)
+      base = build_base_url(domain, scheme: scheme, port: port)
+      url = Dataverse::Concerns::DataverseUrlBuilder.collection_url(base, collection_id)
+      parse(url)
+    end
+
+    def self.dataset_from_parts(domain, dataset_id, scheme: 'https', port: nil)
+      base = build_base_url(domain, scheme: scheme, port: port)
+      url = Dataverse::Concerns::DataverseUrlBuilder.dataset_url(base, dataset_id)
+      parse(url)
+    end
+
     def self.parse(url)
       base = UrlParser.parse(url)
       return nil unless base
@@ -16,6 +33,13 @@ module Dataverse
     end
 
     private_class_method :new
+
+    def self.build_base_url(domain, scheme: 'https', port: nil)
+      url = "#{scheme}://#{domain}"
+      url += ":#{port}" if port
+      url
+    end
+    private_class_method :build_base_url
 
     TYPES.each do |t|
       define_method("#{t}?") { type == t }

--- a/application/test/services/dataverse/dataverse_url_test.rb
+++ b/application/test/services/dataverse/dataverse_url_test.rb
@@ -77,6 +77,44 @@ class Dataverse::DataverseUrlTest < ActiveSupport::TestCase
     assert_nil dataverse_url.version
   end
 
+  test 'should build collection url from parts' do
+    dataverse_url = Dataverse::DataverseUrl.collection_from_parts('demo.dataverse.org', 'mycollection', scheme: 'http')
+
+    assert dataverse_url.collection?
+    assert_equal 'mycollection', dataverse_url.collection_id
+    assert_equal 'http', dataverse_url.scheme
+  end
+
+  test 'should build dataverse url from parts' do
+    dataverse_url = Dataverse::DataverseUrl.dataverse_from_parts('demo.dataverse.org', port: 8443)
+
+    assert dataverse_url.dataverse?
+    assert_equal 'https', dataverse_url.scheme
+    assert_equal 8443, dataverse_url.port
+  end
+
+  test 'should build dataset url from parts' do
+    dataverse_url = Dataverse::DataverseUrl.dataset_from_parts('demo.dataverse.org', 'doi:10.1234/XYZ', port: 8443)
+
+    assert dataverse_url.dataset?
+    assert_equal 'doi:10.1234/XYZ', dataverse_url.dataset_id
+    assert_equal 8443, dataverse_url.port
+  end
+
+  test 'should build collection_url with passed id' do
+    dataverse_url = Dataverse::DataverseUrl.parse('https://demo.dataverse.org/')
+
+    url = dataverse_url.collection_url('mycollection')
+    assert_equal 'https://demo.dataverse.org/dataverse/mycollection', url
+  end
+
+  test 'should build dataset_url with passed id' do
+    dataverse_url = Dataverse::DataverseUrl.parse('https://demo.dataverse.org/')
+
+    url = dataverse_url.dataset_url('doi:10.1234/XYZ')
+    assert_equal 'https://demo.dataverse.org/dataset.xhtml?persistentId=doi%3A10.1234%2FXYZ', url
+  end
+
   test 'should parse file URL with persistentId and fileId' do
     url = 'https://demo.dataverse.org/file.xhtml?persistentId=doi:10.1234/XYZ/ABC&fileId=123&version=1.0'
     dataverse_url = Dataverse::DataverseUrl.parse(url)


### PR DESCRIPTION
## Summary
- add module-level builder functions for Dataverse URLs and reuse them in DataverseUrl
- add dataverse_from_parts helper to build dataverse URLs from components
- allow passing ids directly to `collection_url` and `dataset_url`
- update tests for new behavior

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_687acd6187208321806efaaa20ea36bf