### PR TITLE
test: expand coverage for dataverse and zenodo

### DIFF
--- a/application/test/connectors/dataverse/actions/collection_select_test.rb
+++ b/application/test/connectors/dataverse/actions/collection_select_test.rb
@@ -37,4 +37,12 @@ class Dataverse::Actions::CollectionSelectTest < ActiveSupport::TestCase
     result = @action.send(:collections, @bundle)
     assert_equal 0, result.items.size
   end
+
+  test 'collection_title finds name and returns nil when missing' do
+    json = { success: true, data: { items: [{ identifier: 'c1', name: 'Title1' }], total_count: 1 } }.to_json
+    response = Dataverse::MyDataverseCollectionsResponse.new(json)
+    @action.stubs(:collections).returns(response)
+    assert_equal 'Title1', @action.send(:collection_title, @bundle, 'c1')
+    assert_nil @action.send(:collection_title, @bundle, 'c2')
+  end
 end

--- a/application/test/connectors/dataverse/actions/dataset_select_test.rb
+++ b/application/test/connectors/dataverse/actions/dataset_select_test.rb
@@ -33,4 +33,13 @@ class Dataverse::Actions::DatasetSelectTest < ActiveSupport::TestCase
     @action.stubs(:datasets).returns(datasets)
     assert_nil @action.send(:dataset_title, @bundle, 'missing')
   end
+
+  test 'datasets fetches via collection service' do
+    service = mock('collections')
+    service.expects(:search_collection_items)
+           .with('COL1', page: 1, per_page: 100, include_collections: false, include_drafts: true)
+           .returns(OpenStruct.new(data: :results))
+    Dataverse::CollectionService.expects(:new).with('http://dv.org', api_key: 'KEY').returns(service)
+    assert_equal :results, @action.send(:datasets, @bundle)
+  end
 end

--- a/application/test/connectors/dataverse/upload_connector_processor_test.rb
+++ b/application/test/connectors/dataverse/upload_connector_processor_test.rb
@@ -47,4 +47,11 @@ class Dataverse::UploadConnectorProcessorTest < ActiveSupport::TestCase
     res = @processor.process(req)
     assert_equal ctx, res[:status]
   end
+
+  test 'upload returns cancelled when flagged' do
+    Upload::MultipartHttpRubyUploader.any_instance.stubs(:upload).yields({total:1, uploaded:0}).returns(nil)
+    @processor.instance_variable_set(:@cancelled, true)
+    result = @processor.upload
+    assert_equal FileStatus::CANCELLED, result.status
+  end
 end

--- a/application/test/connectors/zenodo/actions/landing_test.rb
+++ b/application/test/connectors/zenodo/actions/landing_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class Zenodo::Actions::LandingTest < ActiveSupport::TestCase
+  def setup
+    @action = Zenodo::Actions::Landing.new
+    @repo_url = OpenStruct.new(server_url: 'https://zenodo.org')
+  end
+
+  test 'show runs search when query present' do
+    service = mock('search')
+    results = OpenStruct.new(items: [])
+    service.expects(:search).with('q', page: 2).returns(results)
+    Zenodo::SearchService.expects(:new).with('https://zenodo.org').returns(service)
+    res = @action.show(query: 'q', page: 2, repo_url: @repo_url)
+    assert res.success?
+    assert_equal results, res.locals[:results]
+  end
+
+  test 'show without query skips search' do
+    res = @action.show(query: nil, repo_url: @repo_url)
+    assert res.success?
+    assert_nil res.locals[:results]
+  end
+end

--- a/application/test/connectors/zenodo/actions/records_test.rb
+++ b/application/test/connectors/zenodo/actions/records_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+class Zenodo::Actions::RecordsTest < ActiveSupport::TestCase
+  def setup
+    @repo_url = OpenStruct.new(server_url: 'https://zenodo.org')
+    @action = Zenodo::Actions::Records.new('123')
+  end
+
+  test 'show renders record when found' do
+    service = mock('service')
+    service.expects(:find_record).with('123').returns(:record)
+    Zenodo::RecordService.expects(:new).with('https://zenodo.org').returns(service)
+    res = @action.show(repo_url: @repo_url)
+    assert res.success?
+    assert_equal :record, res.locals[:record]
+  end
+
+  test 'show returns error when record missing' do
+    service = mock('service')
+    service.expects(:find_record).with('123').returns(nil)
+    Zenodo::RecordService.expects(:new).with('https://zenodo.org').returns(service)
+    res = @action.show(repo_url: @repo_url)
+    refute res.success?
+  end
+
+  test 'create initializes project and files' do
+    service = mock('service')
+    service.expects(:find_record).with('123').returns(:record)
+    Zenodo::RecordService.expects(:new).with('https://zenodo.org').returns(service)
+
+    Project.stubs(:find).with('1').returns(nil)
+    project = mock('project')
+    project.stubs(:save).returns(true)
+    project.stubs(:name).returns('Proj')
+    project.stubs(:id).returns(1)
+
+    file = mock('file')
+    file.stubs(:valid?).returns(true)
+    file.stubs(:save).returns(true)
+
+    proj_service = mock('proj_service')
+    proj_service.expects(:initialize_project).returns(project)
+    proj_service.expects(:create_files_from_record).with(project, :record, ['f1']).returns([file])
+    Zenodo::ProjectService.expects(:new).with('https://zenodo.org').returns(proj_service)
+
+    res = @action.create(repo_url: @repo_url, file_ids: ['f1'], project_id: '1')
+    assert res.success?
+  end
+
+  test 'create returns error when record not found' do
+    service = mock('service')
+    service.expects(:find_record).with('123').returns(nil)
+    Zenodo::RecordService.expects(:new).with('https://zenodo.org').returns(service)
+    res = @action.create(repo_url: @repo_url, file_ids: [], project_id: '1')
+    refute res.success?
+  end
+end

