### PR TITLE
Add project folder editor modal

### DIFF
--- a/application/app/controllers/projects_controller.rb
+++ b/application/app/controllers/projects_controller.rb
@@ -1,4 +1,5 @@
 class ProjectsController < ApplicationController
+  include LoggingCommon
 
   def index
     @projects = Project.all
@@ -19,7 +20,7 @@ class ProjectsController < ApplicationController
       flash[:alert] = t(".project_create_error", errors: project.errors.full_messages)
     end
 
-    redirect_to projects_path
+    redirect_back fallback_location: projects_path
   end
 
   def update
@@ -41,11 +42,13 @@ class ProjectsController < ApplicationController
         format.html { redirect_back fallback_location: projects_path, notice: t(".project_updated_successfully", project_name: project.name) }
         format.json { render json: project.to_json, status: :ok }
       end
+      log_info('Project updated successfully', { project_id: project_id })
     else
       respond_to do |format|
         format.html { redirect_back fallback_location: projects_path, alert: t(".project_update_error", errors: project.errors.full_messages) }
         format.json { render json: { error: project.errors.full_messages }, status: :unprocessable_entity }
       end
+      log_error('Unable to update project', { project_id: project_id, errors: project.errors.full_messages })
     end
   end
 
@@ -70,6 +73,6 @@ class ProjectsController < ApplicationController
     end
 
     project.destroy
-    redirect_to projects_path, notice: t(".project_deleted_successfully", project_name: project.name)
+    redirect_back fallback_location: projects_path, notice: t(".project_deleted_successfully", project_name: project.name)
   end
 end

--- a/application/app/controllers/projects_controller.rb
+++ b/application/app/controllers/projects_controller.rb
@@ -28,7 +28,7 @@ class ProjectsController < ApplicationController
     if project.nil?
       error_message = t(".project_not_found", id: project_id)
       respond_to do |format|
-        format.html { redirect_to projects_path, alert: error_message }
+        format.html { redirect_back fallback_location: projects_path, alert: error_message }
         format.json { render json: { error: error_message }, status: :not_found }
       end
       return
@@ -38,12 +38,12 @@ class ProjectsController < ApplicationController
 
     if project.update(update_params)
       respond_to do |format|
-        format.html { redirect_to projects_path, notice: t(".project_updated_successfully", project_name: project.name) }
+        format.html { redirect_back fallback_location: projects_path, notice: t(".project_updated_successfully", project_name: project.name) }
         format.json { render json: project.to_json, status: :ok }
       end
     else
       respond_to do |format|
-        format.html { redirect_to projects_path, alert: t(".project_update_error", errors: project.errors.full_messages) }
+        format.html { redirect_back fallback_location: projects_path, alert: t(".project_update_error", errors: project.errors.full_messages) }
         format.json { render json: { error: project.errors.full_messages }, status: :unprocessable_entity }
       end
     end

--- a/application/app/helpers/projects_helper.rb
+++ b/application/app/helpers/projects_helper.rb
@@ -43,4 +43,8 @@ module ProjectsHelper
     }
   end
 
+  def project_download_dir_browser_id(project)
+    "download-dir-browser-#{project.id}"
+  end
+
 end

--- a/application/app/javascript/controllers/file_browser_controller.js
+++ b/application/app/javascript/controllers/file_browser_controller.js
@@ -16,8 +16,23 @@ export default class extends Controller {
             close: `file-browser:close:${this.element.id}`,
             dragStart: `file-browser:dragstart:${this.element.id}`,
             dragEnd: `file-browser:dragend:${this.element.id}`,
-            fileSelected: `file-browser:file-selected:${this.element.id}`
+            fileSelected: `file-browser:file-selected:${this.element.id}`,
+            pathChange: `file-browser:path-change:${this.element.id}`
         }
