### PR TITLE
Add DomainResolver for domain-based URL detection

### DIFF
--- a/application/app/services/repo/resolvers/domain_resolver.rb
+++ b/application/app/services/repo/resolvers/domain_resolver.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'resolv'
+
+module Repo
+  module Resolvers
+    class DomainResolver < Repo::BaseResolver
+      include LoggingCommon
+
+      def self.build
+        new
+      end
+
+      # Highest priority so it runs before other resolvers
+      def priority
+        100_000
+      end
+
+      def resolve(context)
+        return unless context.parsed_input.nil?
+
+        parsed = RepoUrl.parse("https://#{context.input}")
+        host = parsed&.domain
+
+        return unless resolvable_domain?(host)
+
+        context.object_url = parsed.to_s
+      end
+
+      private
+
+      def resolvable_domain?(host)
+        return false if host.blank?
+        Resolv.getaddress(host)
+        true
+      rescue Resolv::ResolvError
+        false
+      end
+    end
+  end
+end

--- a/application/test/services/repo/resolvers/domain_resolver_test.rb
+++ b/application/test/services/repo/resolvers/domain_resolver_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class Repo::Resolvers::DomainResolverTest < ActiveSupport::TestCase
+  include LoggingCommonMock
+
+  def setup
+    @resolver = Repo::Resolvers::DomainResolver.new
+  end
+
+  test 'priority is highest' do
+    assert_equal 100000, @resolver.priority
+  end
+
+  test 'resolve sets object_url when parsed_input nil and domain resolves' do
+    context = Repo::RepoResolverContext.new('example.com')
+    context.stubs(:parsed_input).returns(nil)
+    @resolver.stubs(:resolvable_domain?).returns(true)
+    @resolver.resolve(context)
+    assert_equal 'https://example.com/', context.object_url
+  end
+
+  test 'resolve sets object_url for localhost and docker hosts with ports' do
+    @resolver.stubs(:resolvable_domain?).returns(true)
+    ['localhost:8080', 'host.docker.internal:8000'].each do |input|
+      context = Repo::RepoResolverContext.new(input)
+      context.stubs(:parsed_input).returns(nil)
+      @resolver.resolve(context)
+      assert_equal "https://#{input}/", context.object_url
+    end
+  end
+
+  test 'resolve does nothing when parsed_input present' do
+    context = Repo::RepoResolverContext.new('https://example.com')
+    @resolver.stubs(:resolvable_domain?).returns(true)
+    @resolver.resolve(context)
+    assert_nil context.object_url
+  end
+
+  test 'resolve does not set object_url for unresolvable domain' do
+    context = Repo::RepoResolverContext.new('notadomain.localxyz')
+    context.stubs(:parsed_input).returns(nil)
+    @resolver.stubs(:resolvable_domain?).returns(false)
+    @resolver.resolve(context)
+    assert_nil context.object_url
+  end
+end


### PR DESCRIPTION
## Summary
- rename StringResolver to DomainResolver and guard against inputs that already include a scheme
- keep object_url assignment for resolvable bare hosts like `localhost` or `host.docker.internal`
- streamline tests by removing manual parsed_input state

## Testing
- `bundle install`
- `bundle exec rails test test/services/repo/resolvers/domain_resolver_test.rb`


------
https://chatgpt.com/codex/tasks/task_e_689508acad848321b87c53bf2fddea3c