### PR TITLE
Restrict RepoUrl parsing to HTTP/HTTPS schemes

### DIFF
--- a/application/app/services/repo/repo_url.rb
+++ b/application/app/services/repo/repo_url.rb
@@ -10,10 +10,9 @@ module Repo
       return nil if url.blank?
 
       uri = Addressable::URI.parse(url)
-      unless uri.scheme
-        uri = Addressable::URI.parse("https://#{url}")
-      end
+      scheme = uri.scheme&.downcase
 
+      return nil unless scheme && %w[http https].include?(scheme)
       return nil unless uri.host
 
       new(uri)
@@ -24,15 +23,13 @@ module Repo
     def self.build(domain, scheme: nil, port: nil)
       return nil if domain.blank?
 
-      scheme = 'https' if scheme.blank?
-
       uri = Addressable::URI.new(
-        scheme: scheme,
+        scheme: scheme.presence&.downcase || 'https',
         host: domain,
         port: port
       )
 
-      new(uri)
+      parse(uri.to_s)
     end
 
     private_class_method :new

--- a/application/test/services/repo/repo_url_test.rb
+++ b/application/test/services/repo/repo_url_test.rb
@@ -66,18 +66,7 @@ class Repo::RepoUrlTest < ActiveSupport::TestCase
     assert_equal [], parser.path_segments
   end
 
-  test 'should handle URL with domain and no protocol' do
-    url = 'www.example.com'
-    parser = Repo::RepoUrl.parse(url)
 
-    assert parser
-    assert_equal 'https', parser.scheme
-    assert_equal 'www.example.com', parser.domain
-    assert_nil parser.port
-    assert_equal '/', parser.path
-    assert_equal({}, parser.params)
-    assert_equal [], parser.path_segments
-  end
 
   test 'path should default to /' do
     assert_equal '/', Repo::RepoUrl.parse('https://example.com').path
@@ -101,9 +90,20 @@ class Repo::RepoUrlTest < ActiveSupport::TestCase
     assert_nil Repo::RepoUrl.parse(nil)
   end
 
-  test 'should return nil for invalid URL' do
-    assert_nil Repo::RepoUrl.parse('not a url')
-    assert_nil Repo::RepoUrl.parse('123://bad')
+  test 'should return nil for invalid or unsupported URLs' do
+    invalid_urls = [
+      'not a url',
+      '123://bad',
+      'www.server.com',
+      'doi:10.1234/DVTest',
+      'ftp://server.com',
+      'hdl:11272.1/AB2/NXRVP9',
+      'localhost:8080'
+    ]
+
+    invalid_urls.each do |url|
+      assert_nil Repo::RepoUrl.parse(url), "Expected nil for #{url}"
+    end
   end
 
   test 'build should default to https scheme' do


### PR DESCRIPTION
## Summary
- require a scheme and restrict RepoUrl parsing/building to HTTP or HTTPS
- delegate RepoUrl.build to RepoUrl.parse to reuse validation logic
- test that URLs without a valid HTTP(S) scheme return nil

## Testing
- `bundle install`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_689502e212a083218a06a9ddfd3f4dee