### PR TITLE
Add Repo cache resolver

### DIFF
--- a/application/app/services/repo/resolvers/cache_resolver.rb
+++ b/application/app/services/repo/resolvers/cache_resolver.rb
@@ -1,0 +1,31 @@
+module Repo
+  module Resolvers
+    class CacheResolver < Repo::BaseResolver
+      include LoggingCommon
+
+      def self.build
+        new
+      end
+
+      def priority
+        98_000
+      end
+
+      def resolve(context)
+        return unless context.object_url
+
+        repo_url = Repo::RepoUrl.parse(context.object_url)
+        return unless repo_url
+
+        repo_base_url = repo_url.server_url
+
+        log_info('Checking RepoCache', { repo_url: repo_base_url })
+        repo_info = context.repo_db.get(repo_base_url)
+        if repo_info
+          log_info('RepoCache hit', { repo_url: repo_base_url, type: repo_info.type })
+          context.type = repo_info.type
+        end
+      end
+    end
+  end
+end

--- a/application/app/services/repo/resolvers/dataverse_resolver.rb
+++ b/application/app/services/repo/resolvers/dataverse_resolver.rb
@@ -22,13 +22,6 @@ module Repo
         return unless domain
         repo_base_url = repo_url.dataverse_url
 
-        log_info('Checking RepoCache', {repo_url: repo_base_url})
-        repo_info = context.repo_db.get(repo_base_url)
-        if repo_info
-          context.type = repo_info.type
-          return
-        end
-
         log_info('Checking Dataverse API', {dataverse_url: repo_url.dataverse_url})
         version = responds_to_api?(context.http_client, repo_url)
         if version

--- a/application/app/services/repo/resolvers/zenodo_resolver.rb
+++ b/application/app/services/repo/resolvers/zenodo_resolver.rb
@@ -24,13 +24,6 @@ module Repo
         return unless domain
         repo_base_url = repo_url.zenodo_url
 
-        log_info('Checking RepoCache', { repo_url: repo_base_url })
-        repo_info = context.repo_db.get(repo_base_url)
-        if repo_info
-          context.type = repo_info.type
-          return
-        end
-
         log_info('Checking Zenodo API', { zenodo_url: repo_url.zenodo_url })
         responds = responds_to_api?(context.http_client, repo_url)
         if responds

--- a/application/test/services/repo/resolvers/cache_resolver_test.rb
+++ b/application/test/services/repo/resolvers/cache_resolver_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class Repo::Resolvers::CacheResolverTest < ActiveSupport::TestCase
+  include LoggingCommonMock
+
+  def setup
+    @repo_db_temp = Tempfile.new('repo_db')
+    @repo_db = Repo::RepoDb.new(db_path: @repo_db_temp.path)
+  end
+
+  def teardown
+    @repo_db_temp.unlink
+  end
+
+  test 'resolve sets type from cache when entry exists' do
+    @repo_db.set('https://zenodo.org', type: ConnectorType::ZENODO, metadata: {})
+
+    resolver = Repo::Resolvers::CacheResolver.new
+    context = Repo::RepoResolverContext.new('https://zenodo.org/records/123', repo_db: @repo_db)
+    context.object_url = 'https://zenodo.org/records/123'
+
+    resolver.resolve(context)
+
+    assert_equal ConnectorType::ZENODO, context.type
+  end
+
+  test 'resolve leaves type nil when cache miss' do
+    resolver = Repo::Resolvers::CacheResolver.new
+    context = Repo::RepoResolverContext.new('https://unknown.org/records/123', repo_db: @repo_db)
+    context.object_url = 'https://unknown.org/records/123'
+
+    resolver.resolve(context)
+
+    assert_nil context.type
+  end
+end

--- a/application/test/services/repo/resolvers/dataverse_resolver_test.rb
+++ b/application/test/services/repo/resolvers/dataverse_resolver_test.rb
@@ -12,20 +12,6 @@ class Repo::Resolvers::DataverseResolverTest < ActiveSupport::TestCase
     @repo_db_temp.unlink
   end
 
-  test 'resolve returns cached entry without api call' do
-    @repo_db.set('https://dv.org', type: ConnectorType::DATAVERSE, metadata: { api_version: '5.0' })
-    http_client = mock('client')
-    http_client.expects(:get).never
-
-    resolver = Repo::Resolvers::DataverseResolver.new
-
-    context = Repo::RepoResolverContext.new('https://dv.org/dataverse', http_client: http_client, repo_db: @repo_db)
-    context.object_url = 'https://dv.org/dataverse'
-    resolver.resolve(context)
-
-    assert_equal ConnectorType::DATAVERSE, context.type
-  end
-
   test 'resolve falls back to API when domain unknown' do
     body = { data: { version: '1.0' } }.to_json
     response = stub(success?: true, json: JSON.parse(body))

--- a/application/test/services/repo/resolvers/zenodo_resolver_test.rb
+++ b/application/test/services/repo/resolvers/zenodo_resolver_test.rb
@@ -13,20 +13,6 @@ class Repo::Resolvers::ZenodoResolverTest < ActiveSupport::TestCase
     @repo_db_temp.unlink
   end
 
-  test 'resolve returns cached entry without api call' do
-    @repo_db.set('https://zenodo.org', type: ConnectorType::ZENODO, metadata: {})
-    http_client = mock('client')
-    http_client.expects(:get).never
-
-    resolver = Repo::Resolvers::ZenodoResolver.new
-    context = Repo::RepoResolverContext.new('https://zenodo.org/records/123', http_client: http_client, repo_db: @repo_db)
-    context.object_url = 'https://zenodo.org/records/123'
-
-    resolver.resolve(context)
-
-    assert_equal ConnectorType::ZENODO, context.type
-  end
-
   test 'resolve falls back to API when domain unknown and detects Zenodo' do
     body = { 'hits' => { 'total' => 1, 'hits' => [] } }.to_json
     response = stub(success?: true, json: JSON.parse(body))


### PR DESCRIPTION
## Summary
- add `CacheResolver` to resolve repository type from existing RepoDb entries
- remove redundant cache lookup from `DataverseResolver` and `ZenodoResolver`
- test cache resolver and update resolver specs

## Testing
- `bundle exec rails test -v`


------
https://chatgpt.com/codex/tasks/task_e_6895ae03fb388321bfb3d1fe9340bd8d