--- a/application/test/helpers/dataverse/datasets_helper_test.rb
+++ b/application/test/helpers/dataverse/datasets_helper_test.rb
@@ -43,4 +43,28 @@ class DataverseDatasetsHelperTest < ActionView::TestCase
     assert_equal 's3://bucket', storage_identifier('s3://bucket:12345')
     assert_nil storage_identifier(nil)
   end
+
+  test 'dataverse_dataset_view_url builds path with overrides' do
+    stubs(:view_dataverse_dataset_path).with('host', 'pid', { dv_port: 8080, dv_scheme: 'http', version: '1.0', page: 2, query: 'q' }).returns('/view')
+    url = dataverse_dataset_view_url('http://host:8080', 'pid', version: '1.0', page: 2, query: 'q')
+    assert_equal '/view', url
+  end
+
+  test 'dataset_versions_url uses params for overrides' do
+    stubs(:params).returns({ dv_port: '1234', dv_scheme: 'http' })
+    stubs(:view_dataverse_dataset_versions_path).with('host', 'pid', { dv_port: '1234', dv_scheme: 'http' }).returns('/versions')
+    url = dataset_versions_url('http://host', 'pid')
+    assert_equal '/versions', url
+  end
+
+  test 'external_dataset_url builds correct link' do
+    url = external_dataset_url('http://dv.example', 'pid', '1.0')
+    assert_equal 'http://dv.example/dataset.xhtml?persistentId=pid&version=1.0', url
+  end
+
+  test 'sort_by_draft orders drafts first' do
+    list = [OpenStruct.new(version: '1'), OpenStruct.new(version: ':draft'), OpenStruct.new(version: '2')]
+    sorted = sort_by_draft(list)
+    assert_equal ':draft', sorted.first.version
+  end
 end

--- a/application/test/helpers/zenodo/explore_helper_test.rb
+++ b/application/test/helpers/zenodo/explore_helper_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class ZenodoExploreHelperTest < ActionView::TestCase
+  include Zenodo::ExploreHelper
+
+  def setup
+    @repo_url = OpenStruct.new(domain: 'zenodo.org', scheme_override: nil, port_override: nil)
+  end
+
+  test 'link_to_explore builds path' do
+    stubs(:explore_path).with(connector_type: ConnectorType::ZENODO.to_s,
+                               server_domain: 'zenodo.org',
+                               server_scheme: nil,
+                               server_port: nil,
+                               object_type: 'records',
+                               object_id: '1').returns('/explore')
+    assert_equal '/explore', link_to_explore(@repo_url, type: 'records', id: '1')
+  end
+
+  test 'prev and next links rendered when pages available' do
+    page = Page.new((1..30).to_a, 2, 10)
+    stubs(:explore_path).returns('/link')
+    html = link_to_explore_prev_page('q', page, @repo_url, {})
+    assert_includes html, '/link'
+    html = link_to_explore_next_page('q', page, @repo_url, {})
+    assert_includes html, '/link'
+  end
+
+  test 'prev returns nil on first page' do
+    page = Page.new((1..10).to_a, 1, 10)
+    assert_nil link_to_explore_prev_page('q', page, @repo_url, {})
+  end
+
+  test 'next returns nil on last page' do
+    page = Page.new((1..10).to_a, 1, 10)
+    assert_nil link_to_explore_next_page('q', page, @repo_url, {})
+  end
+end

--- a/application/test/helpers/zenodo/records_helper_test.rb
+++ b/application/test/helpers/zenodo/records_helper_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class ZenodoRecordsHelperTest < ActionView::TestCase
+  include Zenodo::RecordsHelper
+
+  test 'external_record_url uses default base url' do
+    assert_equal 'https://zenodo.org/records/123', external_record_url(123)
+  end
+
+  test 'external_record_url uses custom base url' do
+    assert_equal 'https://sandbox.zenodo.org/records/1', external_record_url(1, 'https://sandbox.zenodo.org')
+  end
+end

--- a/application/test/services/dataverse/collection_service_test.rb
+++ b/application/test/services/dataverse/collection_service_test.rb
@@ -53,4 +53,25 @@ class Dataverse::CollectionServiceTest < ActiveSupport::TestCase
     service = Dataverse::CollectionService.new('https://example.com', http_client: client, api_key: 'KEY')
     assert_nil service.get_my_collections
   end
+
+  test 'get_my_collections requires api key' do
+    service = Dataverse::CollectionService.new('https://example.com', http_client: @client)
+    assert_raises(Dataverse::CollectionService::ApiKeyRequiredException) do
+      service.get_my_collections
+    end
+  end
+
+  test 'search_collection_items returns nil on 404' do
+    client = HttpClientMock.new(file_path: fixture_path('dataverse/search_response/valid_response.json'), status_code: 404)
+    service = Dataverse::CollectionService.new('https://example.com', http_client: client)
+    assert_nil service.search_collection_items('dv')
+  end
+
+  test 'search_collection_items raises on unauthorized' do
+    client = HttpClientMock.new(file_path: fixture_path('dataverse/search_response/valid_response.json'), status_code: 401)
+    service = Dataverse::CollectionService.new('https://example.com', http_client: client)
+    assert_raises(Dataverse::CollectionService::UnauthorizedException) do
+      service.search_collection_items('dv')
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- expand Dataverse::CollectionService tests for API-key and error paths
- add missing coverage for Dataverse and Zenodo actions and helpers
- verify Zenodo search response URL handling

## Testing
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_689241a247c083219c18687104a00e5b