### PR TITLE
Add i18n key checks and clean up translations

### DIFF
--- a/application/Gemfile
+++ b/application/Gemfile
@@ -52,6 +52,7 @@ group :test do
   gem "selenium-webdriver"
   gem "mocha"
   gem 'simplecov', require: false
+  gem 'i18n-tasks', require: false
 end
 
 gem "cssbundling-rails", "~> 1.4"

--- a/application/Gemfile.lock
+++ b/application/Gemfile.lock
@@ -111,8 +111,21 @@ GEM
     erubi (1.13.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    highline (3.1.2)
+      reline
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.0.15)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 3.2.2.1)
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.8, >= 1.8.1)
+      terminal-table (>= 1.5.1)
     importmap-rails (2.1.0)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -201,6 +214,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.2.2.1)
       actionpack (= 7.2.2.1)
       activesupport (= 7.2.2.1)
@@ -271,6 +287,8 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.6)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
     thor (1.3.2)
     timeout (0.4.3)
     tzinfo (2.0.6)
@@ -303,6 +321,7 @@ DEPENDENCIES
   cssbundling-rails (~> 1.4)
   debug
   dotenv-rails
+  i18n-tasks
   importmap-rails
   jbuilder
   mocha

--- a/application/app/controllers/download_files_controller.rb
+++ b/application/app/controllers/download_files_controller.rb
@@ -8,7 +8,7 @@ class DownloadFilesController < ApplicationController
     file = DownloadFile.find(project_id, file_id)
 
     if file.nil?
-      render json: t('.file_not_found_for_project', file_id: file_id, project_id: project_id), status: :not_found
+      render json: t('download_files.file_not_found_for_project', file_id: file_id, project_id: project_id), status: :not_found
       return
     end
 
@@ -29,17 +29,17 @@ class DownloadFilesController < ApplicationController
     file_id = params[:id]
     file = DownloadFile.find(project_id, file_id)
     if file.nil?
-      redirect_back fallback_location: root_path, alert: t('.file_not_found_for_project', file_id: file_id, project_id: project_id)
+      redirect_back fallback_location: root_path, alert: t('download_files.file_not_found_for_project', file_id: file_id, project_id: project_id)
       return
     end
 
     if file.status.downloading?
-      redirect_back fallback_location: root_path, alert: t(".file_in_progress", filename: file.filename)
+      redirect_back fallback_location: root_path, alert: t('download_files.file_in_progress', filename: file.filename)
       return
     end
 
     file.destroy
-    redirect_back fallback_location: root_path, notice: t('.download_file_deleted_successfully', filename: file.filename)
+    redirect_back fallback_location: root_path, notice: t('download_files.download_file_deleted_successfully', filename: file.filename)
   end
 
 end

--- a/application/app/controllers/file_browser_controller.rb
+++ b/application/app/controllers/file_browser_controller.rb
@@ -5,7 +5,7 @@ class FileBrowserController < ApplicationController
     path = safe_path(params[:path])
 
     if path.nil?
-      render json: { error: t(".directory_forbidden") }, status: :forbidden
+      render json: { error: t('file_browser.directory_forbidden') }, status: :forbidden
       return
     end
 

--- a/application/config/i18n-tasks.yml
+++ b/application/config/i18n-tasks.yml
@@ -1,0 +1,9 @@
+base_locale: en
+data:
+  read:
+    - config/locales/**/*.yml
+search:
+  paths:
+    - app
+ignore_unused:
+  - 'js.*'

--- a/application/config/locales/connectors/dataverse/en.yml
+++ b/application/config/locales/connectors/dataverse/en.yml
@@ -25,16 +25,10 @@ en:
         link_collection_title: "Open Dataverse collection: %{name}"
         link_dataset_title: "Open Dataverse dataset: %{name}"
       upload_bundle_actions_bar:
-        button_edit_dataset_title: "Edit Dataset"
-        modal_edit_dataset_title: "Edit Dataset"
         button_select_collection_title: "Select Collection"
         modal_select_collection_title: "Select Dataverse Collection"
         button_dataset_form_tabs_title: "Select/Create Dataset"
         modal_dataset_form_tabs_title: "Select/Create %{collection} Dataset"
-        button_create_dataset_title: "Create Dataset"
-        modal_create_dataset_title: "Create Dataset"
-        button_select_dataset_title: "Select Dataset"
-        modal_select_dataset_title: "Select Dataset"
         button_edit_key_title: "Add/Edit API Token"
         modal_edit_key_title: "Add/Edit Dataverse API Token"
         missing_key_disabled_features_text: "Add key to enable Collection/Dataset features"
