### PR TITLE
Add explorer loader and Zenodo explorers

### DIFF
--- a/application/app/connectors/connector_action_dispatcher.rb
+++ b/application/app/connectors/connector_action_dispatcher.rb
@@ -1,14 +1,21 @@
 # frozen_string_literal: true
 
-# Class to dynamically load connector actions.
+# Class to dynamically load connector actions or explorers.
 # Builds a class name based on connector_type, object_type and object_id
-# and instantiates the corresponding action class.
+# and instantiates the corresponding class.
 class ConnectorActionDispatcher
-  def self.load(connector_type, object_type, object_id)
-    module_name = connector_type.to_s.camelize
-    object_module = 'Actions'
+  def self.action(connector_type, object_type, object_id)
+    load_from_module(connector_type, object_type, object_id, 'Actions')
+  end
 
-    if object_type.to_s == 'actions'
+  def self.explorer(connector_type, object_type, object_id)
+    load_from_module(connector_type, object_type, object_id, 'Explorers')
+  end
+
+  def self.load_from_module(connector_type, object_type, object_id, object_module)
+    module_name = connector_type.to_s.camelize
+
+    if object_type.to_s == object_module.downcase
       class_name = object_id.to_s.camelize
       connector_class = "#{module_name}::#{object_module}::#{class_name}"
       connector_class.constantize.new
@@ -20,6 +27,8 @@ class ConnectorActionDispatcher
   rescue NameError
     raise ConnectorNotSupported, "Invalid connector action #{connector_class}"
   end
+
+  private_class_method :load_from_module
 
   class ConnectorNotSupported < StandardError; end
 end

--- a/application/app/connectors/zenodo/explore_connector_processor.rb
+++ b/application/app/connectors/zenodo/explore_connector_processor.rb
@@ -15,17 +15,23 @@ module Zenodo
     end
 
     def show(request_params)
-      explorer_type = request_params[:object_type]
-      object_id = request_params[:object_id]
-      explorer = ConnectorActionDispatcher.explorer(request_params[:connector_type], explorer_type, object_id)
-      explorer.show(request_params)
+      load_explorer(request_params).show(request_params)
     end
 
     def create(request_params)
+      load_explorer(request_params).create(request_params)
+    end
+
+    private
+
+    def load_explorer(request_params)
       explorer_type = request_params[:object_type]
       object_id = request_params[:object_id]
-      explorer = ConnectorActionDispatcher.explorer(request_params[:connector_type], explorer_type, object_id)
-      explorer.create(request_params)
+      if object_id.present?
+        ConnectorActionDispatcher.explorer(request_params[:connector_type], explorer_type, object_id)
+      else
+        ConnectorActionDispatcher.explorer(request_params[:connector_type], :explorers, explorer_type)
+      end
     end
 
     def landing(_request_params)

--- a/application/app/connectors/zenodo/explore_connector_processor.rb
+++ b/application/app/connectors/zenodo/explore_connector_processor.rb
@@ -15,17 +15,17 @@ module Zenodo
     end
 
     def show(request_params)
-      action_type = request_params[:object_type]
+      explorer_type = request_params[:object_type]
       object_id = request_params[:object_id]
-      action = ConnectorActionDispatcher.load(request_params[:connector_type], action_type, object_id)
-      action.show(request_params)
+      explorer = ConnectorActionDispatcher.explorer(request_params[:connector_type], explorer_type, object_id)
+      explorer.show(request_params)
     end
 
     def create(request_params)
-      action_type = request_params[:object_type]
+      explorer_type = request_params[:object_type]
       object_id = request_params[:object_id]
-      action = ConnectorActionDispatcher.load(request_params[:connector_type], action_type, object_id)
-      action.create(request_params)
+      explorer = ConnectorActionDispatcher.explorer(request_params[:connector_type], explorer_type, object_id)
+      explorer.create(request_params)
     end
 
     def landing(_request_params)

