### PR TITLE
Support Zenodo deposition explore

### DIFF
--- a/application/app/connectors/zenodo/actions/depositions.rb
+++ b/application/app/connectors/zenodo/actions/depositions.rb
@@ -1,0 +1,79 @@
+module Zenodo::Actions
+  class Depositions
+    include LoggingCommon
+
+    def initialize(deposition_id)
+      @deposition_id = deposition_id
+    end
+
+    def show(request_params)
+      repo_url = request_params[:repo_url]
+      repo_info = RepoRegistry.repo_db.get(repo_url.server_url)
+      api_key = repo_info&.metadata&.auth_key
+
+      unless api_key
+        return ConnectorResult.new(
+          message: { alert: I18n.t('zenodo.depositions.message_api_key_required') },
+          success: false
+        )
+      end
+
+      service = Zenodo::DepositionService.new(repo_url.server_url, api_key: api_key)
+      deposition = service.find_deposition(@deposition_id)
+      if deposition.nil?
+        return ConnectorResult.new(
+          message: { alert: I18n.t('zenodo.depositions.message_deposition_not_found', deposition_id: @deposition_id) },
+          success: false
+        )
+      end
+
+      ConnectorResult.new(
+        template: '/connectors/zenodo/records/show',
+        locals: {
+          record: deposition,
+          record_id: @deposition_id,
+          repo_url: repo_url
+        },
+        success: true
+      )
+    rescue Zenodo::ApiService::ApiKeyRequiredException
+      ConnectorResult.new(
+        message: { alert: I18n.t('zenodo.depositions.message_api_key_required') },
+        success: false
+      )
+    end
+
+    def create(request_params)
+      repo_url = request_params[:repo_url]
+      file_ids = request_params[:file_ids] || []
+      project_id = request_params[:project_id]
+
+      record_service = Zenodo::RecordService.new(repo_url.server_url)
+      record = record_service.find_record(@deposition_id)
+      return ConnectorResult.new(message: { alert: I18n.t('zenodo.records.message_record_not_found', record_id: @deposition_id) }, success: false) unless record
+
+      project = Project.find(project_id)
+      project_service = Zenodo::ProjectService.new(repo_url.server_url)
+      if project.nil?
+        project = project_service.initialize_project
+        unless project.save
+          errors = project.errors.full_messages.join(', ')
+          return ConnectorResult.new(message: { alert: I18n.t('zenodo.records.download.message_project_error', errors: errors) }, success: false)
+        end
+      end
+
+      download_files = project_service.initialize_download_files(project, record, file_ids)
+      download_files.each do |file|
+        unless file.valid?
+          errors = file.errors.full_messages.join(', ')
+          return ConnectorResult.new(message: { alert: I18n.t('zenodo.records.download.message_validation_file_error', filename: file.filename, errors: errors) }, success: false)
+        end
+      end
+      save_results = download_files.map(&:save)
+      if save_results.include?(false)
+        return ConnectorResult.new(message: { alert: I18n.t('zenodo.records.download.message_save_file_error') }, success: false)
+      end
+      ConnectorResult.new(message: { notice: I18n.t('zenodo.records.download.message_success', project_name: project.name) }, success: true)
+    end
+  end
+end

--- a/application/app/connectors/zenodo/display_repo_controller_resolver.rb
+++ b/application/app/connectors/zenodo/display_repo_controller_resolver.rb
@@ -14,6 +14,10 @@ module Zenodo
         server_domain = zenodo_url.domain
         object_type = 'records'
         object_id = zenodo_url.record_id
+      elsif zenodo_url&.deposition?
+        server_domain = zenodo_url.domain
+        object_type = 'depositions'
+        object_id = zenodo_url.deposition_id
       else
         server_domain =  Zenodo::ZenodoUrl::DEFAULT_SERVER
         object_type = 'actions'