@@ -94,9 +88,6 @@ en:
       collection_info:
         button_toggle_label: "Collection details"
         header_dataverse_text: "Dataverse collection"
-        link_open_collection_title: "Open collection on Dataverse"
-        button_create_bundle_label: "Create Collection Bundle"
-        button_create_bundle_title: "Create Collection Bundle"
       collection_actions:
         actions_bar_title_a11y_label: "Collection actions bar"
         button_create_bundle_label: "Create Collection Bundle"
@@ -116,7 +107,6 @@ en:
         unnamed_dataverse_text: "Unnamed Dataverse"
       search_bar:
         button_submit_text: "Search Inside"
-        field_search_label: "Search items within the collection"
         field_search_placeholder: "Search items within the collection"
       search_items:
         content_no_items_found_text: "No items found."
@@ -143,17 +133,11 @@ en:
         table_dataset_files_caption: "Dataset files"
       dataset_info:
         button_toggle_label: "Dataset details"
-        button_versions_toggle_label: "Dataset versions"
         field_authors_text: "Authors:"
         field_license_text: "License:"
         field_publication_date_text: "Publication date:"
         field_subjects_text: "Subjects:"
         header_dataset_text: "Dataset"
-        header_description_text: "Description"
-        header_dataset_metadata_text: "Dataset Metadata"
-        link_open_dataset_title: "Open dataset on Dataverse"
-        button_create_bundle_label: "Create Collection Bundle"
-        button_create_bundle_title: "Create Collection Bundle"
       versions:
         message_missing_api_key_text: "<strong>Draft versions are restricted.</strong> Add an API token in repository settings to access draft content when available."
         field_version_label: "Dataset version: %{version}"
@@ -170,7 +154,6 @@ en:
         button_open_project_label: "Open selected project"
       search_bar:
         button_submit_text: "Search Files"
-        field_search_label: "Search files within the dataset"
         field_search_placeholder: "Search files within the dataset"
       show:
         page_title: "OnDemand Loop - Dataverse Dataset"
@@ -185,7 +168,6 @@ en:
         paginator_page_text: "page %{page}"
         msg_no_items_text: "No items found."
       index:
-        breadcrumb_dataverse_title: "Dataverse landing page"
         breadcrumb_home_text: "Home"
         breadcrumb_home_title: "Home"
         image_dataverse_icon_alt: "Dataverse icon"

--- a/application/config/locales/connectors/zenodo/en.yml
+++ b/application/config/locales/connectors/zenodo/en.yml
@@ -32,12 +32,9 @@ en:
         submit: "Save Changes"
         cancel: "Cancel"
       upload_bundle_actions_bar:
-        button_select_deposition_title: "Select Deposition"
-        modal_select_deposition_title: "Select Zenodo deposition"
         button_deposition_fetch_label: "Fetch Deposition"
         button_deposition_fetch_title: "Fetch Zenodo deposition metadata"
         button_create_draft_title: "Create Draft"
-        modal_create_draft_title: "Create Draft"
         button_edit_key_title: "Add/Edit Access Token"
         modal_edit_key_title: "Add/Edit Zenodo Personal Access Token"
         missing_key_disabled_features_text: "Add access token to enable deposition features"
@@ -71,16 +68,13 @@ en:
           table_record_files_caption: "Record files"
 
   zenodo:
+    depositions:
+      show:
+        page_title: "OnDemand Loop - Zenodo Deposition"
     records:
       show:
         page_title: "OnDemand Loop - Zenodo Records"
         caption_files_text: "Zenodo record files (%{count})"
-        checkbox_select_all_label: "Select all files"
-        column_record_filename_text: "File"
-        column_record_size_text: "Size"
-        button_submit_text: "Add Files to Active Project"
-        label_publication_date_text: "Publication date:"
-        label_files_text: "Files:"
     landing_page:
       index:
         page_title: "OnDemand Loop - Zenodo"

--- a/application/config/locales/controllers/en.yml
+++ b/application/config/locales/controllers/en.yml
@@ -1,7 +1,6 @@
 ---
 en:
   download_files:
