### PR TITLE
Avoid redundant DOI resolution when object URL exists

### DIFF
--- a/application/app/services/repo/resolvers/doi_resolver.rb
+++ b/application/app/services/repo/resolvers/doi_resolver.rb
@@ -17,6 +17,8 @@ module Repo
       end
 
       def resolve(context)
+        return if context.object_url
+
         if context.parsed_input.nil?
           doi_url = URI.parse(File.join(@api_url, context.input)).to_s
           object_url = check_url(context, doi_url)

--- a/application/test/services/repo/resolvers/doi_resolver_test.rb
+++ b/application/test/services/repo/resolvers/doi_resolver_test.rb
@@ -27,4 +27,32 @@ class Repo::Resolvers::DoiResolverTest < ActiveSupport::TestCase
     @resolver.resolve(context)
     assert_nil context.object_url
   end
+
+  test 'resolve returns when object_url already set' do
+    client = HttpClientMock.new(file_path: fixture_path('downloads/basic_http/sample_utf8.txt'))
+    context = Repo::RepoResolverContext.new('doi:10.123/abc', http_client: client)
+    context.object_url = 'https://already.com'
+    @resolver.resolve(context)
+    assert_equal 'https://already.com', context.object_url
+    refute client.called?
+  end
+
+  test 'resolve handles doi.org urls directly' do
+    client = HttpClientMock.new(file_path: fixture_path('downloads/basic_http/sample_utf8.txt'),
+                                status_code: 302,
+                                headers: { 'location' => 'https://example.com' })
+    context = Repo::RepoResolverContext.new('https://doi.org/10.123/abc', http_client: client)
+    @resolver.resolve(context)
+    assert_equal 'https://example.com', context.object_url
+    assert_equal 'https://doi.org/10.123/abc', client.called_path
+  end
+
+  test 'resolve sets object_url to input for non doi urls' do
+    client = HttpClientMock.new(file_path: fixture_path('downloads/basic_http/sample_utf8.txt'))
+    url = 'https://example.org/resource'
+    context = Repo::RepoResolverContext.new(url, http_client: client)
+    @resolver.resolve(context)
+    assert_equal url, context.object_url
+    refute client.called?
+  end
 end


### PR DESCRIPTION
## Summary
- Skip resolution in `Repo::Resolvers::DoiResolver` when `context.object_url` is already set
- Broaden DoiResolver test coverage for existing URLs, doi.org inputs, and non-DOI URLs

## Testing
- `bundle exec rails test test/services/repo/resolvers/doi_resolver_test.rb`


------
https://chatgpt.com/codex/tasks/task_e_689513b75e48832185c3c8249268af5f