### PR TITLE
Return unsupported result for Zenodo explore landing

### DIFF
--- a/application/app/connectors/zenodo/explore_connector_processor.rb
+++ b/application/app/connectors/zenodo/explore_connector_processor.rb
@@ -22,6 +22,13 @@ module Zenodo
       load_explorer(request_params).create(request_params)
     end
 
+    def landing(_request_params)
+      ConnectorResult.new(
+        message: { alert: I18n.t('connectors.zenodo.actions.landing.message_action_not_supported') },
+        success: false
+      )
+    end
+
     private
 
     def load_explorer(request_params)
@@ -32,13 +39,6 @@ module Zenodo
       else
         ConnectorActionDispatcher.explorer(request_params[:connector_type], :explorers, explorer_type)
       end
-    end
-
-    def landing(_request_params)
-      ConnectorResult.new(
-        message: { alert: I18n.t('connectors.zenodo.actions.landing.message_action_not_supported') },
-        success: false
-      )
     end
   end
 end

--- a/application/test/connectors/zenodo/explore_connector_processor_test.rb
+++ b/application/test/connectors/zenodo/explore_connector_processor_test.rb
@@ -13,11 +13,25 @@ class Zenodo::ExploreConnectorProcessorTest < ActiveSupport::TestCase
     assert_equal :result, @processor.show(params)
   end
 
+  test 'show delegates to explorer with object id' do
+    params = { connector_type: ConnectorType::ZENODO, object_type: :records, object_id: '3', repo_url: :url }
+    explorer = mock('explorer')
+    ConnectorActionDispatcher.expects(:explorer).with(ConnectorType::ZENODO, :records, '3').returns(explorer)
+    explorer.expects(:show).with(params).returns(:found)
+    assert_equal :found, @processor.show(params)
+  end
+
   test 'create delegates to explorer with object id' do
     params = { connector_type: ConnectorType::ZENODO, object_type: :records, object_id: '2', project_id: '3', file_ids: ['f1'] }
     explorer = mock('explorer')
     ConnectorActionDispatcher.expects(:explorer).with(ConnectorType::ZENODO, :records, '2').returns(explorer)
     explorer.expects(:create).with(params).returns(:created)
     assert_equal :created, @processor.create(params)
+  end
+
+  test 'landing returns not supported result' do
+    result = @processor.landing(connector_type: ConnectorType::ZENODO)
+    assert_not result.success?
+    assert_equal I18n.t('connectors.zenodo.actions.landing.message_action_not_supported'), result.message[:alert]
   end
 end


### PR DESCRIPTION
## Summary
- Keep `landing` public but return message indicating action not supported
- Adjust Zenodo explore connector processor tests for new landing behavior

## Testing
- `bundle exec rails test test/connectors/zenodo/explore_connector_processor_test.rb` *(fails: bundler: command not found: rails)*
- `bundle exec rails test` *(fails: bundler: command not found: rails)*
- `bundle install` *(partial install before interruption)*

------
https://chatgpt.com/codex/tasks/task_e_6893737460c88321a013f970f301da9b