-    compulsory_fields_error: "project_id and id are compulsory"
     file_not_found_for_project: "File: %{file_id} not found for project: %{project_id}"
     file_in_progress: "File: %{filename} cannot be deleted while is being downloaded"
     download_file_deleted_successfully: "Download file deleted: %{filename}"
@@ -34,7 +33,6 @@ en:
       message_success: "Repository added: %{url} type: %{type}"
     update:
       message_not_found: "Repository %{domain} not found"
-      message_success: "Repository %{domain} updated"
     destroy:
       message_not_found: "Repository %{domain} not found"
       message_deleted: "Repository %{domain} (%{type}) deleted"
@@ -59,12 +57,12 @@ en:
       file_in_progress: "File: %{filename} cannot be deleted while is being uploaded"
       upload_file_removed: "Upload file removed from bundle: %{filename}"
     cancel:
-      compulsory_fields_error: "project_id and file_id are compulsory"
       file_not_found: "file not found project_id=%{project_id} upload_bundle_id=%{upload_bundle_id} id=%{file_id}"
   explore:
     show:
       message_invalid_repo_url: "Invalid repository URL: %{repo_url}"
       message_processor_error: "Error processing request for repository: %{connector_type} type: %{object_type} with id: %{object_id}"
+      message_success: "Explore request processed successfully"
     create:
       message_invalid_repo_url: "Invalid repository URL: %{repo_url}"
       message_processor_error: "Error processing request for repository: %{connector_type} type: %{object_type} with id: %{object_id}"

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -15,7 +15,6 @@ en:
       button_cancel_download_a11y_text: "Cancel download of %{filename}"
       button_cancel_download_title: "Cancel download"
       field_creation_date_title: "Creation date"
-      header_scheduled_downloads_text: "Scheduled Downloads"
       field_project_title: "Project: %{name}"
       field_file_title: "Download file: %{filename}"
     index:
@@ -120,8 +119,6 @@ en:
         button_open_project_folder_label: "Open Project workspace folder"
         button_open_project_folder_title: "Open Project workspace folder"
         button_open_project_metadata_title: "Open Project metadata folder"
-        button_edit_download_dir_title: "Change Project folder"
-        button_edit_download_dir_label: "Change folder"
         field_creation_date_title: "Creation date"
         modal_delete_confirmation_title: "Delete Project"
         modal_delete_confirmation_content: "This will remove the project from the app. Files on disk and in remote repositories will remain untouched."
@@ -149,20 +146,6 @@ en:
         modal_delete_confirmation_content: "This will remove the file from the upload bundle. The file will remain on disk and in the remote repository if already uploaded."
       breadcrumbs_text: "Projects"
       page_title: "OnDemand Loop - Project detail"
-    download_files:
-      schedule_date: "Schedule date"
-      repository_files: "Repository Files"
-      completion_date: "Completion date"
-      download_start_date: "Download start date"
-      delete_file: "Delete file"
-    project:
-      download_files: "Download Files"
-    upload_bundle:
-      schedule_date: "Schedule date"
-      repository_files: "Repository Files"
-      completion_date: "Completion date"
-      upload_start_date: "Upload start date"
-      delete_file: "Delete file"
     index:
       actions:
         actions_bar_title: "Projects"
@@ -254,7 +237,6 @@ en:
       actions_bar_title_a11y_label: "Uploads actions bar"
       button_reload_title: "Reload"
     files:
-      badge_repo_tooltip: "External dataset"
       button_browse_file_a11y_text: "Browse file %{filename}"
       button_browse_file_title: "Browse file"
       button_cancel_upload_a11y_text: "Cancel upload of %{filename}"

--- a/scripts/loop_test.sh
+++ b/scripts/loop_test.sh
@@ -4,5 +4,7 @@ bundle config path --local vendor/bundle
 bundle config set build.nokogiri --use-system-libraries
 bundle config set force_ruby_platform true
 bundle install
+bundle exec i18n-tasks missing
+bundle exec i18n-tasks unused
 env RAILS_ENV=test bundle exec rails assets:precompile
 env RAILS_ENV=test bundle exec rake test


### PR DESCRIPTION
## Summary
- add i18n-tasks gem and configuration
- remove unused translation keys and add missing ones
- run i18n checks in test script

## Testing
- `bundle exec i18n-tasks missing`
- `bundle exec i18n-tasks unused`
- `env RAILS_ENV=test bundle exec rails assets:precompile`
- `env RAILS_ENV=test bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_6893b0222a0883219cf4f0abed73abb6