--- a/application/app/connectors/zenodo/download_connector_processor.rb
+++ b/application/app/connectors/zenodo/download_connector_processor.rb
@@ -20,13 +20,18 @@ module Zenodo
       FileUtils.mkdir_p(File.dirname(download_location))
 
       connector_metadata.temp_location = temp_location
-      file.update({metadata: connector_metadata.to_h})
+      file.update({ metadata: connector_metadata.to_h })
+
+      repo_info = RepoRegistry.repo_db.get(connector_metadata.zenodo_url)
+      api_key = repo_info&.metadata&.auth_key
+      headers = {}
+      headers[Zenodo::ApiService::AUTH_HEADER] = "Bearer #{api_key}" if api_key.present?
 
       download_processor = Download::BasicHttpRubyDownloader.new(
         download_url,
         download_location,
         temp_location,
-        headers: {}
+        headers: headers,
       )
       download_processor.download do |_context|
         cancelled

--- a/application/app/connectors/zenodo/upload_connector_processor.rb
+++ b/application/app/connectors/zenodo/upload_connector_processor.rb
@@ -28,7 +28,7 @@ module Zenodo
       file.upload_bundle.update({ metadata: connector_metadata.to_h })
 
       # Step 3: Upload the file using raw S3-compatible POST
-      headers = { 'Authorization' => "Bearer #{connector_metadata.api_key.value}" }
+      headers = { Zenodo::ApiService::AUTH_HEADER => "Bearer #{connector_metadata.api_key.value}" }
       upload_processor = Zenodo::ZenodoBucketHttpUploader.new(upload_url, source_location, headers)
       upload_processor.upload do |context|
         @status_context = context
@@ -45,17 +45,17 @@ module Zenodo
         if file.id == request.body.file_id
           # CANCELLATION IS FOR THIS FILE
           @cancelled = true
-          return {message: 'cancellation requested'}
+          return { message: 'cancellation requested' }
         end
       end
 
       if request.command == 'upload.status'
         if file.id == request.body.file_id
-          return {message: 'upload in progress', status: @status_context}
+          return { message: 'upload in progress', status: @status_context }
         end
       end
 
-      return nil
+      return nil # rubocop:disable Style/RedundantReturn
     end
 
     private

--- a/application/app/models/zenodo/deposition_response.rb
+++ b/application/app/models/zenodo/deposition_response.rb
@@ -1,17 +1,38 @@
 # frozen_string_literal: true
 
+require 'addressable'
+
 module Zenodo
   class DepositionResponse
-    attr_reader :id, :title, :file_count, :bucket_url, :submitted, :raw
+    FileItem = Struct.new(:id, :filename, :filesize, :checksum, :download_link, :download_url, keyword_init: true)
+
+    attr_reader :id, :title, :description, :publication_date,
+                :files, :file_count, :bucket_url, :submitted, :raw
 
     def initialize(response_body)
       @raw = JSON.parse(response_body)
 
-      @id = @raw['id']
+      @id = @raw['id'].to_s
       @submitted = @raw['submitted']
       @bucket_url = @raw.dig('links', 'bucket')
       @title = @raw.dig('metadata', 'title') || 'Untitled'
-      @file_count = @raw['files']&.count || 0
+      @description = @raw.dig('metadata', 'description')
+      @publication_date = @raw.dig('metadata', 'publication_date')
+      @files = Array(@raw['files']).map do |f|
+        raw_url = f.dig('links', 'self')
+        encoded_url = encode_url_path(raw_url)
+
+        FileItem.new(
+          id: f['id'].to_s,
+          filename: f['key'],
+          filesize: f['size'],
+          checksum: f['checksum'],
+          download_link: raw_url,
+          download_url: encoded_url
+        )
+      end
+
+      @file_count = @files.count
     end
 
     def draft?
@@ -20,6 +41,14 @@ module Zenodo
 
     def to_s
       "deposition{id=#{id} files=#{file_count} draft=#{draft?}}"