--- a/application/app/connectors/zenodo/explorers/depositions.rb
+++ b/application/app/connectors/zenodo/explorers/depositions.rb
@@ -1,4 +1,4 @@
-module Zenodo::Actions
+module Zenodo::Explorers
   class Depositions
     include LoggingCommon
 

--- a/application/app/connectors/zenodo/explorers/landing.rb
+++ b/application/app/connectors/zenodo/explorers/landing.rb
@@ -1,4 +1,4 @@
-module Zenodo::Actions
+module Zenodo::Explorers
   class Landing
     include LoggingCommon
 

--- a/application/app/connectors/zenodo/explorers/records.rb
+++ b/application/app/connectors/zenodo/explorers/records.rb
@@ -1,4 +1,4 @@
-module Zenodo::Actions
+module Zenodo::Explorers
   class Records
     include LoggingCommon
 

--- a/application/test/connectors/connector_action_dispatcher_test.rb
+++ b/application/test/connectors/connector_action_dispatcher_test.rb
@@ -2,9 +2,14 @@
 require 'test_helper'
 
 class ConnectorActionDispatcherTest < ActiveSupport::TestCase
-  test 'loads connector action for zenodo landing' do
-    action = ConnectorActionDispatcher.load(ConnectorType::ZENODO, :actions, :landing)
-    assert_instance_of Zenodo::Actions::Landing, action
+  test 'loads connector action for zenodo connector_edit' do
+    action = ConnectorActionDispatcher.action(ConnectorType::ZENODO, :actions, :connector_edit)
+    assert_instance_of Zenodo::Actions::ConnectorEdit, action
+  end
+
+  test 'loads connector explorer for zenodo landing' do
+    explorer = ConnectorActionDispatcher.explorer(ConnectorType::ZENODO, :explorers, :landing)
+    assert_instance_of Zenodo::Explorers::Landing, explorer
   end
 
   test 'passes object id to constructor for non-actions type' do
@@ -18,16 +23,37 @@ class ConnectorActionDispatcherTest < ActiveSupport::TestCase
       end
     end
 
-    action = ConnectorActionDispatcher.load(ConnectorType::ZENODO, :dummy, 123)
+    action = ConnectorActionDispatcher.action(ConnectorType::ZENODO, :dummy, 123)
     assert_instance_of Zenodo::Actions::Dummy, action
     assert_equal 123, action.id
   ensure
     Zenodo::Actions.send(:remove_const, :Dummy)
   end
 
-  test 'raises error for unknown action' do
+  test 'passes object id to explorer constructor for non-explorers type' do
+    module Zenodo::Explorers
+      class Dummy
+        attr_reader :id
+
+        def initialize(id)
+          @id = id
+        end
+      end
+    end
+
+    explorer = ConnectorActionDispatcher.explorer(ConnectorType::ZENODO, :dummy, 456)
+    assert_instance_of Zenodo::Explorers::Dummy, explorer
+    assert_equal 456, explorer.id
+  ensure
+    Zenodo::Explorers.send(:remove_const, :Dummy)
+  end
+
+  test 'raises error for unknown action or explorer' do
     assert_raises(ConnectorActionDispatcher::ConnectorNotSupported) do
-      ConnectorActionDispatcher.load(ConnectorType::ZENODO, :actions, :missing)
+      ConnectorActionDispatcher.action(ConnectorType::ZENODO, :actions, :missing)
+    end
+    assert_raises(ConnectorActionDispatcher::ConnectorNotSupported) do
+      ConnectorActionDispatcher.explorer(ConnectorType::ZENODO, :explorers, :missing)
     end
   end
 end

