### PR TITLE
Add landing endpoint to explore controller

### DIFF
--- a/application/app/connectors/dataverse/explore_connector_processor.rb
+++ b/application/app/connectors/dataverse/explore_connector_processor.rb
@@ -24,5 +24,13 @@ module Dataverse
         success: true
       )
     end
+
+    def landing(request_params)
+      ConnectorResult.new(
+        template: '/connectors/dataverse/explore_placeholder',
+        locals: { data: request_params },
+        success: true
+      )
+    end
   end
 end

--- a/application/app/connectors/zenodo/explore_connector_processor.rb
+++ b/application/app/connectors/zenodo/explore_connector_processor.rb
@@ -27,5 +27,12 @@ module Zenodo
       action = ConnectorActionDispatcher.load(request_params[:connector_type], action_type, object_id)
       action.create(request_params)
     end
+
+    def landing(_request_params)
+      ConnectorResult.new(
+        message: { alert: I18n.t('connectors.zenodo.actions.landing.message_action_not_supported') },
+        success: false
+      )
+    end
   end
 end

--- a/application/config/locales/connectors/zenodo/en.yml
+++ b/application/config/locales/connectors/zenodo/en.yml
@@ -6,6 +6,8 @@ en:
       aria_label: "Visit the Zenodo project homepage"
 
       actions:
+        landing:
+          message_action_not_supported: "Action not supported"
         connector_edit:
           message_success: "Access token updated: %{name}"
         fetch_deposition:

--- a/application/config/locales/controllers/en.yml
+++ b/application/config/locales/controllers/en.yml
@@ -68,3 +68,5 @@ en:
     create:
       message_invalid_repo_url: "Invalid repository URL: %{repo_url}"
       message_processor_error: "Error processing request for repository: %{connector_type} type: %{object_type} with id: %{object_id}"
+    landing:
+      message_processor_error: "Error processing request for repository: %{connector_type}"

--- a/application/config/routes.rb
+++ b/application/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
   get "/view/dataverse/*dv_hostname/dataverses/:id" => "dataverse/collections#show", as: :view_dataverse, format: false
 
   # EXPLORE ROUTE
+  get "/explore/:connector_type/landing" => "explore#landing", as: :explore_landing
   get "/explore/:connector_type/*server_domain/:object_type/:object_id" => "explore#show", as: :explore
   post "/explore/:connector_type/*server_domain/:object_type/:object_id" => "explore#create"
 

--- a/application/test/controllers/explore_controller_test.rb
+++ b/application/test/controllers/explore_controller_test.rb
@@ -13,24 +13,14 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
     assert_select 'div.alert-info'
   end
 
-  test 'zenodo landing action delegates to search service' do
-    service = mock
-    service.expects(:search)
-           .with('test', page: 1)
-           .returns(OpenStruct.new(items: []))
-    Zenodo::SearchService.expects(:new)
-                          .with('https://zenodo.org')
-                          .returns(service)
-
-    get explore_url(
+  test 'zenodo landing action is not supported' do
+    get explore_landing_url(
       connector_type: 'zenodo',
-      server_domain: 'zenodo.org',
-      object_type: 'actions',
-      object_id: 'landing',
       query: 'test'
     )
 
-    assert_response :success
+    assert_redirected_to root_path
+    assert_equal I18n.t('connectors.zenodo.actions.landing.message_action_not_supported'), flash[:alert]
   end
 
   test 'redirects when repo url is invalid' do


### PR DESCRIPTION
## Summary
- add `/explore/:connector_type/landing` to ExploreController
- support landing in Zenodo and Dataverse connector processors
- add translation for landing processor errors
- revert unrelated Zenodo view helper changes
- return failure result for unsupported Zenodo landing with translated message

## Testing
- `bundle install`
- `bin/rails assets:precompile`
- `bin/rails test test/controllers/explore_controller_test.rb test/helpers/zenodo/explore_helper_test.rb test/connectors/zenodo/display_repo_controller_resolver_test.rb`


------
https://chatgpt.com/codex/tasks/task_e_68931bd2a6008321a8a6e3b61a5b6c92