+    end
+
+    private
+
+    def encode_url_path(url)
+      Addressable::URI.parse(url).normalize.to_s
+    rescue Addressable::URI::InvalidURIError => e
+      raise "Invalid URL from Zenodo: #{url.inspect} (#{e.message})"
     end
   end
 end

--- a/application/config/locales/connectors/zenodo/controllers/en.yml
+++ b/application/config/locales/connectors/zenodo/controllers/en.yml
@@ -12,7 +12,10 @@ en:
     landing_page:
       index:
         message_search_error: "Zenodo search error while searching: %{query}"
+    depositions:
+      message_deposition_not_found: "Deposition not found. Deposition id: %{deposition_id}"
+      message_api_key_required: "API key is required to access this deposition"
   connectors:
     zenodo:
       display_repo_controller:
-        message_url_not_supported: "Zenodo URL not supported: %{url}. Only record URLs are currently supported for exploring"
+        message_url_not_supported: "Zenodo URL not supported: %{url}. Only record and deposition URLs are currently supported for exploring"

--- a/application/test/connectors/zenodo/actions/depositions_test.rb
+++ b/application/test/connectors/zenodo/actions/depositions_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class Zenodo::Actions::DepositionsTest < ActiveSupport::TestCase
+  def setup
+    @action = Zenodo::Actions::Depositions.new('10')
+    @repo_url = OpenStruct.new(server_url: 'https://zenodo.org')
+  end
+
+  test 'show loads deposition using repo db api key' do
+    repo_info = OpenStruct.new(metadata: OpenStruct.new(auth_key: 'KEY'))
+    RepoRegistry.repo_db.stubs(:get).with('https://zenodo.org').returns(repo_info)
+
+    service = mock('service')
+    service.expects(:find_deposition).with('10').returns(:deposition)
+    Zenodo::DepositionService.expects(:new).with('https://zenodo.org', api_key: 'KEY').returns(service)
+
+    result = @action.show(repo_url: @repo_url)
+    assert result.success?
+  end
+
+  test 'show returns error when api key missing' do
+    repo_info = OpenStruct.new(metadata: OpenStruct.new(auth_key: nil))
+    RepoRegistry.repo_db.stubs(:get).with('https://zenodo.org').returns(repo_info)
+
+    result = @action.show(repo_url: @repo_url)
+    refute result.success?
+    assert_equal I18n.t('zenodo.depositions.message_api_key_required'), result.message[:alert]
+  end
+end

--- a/application/test/connectors/zenodo/display_repo_controller_resolver_test.rb
+++ b/application/test/connectors/zenodo/display_repo_controller_resolver_test.rb
@@ -12,6 +12,13 @@ class Zenodo::DisplayRepoControllerResolverTest < ActionDispatch::IntegrationTes
     assert result.success?
   end
 
+  test 'deposition url returns deposition path' do
+    url = 'https://zenodo.org/deposit/34'
+    result = @resolver.get_controller_url(url)
+    assert_equal '/explore/zenodo/zenodo.org/depositions/34', result.redirect_url
+    assert result.success?
+  end
+
   test 'zenodo root url returns landing path' do
     url = 'https://zenodo.org'
     result = @resolver.get_controller_url(url)

--- a/application/test/connectors/zenodo/download_connector_processor_test.rb
+++ b/application/test/connectors/zenodo/download_connector_processor_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Zenodo::DownloadConnectorProcessorTest < ActiveSupport::TestCase
@@ -7,7 +9,7 @@ class Zenodo::DownloadConnectorProcessorTest < ActiveSupport::TestCase
     @project = create_project
     @project.save
     @file = create_download_file(@project)
-    @file.metadata = { download_url: 'http://example.com/file.txt' }
+    @file.metadata = { zenodo_url: 'https://zenodo.org', download_url: 'https://zenodo.org/file.txt' }
     @file.stubs(:update)
     Project.stubs(:find).with(@project.id).returns(@project)
     @processor = Zenodo::DownloadConnectorProcessor.new(@file)
