### PR TITLE
Add safeguard for changing project download directory

### DIFF
--- a/application/app/services/common/file_utils.rb
+++ b/application/app/services/common/file_utils.rb
@@ -2,6 +2,7 @@
 
 module Common
   class FileUtils
+    include LoggingCommon
 
     def normalize_name(name)
       name.to_s.parameterize(separator: '_')
@@ -34,6 +35,23 @@ module Common
       download_file.filename = unique_filename(root_dir, download_file.filename)
       download_file.id = normalize_name(download_file.filename)
       download_file
+    end
+
+    def move_all(source_dir, destination_dir)
+      return if source_dir.to_s == destination_dir.to_s
+
+      return unless Dir.exist?(source_dir)
+
+      log_info('Move directory contents', { source: source_dir, destination: destination_dir })
+
+      begin
+        ::FileUtils.mkdir_p(destination_dir)
+        ::FileUtils.mv(Dir["#{source_dir}/*"], destination_dir)
+        ::FileUtils.rmdir(source_dir) if Dir.exist?(source_dir) && Dir.empty?(source_dir)
+      rescue => e
+        log_error('Move directory contents error', { source: source_dir, destination: destination_dir }, e)
+        raise
+      end
     end
 
     private

--- a/application/test/controllers/projects_controller_test.rb
+++ b/application/test/controllers/projects_controller_test.rb
@@ -83,9 +83,12 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update project via HTML with name and download_dir" do
+    new_dir = File.join(@tmp_dir, 'new_html_dir')
+    FileUtils.mkdir_p(new_dir)
+
     put project_url(id: @project.id), params: {
       name: "Updated Name",
-      download_dir: "/some/new/path"
+      download_dir: new_dir
     }
 
     assert_redirected_to projects_url
@@ -94,10 +97,13 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update project via JSON with name and download_dir" do
+    new_dir = File.join(@tmp_dir, 'new_json_dir')
+    FileUtils.mkdir_p(new_dir)
+
     put project_url(id: @project.id),
           params: {
             name: "Updated JSON Name",
-            download_dir: "/some/json/path"
+            download_dir: new_dir
           }.to_json,
           headers: {
             "Content-Type" => "application/json",
@@ -107,7 +113,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     json = JSON.parse(@response.body)
     assert_equal "Updated JSON Name", json["name"]
-    assert_equal "/some/json/path", json["download_dir"]
+    assert_equal new_dir, json["download_dir"]
   end
 
   test "should not update missing project via HTML" do

--- a/application/test/services/common/file_utils_test.rb
+++ b/application/test/services/common/file_utils_test.rb
@@ -101,4 +101,30 @@ class Common::FileUtilsTest < ActiveSupport::TestCase
     assert_equal 'my_report_1.txt', result.filename
     assert_equal 'my_report_1_txt', result.id
   end
+
+  test 'move_all moves contents and removes empty source' do
+    src = Dir.mktmpdir
+    dest = Dir.mktmpdir
+
+    File.write(File.join(src, 'file1'), 'a')
+    FileUtils.mkdir_p(File.join(src, 'sub'))
+    File.write(File.join(src, 'sub', 'file2'), 'b')
+
+    @utils.move_all(src, dest)
+
+    assert File.exist?(File.join(dest, 'file1'))
+    assert File.exist?(File.join(dest, 'sub', 'file2'))
+    refute Dir.exist?(src)
+
+    FileUtils.rm_rf(dest)
+  end
+
+  test 'move_all does nothing when source equals destination' do
+    dir = Dir.mktmpdir
+    File.write(File.join(dir, 'file'), 'a')
+    @utils.move_all(dir, dir)
+    assert File.exist?(File.join(dir, 'file'))
+    FileUtils.rm_rf(dir)
+  end
 end
+


### PR DESCRIPTION
## Summary
- prevent changing `download_dir` on a project while downloads are still pending or downloading
- ensure new `download_dir` path exists and is writable before saving
- move all files from one directory to another with `Common::FileUtils#move_all`
- fix controller specs to use real directories
- test new `move_all` helper
- add logging around `move_all` for debugging
- refactor download_dir validation into its own method and move directory after successful update
- rework `Project#update` to validate and move directories without instance vars

## Testing
- `bundle exec rake test` *(fails: could not find rails-7.2.2.1, sprockets-rails-3.5.2, importmap-rails-2.1.0, stimulus-rails-1.3.4, jbuilder-2.13.0, dotenv-rails-3.1.8, rubocop-rails-omakase-1.1.0, web-console-4.2.1, cssbundling-rails-1.4.3, actioncable-7.2.2.1, actionmailbox-7.2.2.1, actionmailer-7.2.2.1, actionpack-7.2.2.1, actiontext-7.2.2.1, actionview-7.2.2.1, activejob-7.2.2.1, activemodel-7.2.2.1, activerecord-7.2.2.1, activestorage-7.2.2.1, activesupport-7.2.2.1, railties-7.2.2.1, rubocop-1.75.2, rubocop-performance-1.25.0, rubocop-rails-2.31.0, rails-dom-testing-2.2.0, globalid-1.2.1, rubocop-ast-1.44.1, prism-1.4.0 in locally installed gems)*


------
https://chatgpt.com/codex/tasks/task_e_688d09f4f790832196a387e126085c33