--- a/application/test/connectors/zenodo/explore_connector_processor_test.rb
+++ b/application/test/connectors/zenodo/explore_connector_processor_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class Zenodo::ExploreConnectorProcessorTest < ActiveSupport::TestCase
+  def setup
+    @processor = Zenodo::ExploreConnectorProcessor.new
+  end
+
+  test 'show delegates to explorer without object id' do
+    params = { connector_type: ConnectorType::ZENODO, object_type: :landing, query: 'q' }
+    explorer = mock('explorer')
+    ConnectorActionDispatcher.expects(:explorer).with(ConnectorType::ZENODO, :explorers, :landing).returns(explorer)
+    explorer.expects(:show).with(params).returns(:result)
+    assert_equal :result, @processor.show(params)
+  end
+
+  test 'create delegates to explorer with object id' do
+    params = { connector_type: ConnectorType::ZENODO, object_type: :records, object_id: '2', project_id: '3', file_ids: ['f1'] }
+    explorer = mock('explorer')
+    ConnectorActionDispatcher.expects(:explorer).with(ConnectorType::ZENODO, :records, '2').returns(explorer)
+    explorer.expects(:create).with(params).returns(:created)
+    assert_equal :created, @processor.create(params)
+  end
+end

--- a/application/test/connectors/zenodo/explorers/depositions_test.rb
+++ b/application/test/connectors/zenodo/explorers/depositions_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-class Zenodo::Actions::DepositionsTest < ActiveSupport::TestCase
+class Zenodo::Explorers::DepositionsTest < ActiveSupport::TestCase
   def setup
-    @action = Zenodo::Actions::Depositions.new('10')
+    @explorer = Zenodo::Explorers::Depositions.new('10')
     @repo_url = OpenStruct.new(server_url: 'https://zenodo.org')
   end
 
@@ -14,7 +14,7 @@ class Zenodo::Actions::DepositionsTest < ActiveSupport::TestCase
     service.expects(:find_deposition).with('10').returns(:deposition)
     Zenodo::DepositionService.expects(:new).with('https://zenodo.org', api_key: 'KEY').returns(service)
 
-    result = @action.show(repo_url: @repo_url)
+    result = @explorer.show(repo_url: @repo_url)
     assert result.success?
   end
 
@@ -22,7 +22,7 @@ class Zenodo::Actions::DepositionsTest < ActiveSupport::TestCase
     repo_info = OpenStruct.new(metadata: OpenStruct.new(auth_key: nil))
     RepoRegistry.repo_db.stubs(:get).with('https://zenodo.org').returns(repo_info)
 
-    result = @action.show(repo_url: @repo_url)
+    result = @explorer.show(repo_url: @repo_url)
     refute result.success?
     assert_equal I18n.t('zenodo.depositions.message_api_key_required'), result.message[:alert]
   end
@@ -33,7 +33,7 @@ class Zenodo::Actions::DepositionsTest < ActiveSupport::TestCase
     service = mock('service')
     service.expects(:find_deposition).with('10').returns(nil)
     Zenodo::DepositionService.expects(:new).with('https://zenodo.org', api_key: 'KEY').returns(service)
-    result = @action.show(repo_url: @repo_url)
+    result = @explorer.show(repo_url: @repo_url)
     refute result.success?
   end
 
@@ -59,7 +59,7 @@ class Zenodo::Actions::DepositionsTest < ActiveSupport::TestCase
     proj_service.expects(:create_files_from_deposition).with(project, :deposition, ['f1']).returns([file])
     Zenodo::ProjectService.expects(:new).with('https://zenodo.org').returns(proj_service)
 
-    result = @action.create(repo_url: @repo_url, file_ids: ['f1'], project_id: '1')
+    result = @explorer.create(repo_url: @repo_url, file_ids: ['f1'], project_id: '1')
     assert result.success?
   end
 end

--- a/application/test/connectors/zenodo/explorers/landing_test.rb
+++ b/application/test/connectors/zenodo/explorers/landing_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-class Zenodo::Actions::LandingTest < ActiveSupport::TestCase
+class Zenodo::Explorers::LandingTest < ActiveSupport::TestCase
   def setup
-    @action = Zenodo::Actions::Landing.new
+    @explorer = Zenodo::Explorers::Landing.new
     @repo_url = OpenStruct.new(server_url: 'https://zenodo.org')
   end
 