@@ -22,6 +24,7 @@ class Zenodo::DownloadConnectorProcessorTest < ActiveSupport::TestCase
 
   test 'cancelled download' do
     Download::BasicHttpRubyDownloader.any_instance.stubs(:download).yields(nil)
+    FileUtils.stubs(:mkdir_p)
     @processor.instance_variable_set(:@cancelled, true)
     result = @processor.download
     assert_equal FileStatus::CANCELLED, result.status
@@ -32,5 +35,23 @@ class Zenodo::DownloadConnectorProcessorTest < ActiveSupport::TestCase
     res = @processor.process(req)
     assert_equal true, @processor.cancelled
     assert_equal 'cancellation requested', res[:message]
+  end
+
+  test 'includes api key header when available' do
+    repo_info = OpenStruct.new(metadata: OpenStruct.new(auth_key: 'KEY'))
+    RepoRegistry.repo_db.stubs(:get).with('https://zenodo.org').returns(repo_info)
+    FileUtils.stubs(:mkdir_p)
+
+    download_location = @file.download_location
+    temp_location = "#{download_location}.part"
+    mock_downloader = mock('downloader')
+    Download::BasicHttpRubyDownloader
+      .expects(:new)
+      .with('https://zenodo.org/file.txt', download_location, temp_location,
+            headers: { Zenodo::ApiService::AUTH_HEADER => 'Bearer KEY' })
+      .returns(mock_downloader)
+    mock_downloader.stubs(:download).yields(nil)
+
+    @processor.download
   end
 end

--- a/application/test/connectors/zenodo/upload_connector_processor_test.rb
+++ b/application/test/connectors/zenodo/upload_connector_processor_test.rb
@@ -9,38 +9,49 @@ class Zenodo::UploadConnectorProcessorTest < ActiveSupport::TestCase
     @project = create_project
     @bundle = create_upload_bundle(@project)
     @file = create_upload_file(@project, @bundle)
+    @file.stubs(:file_location).returns('/tmp/file.txt')
+    @file.stubs(:filename).returns('file.txt')
     @processor = Zenodo::UploadConnectorProcessor.new(@file)
   end
 
   test 'upload returns success when upload completes' do
-    @bundle.metadata = {bucket_url: 'https://bucket', api_key: OpenStruct.new(value: 'KEY')}
+    @bundle.metadata = { bucket_url: 'https://bucket', api_key: OpenStruct.new(value: 'KEY') }
     @processor = Zenodo::UploadConnectorProcessor.new(@file)
 
-    Zenodo::ZenodoBucketHttpUploader.any_instance.stubs(:upload).yields({total:1, uploaded:1})
+    file_name = 'file.txt'
+    upload_url = FluentUrl.new('https://bucket').add_path(file_name).to_s
+
+    uploader = mock
+    uploader.expects(:upload).yields({ total: 1, uploaded: 1 })
+    Zenodo::ZenodoBucketHttpUploader.expects(:new).with(
+      upload_url,
+      '/tmp/file.txt',
+      { Zenodo::ApiService::AUTH_HEADER => 'Bearer KEY' },
+    ).returns(uploader)
 
     result = @processor.upload
     assert_equal FileStatus::SUCCESS, result.status
   end
 
   test 'upload returns error when bucket_url missing' do
-    @bundle.metadata = {bucket_url: nil, api_key: OpenStruct.new(value: 'KEY')}
+    @bundle.metadata = { bucket_url: nil, api_key: OpenStruct.new(value: 'KEY') }
     result = @processor.upload
     assert_equal FileStatus::ERROR, result.status
     assert_match 'Missing bucket URL', result.message
   end
 
   test 'process handles cancel and status' do
-    @bundle.metadata = {bucket_url: 'https://bucket', api_key: OpenStruct.new(value: 'KEY')}
+    @bundle.metadata = { bucket_url: 'https://bucket', api_key: OpenStruct.new(value: 'KEY') }
     @processor = Zenodo::UploadConnectorProcessor.new(@file)
 