+
+        // Notify listeners of the initial path
+        if (this.hasPathInputTarget) {
+            this.dispatchPathChange(this.pathInputTarget.value)
+        }
+    }
+
+    dispatchPathChange(path) {
+        const pathChangeEvent = new CustomEvent(this.eventNames.pathChange, {
+            detail: { path: path },
+            bubbles: true
+        })
+
+        document.dispatchEvent(pathChangeEvent)
     }
 
     navigate() {
@@ -33,6 +48,7 @@ export default class extends Controller {
             })
             .then(html => {
                 this.element.innerHTML = html
+                this.dispatchPathChange(newPath)
             })
             .catch(error => {
                 showFlash('error', error.error, this.element.id)

--- a/application/app/javascript/controllers/project_download_dir_controller.js
+++ b/application/app/javascript/controllers/project_download_dir_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static targets = ["modal", "browser", "path", "form"]
+
+    connect() {
+        this.modalInstance = bootstrap.Modal.getOrCreateInstance(this.modalTarget)
+        this.boundUpdate = this.updatePathFromEvent.bind(this)
+        if (this.hasBrowserTarget) {
+            const id = this.browserTarget.id
+            document.addEventListener(`file-browser:path-change:${id}`, this.boundUpdate)
+        }
+    }
+
+    disconnect() {
+        if (this.hasBrowserTarget) {
+            const id = this.browserTarget.id
+            document.removeEventListener(`file-browser:path-change:${id}`, this.boundUpdate)
+        }
+    }
+
+    open(event) {
+        if (event) event.preventDefault()
+        this.modalInstance.show()
+    }
+
+    updatePathFromEvent(event) {
+        const path = event.detail.path
+        if (this.hasPathTarget) this.pathTarget.value = path
+    }
+
+    select(event) {
+        if (event) event.preventDefault()
+        // get current path from browser
+        const input = this.browserTarget.querySelector('[data-file-browser-target="pathInput"]')
+        if (input) this.pathTarget.value = input.value
+        this.formTarget.requestSubmit()
+    }
+}

--- a/application/app/javascript/controllers/project_download_dir_controller.js
+++ b/application/app/javascript/controllers/project_download_dir_controller.js
@@ -1,21 +1,20 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-    static targets = ["modal", "browser", "path", "form"]
+    static targets = ["modal", "path", "form"]
+    static values = { browserId: String }
 
     connect() {
         this.modalInstance = bootstrap.Modal.getOrCreateInstance(this.modalTarget)
         this.boundUpdate = this.updatePathFromEvent.bind(this)
-        if (this.hasBrowserTarget) {
-            const id = this.browserTarget.id
-            document.addEventListener(`file-browser:path-change:${id}`, this.boundUpdate)
+        if (this.browserIdValue) {
+            document.addEventListener(`file-browser:path-change:${this.browserIdValue}`, this.boundUpdate)
         }
     }
 
     disconnect() {
-        if (this.hasBrowserTarget) {
-            const id = this.browserTarget.id
-            document.removeEventListener(`file-browser:path-change:${id}`, this.boundUpdate)
+        if (this.browserIdValue) {
+            document.removeEventListener(`file-browser:path-change:${this.browserIdValue}`, this.boundUpdate)
         }
     }
 
@@ -31,9 +30,11 @@ export default class extends Controller {
 
     select(event) {
         if (event) event.preventDefault()
-        // get current path from browser
-        const input = this.browserTarget.querySelector('[data-file-browser-target="pathInput"]')
-        if (input) this.pathTarget.value = input.value
+        const browser = document.getElementById(this.browserIdValue)
+        if (browser) {
+            const input = browser.querySelector('[data-file-browser-target="pathInput"]')
+            if (input) this.pathTarget.value = input.value
+        }
         this.formTarget.requestSubmit()
     }
 }

--- a/application/app/javascript/controllers/project_download_dir_controller.js
+++ b/application/app/javascript/controllers/project_download_dir_controller.js
@@ -30,11 +30,7 @@ export default class extends Controller {
 
     select(event) {
         if (event) event.preventDefault()
-        const browser = document.getElementById(this.browserIdValue)
-        if (browser) {
-            const input = browser.querySelector('[data-file-browser-target="pathInput"]')
-            if (input) this.pathTarget.value = input.value
-        }
+        // pathTarget stays updated via the file-browser:path-change event
         this.formTarget.requestSubmit()
     }
 }

--- a/application/app/process/script_launcher.rb
+++ b/application/app/process/script_launcher.rb
@@ -11,6 +11,7 @@ class ScriptLauncher
 
   def launch_script
     if pending_files?
+      log_info("Launching Detached Process Script...")
       start_process_from_script(LAUNCH_SCRIPT, 'launch_detached_process.log')
     else
       log_info("No pending files - skipping")

--- a/application/app/views/download_status/_actions.html.erb
+++ b/application/app/views/download_status/_actions.html.erb
@@ -1,4 +1,4 @@
-<div class="text-end bg-white z-index-999" aria-label="<%= t('.actions_bar_title_a11y_label') %>">
+<div class="text-end bg-white" aria-label="<%= t('.actions_bar_title_a11y_label') %>">
   <%= link_to(files_app_url(Configuration.download_root), class: 'btn btn-outline-dark btn-sm', target: '_blank',
               title: t('.button_downloads_directory_title')) do %>
     <i class="bi bi-folder-fill" aria-hidden="true"></i><span class="ps-1"><%= t('.button_downloads_directory_title') %></span>
@@ -8,4 +8,4 @@
   <% end %>
 </div>
 
-<hr>
+<hr class="mt-2">

--- a/application/app/views/layouts/_repo_resolver_bar.html.erb
+++ b/application/app/views/layouts/_repo_resolver_bar.html.erb
@@ -23,27 +23,22 @@
     <% end %>
 
     <!-- Resolver Form (right aligned) -->
-    <form data-controller="submit-button" action="<%= repo_resolver_path %>" method="post" class="d-flex align-items-center gap-3" style="flex: 1 1 auto;">
-      <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+    <%= render layout: "shared/button_to", locals: {
+      url: repo_resolver_path,
+      form_class: 'flex-grow-1 d-flex align-items-center gap-2',
+      class: 'btn-primary-dark',
+      icon_html: image_tag('icon.png', alt: t('.button_submit_icon_alt'), class: 'icon-class d-block', style: 'height: 1rem; width: auto; object-fit: contain;' ),
+      label: t('.button_submit_text')
+    } do %>
 
       <input type="text"
              name="repo_url"
              id="<%= input_id %>"
-             placeholder="<%= t('.input_repo_url_placeholder') %>"
-             aria-label="<%= t('.input_repo_url_label') %>"
-             class="form-control"
-             style="flex: 1 1 auto;">
+             placeholder="<%= t('layouts.repo_resolver_bar.input_repo_url_placeholder') %>"
+             aria-label="<%= t('layouts.repo_resolver_bar.input_repo_url_label') %>"
+             class="d-inline form-control me-3">
 
-      <button class="btn btn-primary-dark ps-2 pe-3 d-inline-flex align-items-center" type="submit"
-              data-submit-button-target="button"
-              data-action="click->submit-button#click">
-        <span data-submit-button-target="spinner" aria-live="polite"
-              class="spinner-border spinner-border-sm me-1 d-none"
-              role="status" aria-hidden="true"></span>
-        <%= image_tag('icon.png', alt: t('.button_submit_icon_alt'), class: 'icon-class me-2') %>
-        <span data-submit-button-target="label"><%= t('.button_submit_text') %></span>
-      </button>
-    </form>
+    <% end %>
 
   </div>
 </div>

--- a/application/app/views/projects/index/_actions.html.erb
+++ b/application/app/views/projects/index/_actions.html.erb
@@ -1,4 +1,4 @@
-<div class="d-flex justify-content-between align-items-center mt-3" aria-label="<%= t('.actions_bar_title_a11y_label') %>">
+<div class="d-flex justify-content-between align-items-center" aria-label="<%= t('.actions_bar_title_a11y_label') %>">
   <div class="d-flex align-items-center gap-2">
     <h2 class="mb-0 me-2 fs-4 h5"><%= t('.actions_bar_title') %></h2>
   </div>

--- a/application/app/views/projects/show/_download_actions.html.erb
+++ b/application/app/views/projects/show/_download_actions.html.erb
@@ -1,5 +1,6 @@
 
 <% file_status = OpenStruct.new(project_progress_data(project.status_summary)) %>
+<% file_browser_id = project_download_dir_browser_id(project) %>
 <div class="card mb-3 shadow-sm rounded overflow-hidden">
   <div class="card-header d-flex justify-content-between align-items-center bg-light-darker">
     <div class="d-flex align-items-center gap-3">
@@ -11,6 +12,20 @@
         <i class="bi bi-folder-fill" aria-hidden="true"></i>
         <span class="visually-hidden"><%= t('.button_open_downloads_folder_title') %></span>
       </a>
+      <div data-controller="project-download-dir"
+           data-project-download-dir-browser-id-value="<%= file_browser_id %>">
+        <button type="button" class="btn btn-sm btn-outline-secondary"
+                data-controller="lazy-loader"
+                data-lazy-loader-container-id-value="<%= file_browser_id %>"
+                data-lazy-loader-url-value="<%= file_browser_path(path: project.download_dir) %>"
+                data-action="click->lazy-loader#load click->project-download-dir#open"
+                title="<%= t('.button_edit_download_dir_title') %>"
+                aria-label="<%= t('.button_edit_download_dir_label') %>">
+          <i class="bi bi-pencil-square" aria-hidden="true"></i>
+          <span class="visually-hidden"><%= t('.button_edit_download_dir_label') %></span>
+        </button>
+        <%= render partial: '/projects/show/edit_download_dir_modal', locals: { project: project, file_browser_id: file_browser_id } %>
+      </div>
       <div class="d-flex flex-column">
         <h3 class="mb-0 h5"><%= t('.header_download_files_text') %></h3>
         <small class="text-muted"><%= project.download_dir %></small>

--- a/application/app/views/projects/show/_download_actions.html.erb
+++ b/application/app/views/projects/show/_download_actions.html.erb
@@ -4,6 +4,9 @@
 <div class="card mb-3 shadow-sm rounded overflow-hidden">
   <div class="card-header d-flex justify-content-between align-items-center bg-light-darker">
     <div class="d-flex align-items-center gap-3">
+
+      <div class="d-flex align-items-center gap-2">
+      <!-- open workspace folder -->
       <a href="<%= files_app_url(project.download_dir) %>"
          target="_blank"
          class="btn btn-sm btn-outline-secondary"
@@ -12,6 +15,7 @@
         <i class="bi bi-folder-fill" aria-hidden="true"></i>
         <span class="visually-hidden"><%= t('.button_open_downloads_folder_title') %></span>
       </a>
+      <!-- edit workspace folder -->
       <div data-controller="project-download-dir"
            data-project-download-dir-browser-id-value="<%= file_browser_id %>">
         <button type="button" class="btn btn-sm btn-outline-secondary"
@@ -26,6 +30,8 @@
         </button>
         <%= render partial: '/projects/show/edit_download_dir_modal', locals: { project: project, file_browser_id: file_browser_id } %>
       </div>
+      </div>
+      <!-- download metadata -->
       <div class="d-flex flex-column">
         <h3 class="mb-0 h5"><%= t('.header_download_files_text') %></h3>
         <small class="text-muted"><%= project.download_dir %></small>

--- a/application/app/views/projects/show/_edit_download_dir_modal.html.erb
+++ b/application/app/views/projects/show/_edit_download_dir_modal.html.erb
@@ -1,3 +1,4 @@
+<% file_browser_id ||= project_download_dir_browser_id(project) %>
 <div id="edit-download-dir-modal"
      class="modal fade"
      tabindex="-1"
@@ -17,11 +18,7 @@
           <div class="mb-3">
             <input type="text" readonly name="download_dir" class="form-control" value="<%= project.download_dir %>" data-project-download-dir-target="path" aria-label="<%= t('.field_path_label') %>">
           </div>
-          <div data-project-download-dir-target="browser" id="download-dir-browser-<%= project.id %>"
-               data-controller="file-browser"
-               data-file-browser-url-value="<%= file_browser_path(path: project.download_dir) %>"
-               style="height: 500px;" class="mb-3 overflow-auto border rounded">
-          </div>
+          <%= render partial: '/file_browser/file_browser', locals: { id: file_browser_id, class: 'mb-3 d-none' } %>
           <div class="d-flex justify-content-end gap-2 mt-4">
             <button type="submit" class="btn btn-primary" data-action="project-download-dir#select">
               <i class="bi bi-check-lg me-1" aria-hidden="true"></i><%= t('.button_select_text') %>

--- a/application/app/views/projects/show/_edit_download_dir_modal.html.erb
+++ b/application/app/views/projects/show/_edit_download_dir_modal.html.erb
@@ -1,0 +1,35 @@
+<div id="edit-download-dir-modal"
+     class="modal fade"
+     tabindex="-1"
+     aria-modal="true"
+     role="dialog"
+     data-project-download-dir-target="modal">
+  <div class="modal-dialog modal-xl">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title"><%= t('.header_title') %></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<%= t('layouts.modal.button_close_label') %>"></button>
+      </div>
+      <div class="modal-body">
+        <form data-project-download-dir-target="form" action="<%= project_path(id: project.id) %>" method="post">
+          <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+          <%= hidden_field_tag :_method, 'put' %>
+          <div class="mb-3">
+            <input type="text" readonly name="download_dir" class="form-control" value="<%= project.download_dir %>" data-project-download-dir-target="path" aria-label="<%= t('.field_path_label') %>">
+          </div>
+          <div data-project-download-dir-target="browser" id="download-dir-browser-<%= project.id %>"
+               data-controller="file-browser"
+               data-file-browser-url-value="<%= file_browser_path(path: project.download_dir) %>"
+               style="height: 500px;" class="mb-3 overflow-auto border rounded">
+          </div>
+          <div class="d-flex justify-content-end gap-2 mt-4">
+            <button type="submit" class="btn btn-primary" data-action="project-download-dir#select">
+              <i class="bi bi-check-lg me-1" aria-hidden="true"></i><%= t('.button_select_text') %>
+            </button>
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><%= t('.button_cancel_text') %></button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/application/app/views/projects/show/_edit_download_dir_modal.html.erb
+++ b/application/app/views/projects/show/_edit_download_dir_modal.html.erb
@@ -8,7 +8,7 @@
   <div class="modal-dialog modal-xl">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"><%= t('.header_title') %></h5>
+        <h5 class="modal-title"><%= t('.header_title', project_name: project.name) %></h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<%= t('layouts.modal.button_close_label') %>"></button>
       </div>
       <div class="modal-body">
@@ -16,7 +16,7 @@
           <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
           <%= hidden_field_tag :_method, 'put' %>
           <div class="mb-3">
-            <input type="text" readonly name="download_dir" class="form-control" value="<%= project.download_dir %>" data-project-download-dir-target="path" aria-label="<%= t('.field_path_label') %>">
+            <input type="text" readonly name="download_dir" class="form-control bg-light text-muted" value="<%= project.download_dir %>" data-project-download-dir-target="path" aria-label="<%= t('.field_path_label') %>">
           </div>
           <%= render partial: '/file_browser/file_browser', locals: { id: file_browser_id, class: 'mb-3 d-none' } %>
           <div class="d-flex justify-content-end gap-2 mt-4">

--- a/application/app/views/projects/show/_project_actions.html.erb
+++ b/application/app/views/projects/show/_project_actions.html.erb
@@ -15,6 +15,17 @@
       <span class="visually-hidden"><%= t('.button_open_project_folder_label') %></span>
     </a>
 
+    <div data-controller="project-download-dir">
+      <button type="button" class="btn btn-sm btn-outline-secondary"
+              data-action="project-download-dir#open"
+              title="<%= t('.button_edit_download_dir_title') %>"
+              aria-label="<%= t('.button_edit_download_dir_label') %>">
+        <i class="bi bi-pencil-square" aria-hidden="true"></i>
+        <span class="visually-hidden"><%= t('.button_edit_download_dir_label') %></span>
+      </button>
+      <%= render partial: '/projects/show/edit_download_dir_modal', locals: { project: project } %>
+    </div>
+
     <%= render partial: '/shared/file_row_date', locals: { date: project.creation_date, title: t('.field_creation_date_title'), classes: 'me-1' } %>
 
     <h2 class="mb-0 fs-4 h5" data-project-name-target="name display"><%= project.name %></h2>

--- a/application/app/views/projects/show/_project_actions.html.erb
+++ b/application/app/views/projects/show/_project_actions.html.erb
@@ -15,15 +15,20 @@
       <span class="visually-hidden"><%= t('.button_open_project_folder_label') %></span>
     </a>
 
-    <div data-controller="project-download-dir">
+    <% file_browser_id = project_download_dir_browser_id(project) %>
+    <div data-controller="project-download-dir"
+         data-project-download-dir-browser-id-value="<%= file_browser_id %>">
       <button type="button" class="btn btn-sm btn-outline-secondary"
-              data-action="project-download-dir#open"
+              data-controller="lazy-loader"
+              data-lazy-loader-container-id-value="<%= file_browser_id %>"
+              data-lazy-loader-url-value="<%= file_browser_path(path: project.download_dir) %>"
+              data-action="click->lazy-loader#load click->project-download-dir#open"
               title="<%= t('.button_edit_download_dir_title') %>"
               aria-label="<%= t('.button_edit_download_dir_label') %>">
         <i class="bi bi-pencil-square" aria-hidden="true"></i>
         <span class="visually-hidden"><%= t('.button_edit_download_dir_label') %></span>
       </button>
-      <%= render partial: '/projects/show/edit_download_dir_modal', locals: { project: project } %>
+      <%= render partial: '/projects/show/edit_download_dir_modal', locals: { project: project, file_browser_id: file_browser_id } %>
     </div>
 
     <%= render partial: '/shared/file_row_date', locals: { date: project.creation_date, title: t('.field_creation_date_title'), classes: 'me-1' } %>

--- a/application/app/views/projects/show/_project_actions.html.erb
+++ b/application/app/views/projects/show/_project_actions.html.erb
@@ -1,4 +1,4 @@
-<div class="d-flex justify-content-between align-items-center mt-3 flex-wrap"
+<div class="d-flex justify-content-between align-items-center flex-wrap"
      data-controller="project-name"
      data-project-name-initial-name-value="<%= project.name %>"
      data-project-name-url-value="<%= project_path(id: project.id) %>"

--- a/application/app/views/projects/show/_project_actions.html.erb
+++ b/application/app/views/projects/show/_project_actions.html.erb
@@ -15,21 +15,6 @@
       <span class="visually-hidden"><%= t('.button_open_project_folder_label') %></span>
     </a>
 
-    <% file_browser_id = project_download_dir_browser_id(project) %>
-    <div data-controller="project-download-dir"
-         data-project-download-dir-browser-id-value="<%= file_browser_id %>">
-      <button type="button" class="btn btn-sm btn-outline-secondary"
-              data-controller="lazy-loader"
-              data-lazy-loader-container-id-value="<%= file_browser_id %>"
-              data-lazy-loader-url-value="<%= file_browser_path(path: project.download_dir) %>"
-              data-action="click->lazy-loader#load click->project-download-dir#open"
-              title="<%= t('.button_edit_download_dir_title') %>"
-              aria-label="<%= t('.button_edit_download_dir_label') %>">
-        <i class="bi bi-pencil-square" aria-hidden="true"></i>
-        <span class="visually-hidden"><%= t('.button_edit_download_dir_label') %></span>
-      </button>
-      <%= render partial: '/projects/show/edit_download_dir_modal', locals: { project: project, file_browser_id: file_browser_id } %>
-    </div>
 
     <%= render partial: '/shared/file_row_date', locals: { date: project.creation_date, title: t('.field_creation_date_title'), classes: 'me-1' } %>
 

--- a/application/app/views/shared/_button_to.html.erb
+++ b/application/app/views/shared/_button_to.html.erb
@@ -27,12 +27,15 @@
           class="spinner-border spinner-border-sm me-1 d-none"
           role="status" aria-hidden="true"></span>
 
-    <span data-submit-button-target="label">
-      <% if local_assigns[:icon] %>
+    <span data-submit-button-target="label" class="d-inline-flex align-items-center gap-2">
+    <% if local_assigns[:icon] %>
         <i class="<%= icon %>" aria-hidden="true"></i>
       <% end %>
+      <% if local_assigns[:icon_html] %>
+        <%= icon_html %>
+      <% end %>
       <% if local_assigns[:label] %>
-        <span class="ps-1"><%= label %></span>
+        <span><%= label %></span>
       <% end %>
     </span>
 

--- a/application/app/views/upload_status/_actions.html.erb
+++ b/application/app/views/upload_status/_actions.html.erb
@@ -1,7 +1,7 @@
-<div class="text-end bg-white z-index-999" aria-label="<%= t('.actions_bar_title_a11y_label') %>">
+<div class="text-end bg-white" aria-label="<%= t('.actions_bar_title_a11y_label') %>">
   <%= link_to(upload_status_path, class: 'btn btn-outline-dark btn-sm', role: 'button', title: t('.button_reload_title')) do %>
     <i class="bi bi-arrow-clockwise bold" aria-hidden="true"></i><span class="ps-1"><%= t('.button_reload_title') %></span>
   <% end %>
 </div>
 
-<hr>
+<hr class="mt-2">

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -118,11 +118,18 @@ en:
         button_open_project_folder_label: "Open Project workspace folder"
         button_open_project_folder_title: "Open Project workspace folder"
         button_open_project_metadata_title: "Open Project metadata folder"
+        button_edit_download_dir_title: "Change Project folder"
+        button_edit_download_dir_label: "Change folder"
         field_creation_date_title: "Creation date"
         modal_delete_confirmation_title: "Delete Project"
         modal_delete_confirmation_content: "This will remove the project from the app. Files on disk and in remote repositories will remain untouched."
       project_tabs:
         tab_download_files_text: "Download Files"
+      edit_download_dir_modal:
+        header_title: "Select Project Folder"
+        field_path_label: "Selected path"
+        button_select_text: "Select"
+        button_cancel_text: "Cancel"
       upload_actions:
         button_add_files_text: "Add Files"
         button_add_files_title: "Add Files"

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -93,6 +93,8 @@ en:
         header_download_files_text: "Downloads"
         button_add_files_text: "Add Files"
         button_add_files_title: "Add dataset to browse and select files"
+        button_edit_download_dir_title: "Change Project folder"
+        button_edit_download_dir_label: "Change folder"
       download_files:
         badge_repository_files_tooltip: "Repository Files"
         button_delete_file_title: "Delete File"

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -93,8 +93,8 @@ en:
         header_download_files_text: "Downloads"
         button_add_files_text: "Add Files"
         button_add_files_title: "Add dataset to browse and select files"
-        button_edit_download_dir_title: "Change Project folder"
-        button_edit_download_dir_label: "Change folder"
+        button_edit_download_dir_title: "Update project workspace folder"
+        button_edit_download_dir_label: "Update workspace folder"
       download_files:
         badge_repository_files_tooltip: "Repository Files"
         button_delete_file_title: "Delete File"
@@ -128,7 +128,7 @@ en:
       project_tabs:
         tab_download_files_text: "Download Files"
       edit_download_dir_modal:
-        header_title: "Select Project Folder"
+        header_title: "Select Workspace Folder for Project: %{project_name}"
         field_path_label: "Selected path"
         button_select_text: "Select"
         button_cancel_text: "Cancel"

--- a/application/test/helpers/projects_helper_test.rb
+++ b/application/test/helpers/projects_helper_test.rb
@@ -65,4 +65,9 @@ class ProjectsHelperTest < ActionView::TestCase
 
     assert_equal [project1, project2], result
   end
+
+  test 'project_download_dir_browser_id returns id string' do
+    project = OpenStruct.new(id: 42)
+    assert_equal 'download-dir-browser-42', project_download_dir_browser_id(project)
+  end
 end


### PR DESCRIPTION
## Summary
- notify listeners when file browser path changes
- add project download directory controller and modal
- expose folder change button in project actions
- translate new UI strings

## Testing
- `make test` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c902feeac83218c90e788ca34a661