### PR TITLE
Add tracing mechanism

### DIFF
--- a/application/app/controllers/traces_controller.rb
+++ b/application/app/controllers/traces_controller.rb
@@ -1,0 +1,53 @@
+class TracesController < ApplicationController
+  def index
+    entity_type = params[:entity_type]
+    ids = extract_ids(entity_type, params)
+    traces = Trace.all(entity_type, ids)
+    render json: traces.map(&:to_h)
+  rescue ArgumentError => e
+    render json: { error: e.message }, status: :bad_request
+  end
+
+  def show
+    entity_type = params[:entity_type]
+    ids = extract_ids(entity_type, params)
+    trace = Trace.find(entity_type, ids, params[:id])
+    if trace
+      render json: trace.to_h
+    else
+      head :not_found
+    end
+  rescue ArgumentError => e
+    render json: { error: e.message }, status: :bad_request
+  end
+
+  def create
+    entity_type = params[:entity_type]
+    ids = extract_ids(entity_type, params)
+    trace = Trace.add(entity_type: entity_type, entity_ids: ids, message: params[:message])
+    if trace
+      render json: trace.to_h, status: :created
+    else
+      render json: { error: 'invalid trace' }, status: :unprocessable_entity
+    end
+  rescue ArgumentError => e
+    render json: { error: e.message }, status: :bad_request
+  end
+
+  private
+
+  def extract_ids(entity_type, params)
+    case entity_type
+    when 'project'
+      [params[:project_id] || params[:id]]
+    when 'download_file'
+      [params[:project_id], params[:download_file_id] || params[:file_id]]
+    when 'upload_bundle'
+      [params[:project_id], params[:upload_bundle_id] || params[:id]]
+    when 'upload_file'
+      [params[:project_id], params[:upload_bundle_id], params[:upload_file_id] || params[:id]]
+    else
+      raise ArgumentError, 'Invalid entity_type'
+    end.compact
+  end
+end

--- a/application/app/models/trace.rb
+++ b/application/app/models/trace.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+class Trace < ApplicationDiskRecord
+  include ActiveModel::Model
+  include DateTimeCommon
+
+  ATTRIBUTES = %w[id entity_type entity_ids creation_date message].freeze
+
+  attr_accessor(*ATTRIBUTES)
+
+  validates_presence_of :id, :entity_type, :creation_date, :message
+
+  def self.add(entity_type:, entity_ids:, message:)
+    trace = new(
+      id: generate_id,
+      entity_type: entity_type.to_s,
+      entity_ids: Array(entity_ids),
+      creation_date: DateTimeCommon.now,
+      message: message
+    )
+    trace.save
+    trace
+  end
+
+  def self.record(entity, message)
+    entity_type, ids = parse_entity(entity)
+    add(entity_type: entity_type, entity_ids: ids, message: message)
+  end
+
+  def save
+    return false unless valid?
+
+    store_to_file(self.class.filename(entity_type, entity_ids, id))
+  end
+
+  def self.all(entity_type = nil, entity_ids = [])
+    directory = directory(entity_type, entity_ids)
+    return [] unless Dir.exist?(directory)
+
+    Dir.glob(File.join(directory, '*.yml'))
+       .sort_by { |f| -File.ctime(f).to_f }
+       .map { |f| load_from_file(f) }
+       .compact
+  end
+
+  def self.find(entity_type, entity_ids, trace_id)
+    file = filename(entity_type, entity_ids, trace_id)
+    return nil unless File.exist?(file)
+
+    load_from_file(file)
+  end
+
+  def self.directory(entity_type, ids)
+    File.join(metadata_root_directory, 'traces', entity_type.to_s, *Array(ids))
+  end
+
+  def self.filename(entity_type, ids, trace_id)
+    File.join(directory(entity_type, ids), "#{trace_id}.yml")
+  end
+
+  def self.parse_entity(entity)
+    case entity
+    when Project
+      ['project', [entity.id]]
+    when DownloadFile
+      ['download_file', [entity.project_id, entity.id]]
+    when UploadBundle
+      ['upload_bundle', [entity.project_id, entity.id]]
+    when UploadFile
+      ['upload_file', [entity.project_id, entity.upload_bundle_id, entity.id]]
+    else
+      raise ArgumentError, "Unknown entity type: #{entity.class}"
+    end
+  end
+  private_class_method :parse_entity
+end

--- a/application/config/routes.rb
+++ b/application/config/routes.rb
@@ -64,6 +64,9 @@ Rails.application.routes.draw do
   get "/view/zenodo" => "zenodo/landing_page#index", as: :view_zenodo_landing
   get "/view/zenodo/records/:id" => "zenodo/records#show", as: :view_zenodo_record, format: false
 
+  # TRACE ROUTES
+  resources :traces, only: [:index, :show, :create]
+
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/application/test/models/trace_test.rb
+++ b/application/test/models/trace_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class TraceTest < ActiveSupport::TestCase
+  def setup
+    @tmp_dir = Dir.mktmpdir
+    Trace.stubs(:metadata_root_directory).returns(@tmp_dir)
+  end
+
+  def teardown
+    FileUtils.remove_entry(@tmp_dir)
+  end
+
+  test 'add and find trace for project' do
+    trace = Trace.add(entity_type: 'project', entity_ids: ['p1'], message: 'created')
+    file = Trace.filename('project', ['p1'], trace.id)
+    assert File.exist?(file)
+
+    loaded = Trace.find('project', ['p1'], trace.id)
+    assert_equal trace.message, loaded.message
+    assert_equal trace.entity_type, loaded.entity_type
+  end
+
+  test 'list traces for project ordered by creation date' do
+    Trace.add(entity_type: 'project', entity_ids: ['p1'], message: 'a')
+    sleep 1
+    Trace.add(entity_type: 'project', entity_ids: ['p1'], message: 'b')
+
+    traces = Trace.all('project', ['p1'])
+    assert_equal 2, traces.size
+    assert_equal 'b', traces.first.message
+  end
+end

--- a/application/test/models/trace_test.rb
+++ b/application/test/models/trace_test.rb
@@ -4,6 +4,7 @@ class TraceTest < ActiveSupport::TestCase
   def setup
     @tmp_dir = Dir.mktmpdir
     Trace.stubs(:metadata_root_directory).returns(@tmp_dir)
+    Project.stubs(:metadata_root_directory).returns(@tmp_dir)
   end
 
   def teardown
@@ -12,7 +13,7 @@ class TraceTest < ActiveSupport::TestCase
 
   test 'add and find trace for project' do
     trace = Trace.add(entity_type: 'project', entity_ids: ['p1'], message: 'created')
-    file = Trace.filename('project', ['p1'], trace.id)
+    file = Trace.project_file('p1')
     assert File.exist?(file)
 
     loaded = Trace.find('project', ['p1'], trace.id)


### PR DESCRIPTION
## Summary
- implement Trace model with YAML storage
- add TracesController and routes
- allow adding and querying traces grouped by entity
- test trace model

## Testing
- `bundle install`
- `RAILS_ENV=test bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68889f387e688321af325ae1abf1f85b