### PR TITLE
Add logging to core connector flows

### DIFF
--- a/application/app/connectors/dataverse/actions/collection_select.rb
+++ b/application/app/connectors/dataverse/actions/collection_select.rb
@@ -1,7 +1,10 @@
 module Dataverse::Actions
   class CollectionSelect
+    include LoggingCommon
+
     def edit(upload_bundle, request_params)
       collections = collections(upload_bundle)
+      log_info('Collection select edit', { upload_bundle: upload_bundle.id, collections: collections.items.size })
 
       ConnectorResult.new(
         template: '/connectors/dataverse/collection_select_form',
@@ -16,6 +19,8 @@ module Dataverse::Actions
       metadata[:collection_id] = collection_id
       metadata[:collection_title] = collection_title
       upload_bundle.update({ metadata: metadata })
+
+      log_info('Collection selected', { upload_bundle: upload_bundle.id, collection_id: collection_id })
 
       ConnectorResult.new(
         message: { notice: I18n.t('connectors.dataverse.actions.collection_select.message_success', title: collection_title) },

--- a/application/app/connectors/dataverse/actions/collection_select.rb
+++ b/application/app/connectors/dataverse/actions/collection_select.rb
@@ -3,12 +3,12 @@ module Dataverse::Actions
     include LoggingCommon
 
     def edit(upload_bundle, request_params)
-      collections = collections(upload_bundle)
-      log_info('Collection select edit', { upload_bundle: upload_bundle.id, collections: collections.items.size })
+      user_collections_response = collections(upload_bundle)
+      log_info('Collection select edit', { upload_bundle: upload_bundle.id, collections: user_collections_response.items.size })
 
       ConnectorResult.new(
         template: '/connectors/dataverse/collection_select_form',
-        locals: { upload_bundle: upload_bundle, data: collections },
+        locals: { upload_bundle: upload_bundle, data: user_collections_response },
       )
     end
 
@@ -38,8 +38,8 @@ module Dataverse::Actions
     end
 
     def collection_title(upload_bundle, collection_id)
-      collections = collections(upload_bundle)
-      collections.items.select{|c| c.identifier == collection_id}.first&.name
+      user_collections_response = collections(upload_bundle)
+      user_collections_response.items.select { |c| c.identifier == collection_id }.first&.name
     end
   end
 end

--- a/application/app/connectors/dataverse/actions/connector_edit.rb
+++ b/application/app/connectors/dataverse/actions/connector_edit.rb
@@ -1,5 +1,7 @@
 module Dataverse::Actions
   class ConnectorEdit
+    include LoggingCommon
+
     def edit(upload_bundle, request_params)
       ConnectorResult.new(
         template: '/connectors/dataverse/connector_edit_form',
@@ -10,6 +12,7 @@ module Dataverse::Actions
     def update(upload_bundle, request_params)
       repo_key = request_params[:api_key]
       scope = request_params[:key_scope]
+      log_info('Updating API key', { upload_bundle: upload_bundle.id, scope: scope })
       if scope == 'bundle'
         metadata = upload_bundle.metadata
         metadata[:auth_key] = repo_key

--- a/application/app/connectors/dataverse/actions/dataset_create.rb
+++ b/application/app/connectors/dataverse/actions/dataset_create.rb
@@ -1,5 +1,7 @@
 module Dataverse::Actions
   class DatasetCreate
+    include LoggingCommon
+
     def edit(upload_bundle, request_params)
       raise NotImplementedError, 'Only update is supported for DatasetCreate'
     end
@@ -8,6 +10,8 @@ module Dataverse::Actions
       dataverse_url = upload_bundle.connector_metadata.dataverse_url
       api_key = upload_bundle.connector_metadata.api_key.value
       collection_id = upload_bundle.connector_metadata.collection_id
+
+      log_info('Creating dataset', { upload_bundle: upload_bundle.id, collection_id: collection_id })
 
       request = Dataverse::CreateDatasetRequest.new(
         title: request_params[:title],
@@ -24,6 +28,7 @@ module Dataverse::Actions
       metadata[:dataset_id] = response.persistent_id
       metadata[:dataset_title] = request.title
       upload_bundle.update({ metadata: metadata })
+      log_info('Dataset created', { upload_bundle: upload_bundle.id, dataset_id: response.persistent_id })
 
       ConnectorResult.new(
         message: { notice: I18n.t('connectors.dataverse.actions.dataset_create.message_success', id: response.persistent_id, title: request.title) },

--- a/application/app/connectors/dataverse/actions/dataset_form_tabs.rb
+++ b/application/app/connectors/dataverse/actions/dataset_form_tabs.rb
@@ -1,9 +1,12 @@
 module Dataverse::Actions
   class DatasetFormTabs
+    include LoggingCommon
+
     def edit(upload_bundle, request_params)
       datasets = datasets(upload_bundle)
       subjects = subjects(upload_bundle)
       profile = profile(upload_bundle)
+      log_info('Dataset form tabs', { upload_bundle: upload_bundle.id, datasets: datasets.items.size, subjects: subjects.size })
 
       ConnectorResult.new(
         template: '/connectors/dataverse/dataset_form_tabs',

--- a/application/app/connectors/dataverse/actions/dataset_select.rb
+++ b/application/app/connectors/dataverse/actions/dataset_select.rb
@@ -1,5 +1,7 @@
 module Dataverse::Actions
   class DatasetSelect
+    include LoggingCommon
+
     def edit(upload_bundle, request_params)
       raise NotImplementedError, 'Only update is supported for DatasetSelect'
     end
@@ -11,6 +13,8 @@ module Dataverse::Actions
       metadata[:dataset_id] = dataset_id
       metadata[:dataset_title] = dataset_title
       upload_bundle.update({ metadata: metadata })
+
+      log_info('Dataset selected', { upload_bundle: upload_bundle.id, dataset_id: dataset_id })
 
       ConnectorResult.new(
         message: { notice: I18n.t('connectors.dataverse.actions.dataset_select.message_success', title: dataset_title) },

--- a/application/app/connectors/dataverse/actions/upload_bundle_create.rb
+++ b/application/app/connectors/dataverse/actions/upload_bundle_create.rb
@@ -1,11 +1,13 @@
 module Dataverse::Actions
   class UploadBundleCreate
     include LoggingCommon
+
     include DateTimeCommon
 
     def create(project, request_params)
       remote_repo_url = request_params[:object_url]
       url_data = Dataverse::DataverseUrl.parse(remote_repo_url)
+      log_info('Creating upload bundle', { project_id: project.id, remote_repo_url: remote_repo_url })
 
       if url_data.collection?
         collection_service = Dataverse::CollectionService.new(url_data.dataverse_url)
@@ -60,6 +62,7 @@ module Dataverse::Actions
         }
       end
       upload_bundle.save
+      log_info('Upload bundle created', { bundle_id: upload_bundle.id })
 
       ConnectorResult.new(
         resource: upload_bundle,

--- a/application/app/connectors/zenodo/actions/connector_edit.rb
+++ b/application/app/connectors/zenodo/actions/connector_edit.rb
@@ -12,6 +12,7 @@ module Zenodo::Actions
     def update(upload_bundle, request_params)
       repo_key = request_params[:api_key]
       scope = request_params[:key_scope]
+      log_info('Updating API key', { upload_bundle: upload_bundle.id, scope: scope })
       if scope == 'bundle'
         metadata = upload_bundle.metadata
         metadata[:auth_key] = repo_key

--- a/application/app/connectors/zenodo/actions/deposition_fetch.rb
+++ b/application/app/connectors/zenodo/actions/deposition_fetch.rb
@@ -1,6 +1,7 @@
 module Zenodo::Actions
   class DepositionFetch
     include LoggingCommon
+
     include DateTimeCommon
 
     def edit(upload_bundle, request_params)
@@ -11,6 +12,7 @@ module Zenodo::Actions
       connector_metadata = upload_bundle.connector_metadata
       connector_metadata.api_key
       api_key = connector_metadata.api_key.value
+      log_info('Fetching deposition', { upload_bundle: upload_bundle.id, deposition_id: connector_metadata.deposition_id, record_id: connector_metadata.record_id })
 
       if connector_metadata.deposition_id.present?
         deposition_service = Zenodo::DepositionService.new(connector_metadata.zenodo_url, api_key: api_key)
@@ -31,6 +33,7 @@ module Zenodo::Actions
       connector_metadata.deposition_id ||= deposition.id.to_s
       connector_metadata.draft = deposition.draft?
       upload_bundle.update({ metadata: connector_metadata.to_h })
+      log_info('Deposition fetched', { upload_bundle: upload_bundle.id, deposition_id: connector_metadata.deposition_id })
 
       ConnectorResult.new(
         resource: upload_bundle,

--- a/application/app/connectors/zenodo/actions/landing.rb
+++ b/application/app/connectors/zenodo/actions/landing.rb
@@ -6,11 +6,13 @@ module Zenodo::Actions
       query = request_params[:query]
       page = request_params[:page]&.to_i || 1
       repo_url = request_params[:repo_url]
+      log_info('Landing show', { repo_url: repo_url, query: query, page: page })
       results = nil
 
       if query.present?
         service = Zenodo::SearchService.new(repo_url.server_url)
         results = service.search(query, page: page)
+        log_info('Search results', { query: query, page: page, results: results&.items&.size })
       end
       ConnectorResult.new(
         template: '/connectors/zenodo/landing/index',

--- a/application/app/connectors/zenodo/actions/records.rb
+++ b/application/app/connectors/zenodo/actions/records.rb
@@ -8,10 +8,12 @@ module Zenodo::Actions
 
     def show(request_params)
       repo_url = request_params[:repo_url]
+      log_info('Record show', { record_id: @record_id, repo_url: repo_url })
 
       service = Zenodo::RecordService.new(repo_url.server_url)
       record = service.find_record(@record_id)
       if record.nil?
+        log_info('Record not found', { record_id: @record_id })
         return ConnectorResult.new(
           message: { alert: I18n.t('zenodo.records.message_record_not_found', record_id: @record_id) },
           success: false
@@ -33,6 +35,7 @@ module Zenodo::Actions
       repo_url = request_params[:repo_url]
       file_ids = request_params[:file_ids] || []
       project_id = request_params[:project_id]
+      log_info('Record create', { record_id: @record_id, project_id: project_id, file_ids: file_ids })
 
       record_service = Zenodo::RecordService.new(repo_url.server_url)
       record = record_service.find_record(@record_id)
@@ -59,6 +62,7 @@ module Zenodo::Actions
       if save_results.include?(false)
         return ConnectorResult.new(message: { alert: I18n.t('zenodo.records.download.message_save_file_error') }, success: false)
       end
+      log_info('Download files created', { project_id: project.id, files: download_files.size })
       ConnectorResult.new(message: { notice: I18n.t('zenodo.records.download.message_success', project_name: project.name) }, success: true)
     end
   end

--- a/application/app/connectors/zenodo/actions/upload_bundle_create.rb
+++ b/application/app/connectors/zenodo/actions/upload_bundle_create.rb
@@ -1,11 +1,13 @@
 module Zenodo::Actions
   class UploadBundleCreate
     include LoggingCommon
+
     include DateTimeCommon
 
     def create(project, request_params)
       remote_repo_url = request_params[:object_url]
       url_data = Zenodo::ZenodoUrl.parse(remote_repo_url)
+      log_info('Creating upload bundle', { project_id: project.id, remote_repo_url: remote_repo_url })
 
       unless url_data.deposition? || url_data.record?
         return error(I18n.t('connectors.zenodo.actions.upload_bundle_create.message_url_not_supported', url: remote_repo_url))
@@ -51,6 +53,7 @@ module Zenodo::Actions
         }
       end
       upload_bundle.save
+      log_info('Upload bundle created', { bundle_id: upload_bundle.id })
 
       ConnectorResult.new(
         resource: upload_bundle,

--- a/application/test/connectors/dataverse/actions/collection_select_test.rb
+++ b/application/test/connectors/dataverse/actions/collection_select_test.rb
@@ -11,22 +11,28 @@ class Dataverse::Actions::CollectionSelectTest < ActiveSupport::TestCase
   end
 
   test 'edit returns form' do
-    @action.stubs(:collections).returns([])
+    json = { success: true, data: { items: [], total_count: 0 } }.to_json
+    response = Dataverse::MyDataverseCollectionsResponse.new(json)
+    @action.stubs(:collections).returns(response)
     result = @action.edit(@bundle, {})
     assert_equal '/connectors/dataverse/collection_select_form', result.template
   end
 
   test 'update stores collection data' do
-    @action.stubs(:collections).returns(OpenStruct.new(items:[OpenStruct.new(identifier:'c1', name:'title')]))
+    json = { success: true, data: { items: [{ identifier: 'c1', name: 'title' }], total_count: 1 } }.to_json
+    response = Dataverse::MyDataverseCollectionsResponse.new(json)
+    @action.stubs(:collections).returns(response)
     @bundle.stubs(:metadata).returns({})
-    result = @action.update(@bundle, {collection_id: 'c1'})
+    result = @action.update(@bundle, { collection_id: 'c1' })
     assert result.success?
     assert_equal 'c1', @bundle.metadata[:collection_id]
   end
 
   test 'collections helper uses service' do
+    json = { success: true, data: { items: [], total_count: 0 } }.to_json
+    response = Dataverse::MyDataverseCollectionsResponse.new(json)
     service = mock('service')
-    service.expects(:get_my_collections).returns(OpenStruct.new(items: []))
+    service.expects(:get_my_collections).returns(response)
     Dataverse::CollectionService.stubs(:new).returns(service)
     result = @action.send(:collections, @bundle)
     assert_equal 0, result.items.size

--- a/application/test/connectors/dataverse/actions/dataset_form_tabs_test.rb
+++ b/application/test/connectors/dataverse/actions/dataset_form_tabs_test.rb
@@ -9,7 +9,7 @@ class Dataverse::Actions::DatasetFormTabsTest < ActiveSupport::TestCase
   end
 
   test 'edit returns tabs form partial' do
-    @action.stubs(:datasets).returns([])
+    @action.stubs(:datasets).returns(OpenStruct.new(items: []))
     @action.stubs(:subjects).returns([])
     @action.stubs(:profile).returns(nil)
     result = @action.edit(@bundle, {})


### PR DESCRIPTION
## Summary
- log command client request and response lifecycle
- add logging for Zenodo connector actions
- add logging for Dataverse connector actions
- separate LoggingCommon includes with a blank line for consistent style

## Testing
- `bundle install`
- `bundle exec rake test` *(fails: Could not find rails-7.2.2.1, sprockets-rails-3.5.2, importmap-rails-2.1.0, stimulus-rails-1.3.4, jbuilder-2.13.0, bootsnap-1.18.4, dotenv-rails-3.1.8, brakeman-7.0.2, rubocop-rails-omakase-1.1.0, puma-6.6.0, web-console-4.2.1, capybara-3.40.0, selenium-webdriver-4.31.0, mocha-2.7.1, simplecov-0.22.0, cssbundling-rails-1.4.3, actioncable-7.2.2.1, actionmailbox-7.2.2.1, actionmailer-7.2.2.1, actionpack-7.2.2.1, actiontext-7.2.2.1, actionview-7.2.2.1, activejob-7.2.2.1, activemodel-7.2.2.1, activerecord-7.2.2.1, activestorage-7.2.2.1, activesupport-7.2.2.1, railties-7.2.2.1, sprockets-4.2.1, msgpack-1.8.0, irb-1.15.2, reline-0.6.1, rubocop-1.75.2, rubocop-performance-1.25.0, rubocop-rails-2.31.0, nio4r-2.7.4, addressable-2.8.7, nokogiri-1.18.7, rack-test-2.2.0, xpath-3.2.0, rubyzip-2.4.1, websocket-1.2.11, simplecov-html-0.13.1, simplecov_json_formatter-0.1.4, websocket-driver-0.7.7, mail-2.8.1, rails-dom-testing-2.2.0, rack-session-2.1.0, rails-html-sanitizer-1.6.2, globalid-1.2.1, bigdecimal-3.1.9, i18n-1.14.7, tzinfo-2.0.6, rackup-2.2.1, rdoc-6.13.1, parser-3.3.8.0, rubocop-ast-1.44.1, unicode-display_width-3.1.4, mini_portile2-2.8.8, net-imap-0.5.6, loofah-2.24.0, psych-5.2.3, prism-1.4.0, unicode-emoji-4.0.4)*

------
https://chatgpt.com/codex/tasks/task_e_6891d5d63c508321898635af3ce803d4