@@ -11,13 +11,13 @@ class Zenodo::Actions::LandingTest < ActiveSupport::TestCase
     results = OpenStruct.new(items: [])
     service.expects(:search).with('q', page: 2).returns(results)
     Zenodo::SearchService.expects(:new).with('https://zenodo.org').returns(service)
-    res = @action.show(query: 'q', page: 2, repo_url: @repo_url)
+    res = @explorer.show(query: 'q', page: 2, repo_url: @repo_url)
     assert res.success?
     assert_equal results, res.locals[:results]
   end
 
   test 'show without query skips search' do
-    res = @action.show(query: nil, repo_url: @repo_url)
+    res = @explorer.show(query: nil, repo_url: @repo_url)
     assert res.success?
     assert_nil res.locals[:results]
   end

--- a/application/test/connectors/zenodo/explorers/records_test.rb
+++ b/application/test/connectors/zenodo/explorers/records_test.rb
@@ -1,16 +1,16 @@
 require 'test_helper'
 
-class Zenodo::Actions::RecordsTest < ActiveSupport::TestCase
+class Zenodo::Explorers::RecordsTest < ActiveSupport::TestCase
   def setup
     @repo_url = OpenStruct.new(server_url: 'https://zenodo.org')
-    @action = Zenodo::Actions::Records.new('123')
+    @explorer = Zenodo::Explorers::Records.new('123')
   end
 
   test 'show renders record when found' do
     service = mock('service')
     service.expects(:find_record).with('123').returns(:record)
     Zenodo::RecordService.expects(:new).with('https://zenodo.org').returns(service)
-    res = @action.show(repo_url: @repo_url)
+    res = @explorer.show(repo_url: @repo_url)
     assert res.success?
     assert_equal :record, res.locals[:record]
   end
@@ -19,7 +19,7 @@ class Zenodo::Actions::RecordsTest < ActiveSupport::TestCase
     service = mock('service')
     service.expects(:find_record).with('123').returns(nil)
     Zenodo::RecordService.expects(:new).with('https://zenodo.org').returns(service)
-    res = @action.show(repo_url: @repo_url)
+    res = @explorer.show(repo_url: @repo_url)
     refute res.success?
   end
 
@@ -43,7 +43,7 @@ class Zenodo::Actions::RecordsTest < ActiveSupport::TestCase
     proj_service.expects(:create_files_from_record).with(project, :record, ['f1']).returns([file])
     Zenodo::ProjectService.expects(:new).with('https://zenodo.org').returns(proj_service)
 
-    res = @action.create(repo_url: @repo_url, file_ids: ['f1'], project_id: '1')
+    res = @explorer.create(repo_url: @repo_url, file_ids: ['f1'], project_id: '1')
     assert res.success?
   end
 
@@ -51,7 +51,7 @@ class Zenodo::Actions::RecordsTest < ActiveSupport::TestCase
     service = mock('service')
     service.expects(:find_record).with('123').returns(nil)
     Zenodo::RecordService.expects(:new).with('https://zenodo.org').returns(service)
-    res = @action.create(repo_url: @repo_url, file_ids: [], project_id: '1')
+    res = @explorer.create(repo_url: @repo_url, file_ids: [], project_id: '1')
     refute res.success?
   end
 end

--- a/application/test/controllers/explore_controller_test.rb
+++ b/application/test/controllers/explore_controller_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class ExploreControllerTest < ActionDispatch::IntegrationTest
   def stub_processor(action, result: nil, exception: nil)
@@ -112,4 +112,3 @@ class ExploreControllerTest < ActionDispatch::IntegrationTest
     assert_equal I18n.t('explore.create.message_processor_error', connector_type: 'zenodo', object_type: 'records', object_id: '1'), flash[:alert]
   end
 end
-


### PR DESCRIPTION
## Summary
- allow ConnectorActionDispatcher to load both actions and explorers
- move Zenodo landing, records and depositions to explorers
- update tests and explorer processor to call the new dispatcher

## Testing
- `cd application && bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6893647d9ce48321b850f07cc12b6a04