-    Zenodo::ZenodoBucketHttpUploader.any_instance.stubs(:upload).yields({total:1, uploaded:1})
+    Zenodo::ZenodoBucketHttpUploader.any_instance.stubs(:upload).yields({ total: 1, uploaded: 1 })
 
     @processor.upload
-    request = Command::Request.new(command: 'upload.status', body: {file_id: @file.id})
+    request = Command::Request.new(command: 'upload.status', body: { file_id: @file.id })
     status = @processor.process(request)
-    assert_equal({message: 'upload in progress', status: {total:1, uploaded:1}}, status)
+    assert_equal({ message: 'upload in progress', status: { total: 1, uploaded: 1 } }, status)
 
-    cancel_req = Command::Request.new(command: 'upload.cancel', body: {file_id: @file.id})
+    cancel_req = Command::Request.new(command: 'upload.cancel', body: { file_id: @file.id })
     cancel_result = @processor.process(cancel_req)
     assert_equal true, @processor.cancelled
     assert_equal 'cancellation requested', cancel_result[:message]

--- a/application/test/fixtures/zenodo/deposition_response.json
+++ b/application/test/fixtures/zenodo/deposition_response.json
@@ -2,8 +2,18 @@
   "id": 1,
   "submitted": false,
   "links": {"bucket": "https://zenodo.org/api/files/123"},
-  "metadata": {"title": "My Deposition"},
+  "metadata": {
+    "title": "My Deposition",
+    "description": "Deposition description",
+    "publication_date": "2024-01-01"
+  },
   "files": [
-    {"id": "10", "key": "file.txt", "size": 1234, "links": {"self": "https://zenodo.org/api/files/123/file.txt"}}
+    {
+      "id": "10",
+      "key": "file.txt",
+      "size": 1234,
+      "checksum": "md5:abc",
+      "links": {"self": "https://zenodo.org/api/files/123/file.txt"}
+    }
   ]
 }

--- a/application/test/models/zenodo/deposition_response_test.rb
+++ b/application/test/models/zenodo/deposition_response_test.rb
@@ -10,10 +10,20 @@ class Zenodo::DepositionResponseTest < ActiveSupport::TestCase
   end
 
   test 'parses values' do
-    assert_equal 1, @resp.id
+    assert_equal '1', @resp.id
     assert_equal 'My Deposition', @resp.title
+    assert_equal 'Deposition description', @resp.description
+    assert_equal '2024-01-01', @resp.publication_date
     assert_equal 'https://zenodo.org/api/files/123', @resp.bucket_url
     assert_equal 1, @resp.file_count
+    assert_equal 1, @resp.files.size
+    file = @resp.files.first
+    assert_equal '10', file.id
+    assert_equal 'file.txt', file.filename
+    assert_equal 1234, file.filesize
+    assert_equal 'md5:abc', file.checksum
+    assert_equal 'https://zenodo.org/api/files/123/file.txt', file.download_link
+    assert_equal 'https://zenodo.org/api/files/123/file.txt', file.download_url
     assert @resp.draft?
   end
 end


### PR DESCRIPTION
## Summary
- handle Zenodo deposition URLs in repo resolver and pass token parameter
- add exploration action for depositions and enhanced deposition model
- permit token param through explore processor and update translations/tests
- include repo API key in Zenodo download processor for protected deposition file downloads
- use Zenodo API auth header constant in upload processor and add coverage

## Testing
- `bundle exec rubocop app/connectors/zenodo/upload_connector_processor.rb test/connectors/zenodo/upload_connector_processor_test.rb`
- `bundle exec rails test test/connectors/zenodo/upload_connector_processor_test.rb test/connectors/zenodo/download_connector_processor_test.rb test/connectors/zenodo/actions/depositions_test.rb test/connectors/zenodo/display_repo_controller_resolver_test.rb test/services/zenodo/zenodo_url_test.rb test/models/zenodo/deposition_response_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_689130660a9c8321b8bf1b70fdfb7f4d