### PR TITLE
feat: Update status widgets with more metrics

### DIFF
--- a/application/app/helpers/projects_helper.rb
+++ b/application/app/helpers/projects_helper.rb
@@ -12,7 +12,8 @@ module ProjectsHelper
   end
 
   def project_progress_data(file_status_count, title = '')
-    pending = file_status_count.pending.to_i + file_status_count.downloading.to_i
+    pending = file_status_count.pending.to_i
+    in_progress = file_status_count.downloading.to_i + file_status_count.uploading.to_i
     completed = file_status_count.success.to_i
     cancelled = file_status_count.cancelled.to_i
     error = file_status_count.error.to_i
@@ -20,6 +21,7 @@ module ProjectsHelper
       id: SecureRandom.uuid,
       title: title,
       pending: pending,
+      in_progress: in_progress,
       completed: completed,
       cancelled: cancelled,
       error: error,

--- a/application/app/views/shared/_file_summary_widget.html.erb
+++ b/application/app/views/shared/_file_summary_widget.html.erb
@@ -1,6 +1,7 @@
 <%# Ensure values have defaults %>
 <% completed ||= 0 %>
 <% pending ||= 0 %>
+<% in_progress ||= 0 %>
 <% cancelled ||= 0 %>
 <% error ||= 0 %>
 <% total ||= 0 %>
@@ -55,6 +56,7 @@
 
     <div class="d-flex flex-wrap align-items-center gap-2 file-summary">
       <span class="badge badge-project-pending"><%= t('.badge_pending_text') %>: <%= pending %></span>
+      <span class="badge badge-project-progress"><%= t('.badge_in_progress_text') %>: <%= in_progress %></span>
       <span class="badge badge-project-completed"><%= t('.badge_completed_text') %>: <%= completed %></span>
       <span class="badge badge-project-cancel"><%= t('.badge_cancelled_text') %>: <%= cancelled %></span>
       <span class="badge badge-project-error"><%= t('.badge_error_text') %>: <%= error %></span>

--- a/application/app/views/shared/_process_summary_widget.html.erb
+++ b/application/app/views/shared/_process_summary_widget.html.erb
@@ -1,9 +1,9 @@
 <%# Ensure values have defaults %>
-<% completed = summary.success + summary.cancelled + summary.error %>
+<% total_completed = summary.success + summary.cancelled + summary.error %>
 <% total = summary.total %>
 
 <%
-  percent = total == 0 ? 0 : (completed * 100 / total.to_f).round(1).to_i
+  percent = total == 0 ? 0 : (total_completed * 100 / total.to_f).round(1).to_i
   offset = (114 - (114 * percent.to_f / 100)).round(1).to_i
 %>
 
@@ -45,8 +45,10 @@
   <div class="d-flex flex-column justify-content-start">
     <div class="d-flex flex-wrap align-items-center gap-2 file-summary">
       <span class="badge badge-project-pending">Pending: <%= summary.pending %></span>
-      <span class="badge badge-project-progress">In Progress: <%= summary.downloading %></span>
-      <span class="badge badge-project-completed">Completed: <%= completed %></span>
+      <span class="badge badge-project-progress">In Progress: <%= summary.downloading + summary.uploading %></span>
+      <span class="badge badge-project-completed">Completed: <%= summary.success %></span>
+      <span class="badge badge-project-cancel">Cancelled: <%= summary.cancelled %></span>
+      <span class="badge badge-project-error">Error: <%= summary.error %></span>
       <span class="badge badge-project-total">Total: <%= summary.total %></span>
     </div>
   </div>

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -215,6 +215,7 @@ en:
       badge_completed_text: "Completed"
       badge_error_text: "Error"
       badge_pending_text: "Pending"
+      badge_in_progress_text: "In Progress"
       badge_total_text: "Total"
     files_process_header:
       download:

--- a/application/test/helpers/projects_helper_test.rb
+++ b/application/test/helpers/projects_helper_test.rb
@@ -12,14 +12,15 @@ class ProjectsHelperTest < ActionView::TestCase
   end
 
   test 'project_progress_data compiles counts' do
-    summary = OpenStruct.new(pending: 1, downloading: 2, success: 3, cancelled: 1, error: 0, total: 7)
+    summary = OpenStruct.new(pending: 1, downloading: 2, uploading: 1, success: 3, cancelled: 1, error: 0, total: 8)
     data = project_progress_data(summary, 't')
     assert_equal 't', data[:title]
-    assert_equal 3, data[:pending]
+    assert_equal 1, data[:pending]
+    assert_equal 3, data[:in_progress]
     assert_equal 3, data[:completed]
     assert_equal 1, data[:cancelled]
     assert_equal 0, data[:error]
-    assert_equal 7, data[:total]
+    assert_equal 8, data[:total]
     assert_not_nil data[:id]
   end
 end

--- a/docs/guide/content/user_guide/downloading_files.md
+++ b/docs/guide/content/user_guide/downloading_files.md
@@ -48,6 +48,7 @@ At the top of the Downloads tab, a summary panel displays key information about 
 - **Status Summary Counters**  
   A visual breakdown of all download requests associated with this project:
     - **Pending** – Files waiting to be processed.
+    - **In Progress** – Files currently being downloaded.
     - **Completed** – Successfully downloaded files.
     - **Cancelled** – Downloads that were manually cancelled before completion.
     - **Error** – Downloads that failed due to network, a repository issue or a failed checksum verification.
@@ -97,6 +98,8 @@ At the top of the global **Downloads** page, a summary panel displays the curren
     - **Pending** – Files queued for download but not yet started.
     - **In Progress** – Files currently being downloaded.
     - **Completed** – Successfully downloaded files.
+    - **Cancelled** – Downloads that were manually cancelled before completion.
+    - **Error** – Downloads that failed while in progress.
     - **Total** – The total number of files in the current job.
 
 #### Files Metadata

--- a/docs/guide/content/user_guide/uploading_files.md
+++ b/docs/guide/content/user_guide/uploading_files.md
@@ -131,6 +131,8 @@ At the top of the global Uploads page, a summary panel displays the current syst
     - **Pending** – Files queued for upload.
     - **In Progress** – Files currently being uploaded.
     - **Completed** – Files uploaded successfully.
+    - **Cancelled** – Uploads that were manually cancelled before completion.
+    - **Error** – Uploads that encountered a problem during transfer.
     - **Total** – Total number of files in the current batch.
 
 #### Files Metadata


### PR DESCRIPTION
## Summary
- add `badge_in_progress_text` translation
- extend `project_progress_data` helper with in_progress metric
- display new badge in `_file_summary_widget`
- show cancelled and error badges in `_process_summary_widget`
- update helper tests for new metrics

## Testing
- `bundle install --quiet` *(fails: Net::HTTPClientException 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688a16894464832b8493908eda8ba3d9