### PR TITLE
Add params_schema to Zenodo and Dataverse handlers

### DIFF
--- a/application/app/connectors/dataverse/handlers/collection_select.rb
+++ b/application/app/connectors/dataverse/handlers/collection_select.rb
@@ -6,6 +6,12 @@ module Dataverse::Handlers
       @object_id = object_id
     end
 
+    def params_schema
+      [
+        :collection_id
+      ]
+    end
+
     def edit(upload_bundle, request_params)
       user_collections_response = collections(upload_bundle)
       log_info('Collection select edit', { upload_bundle: upload_bundle.id, collections: user_collections_response.items.size })

--- a/application/app/connectors/dataverse/handlers/collections.rb
+++ b/application/app/connectors/dataverse/handlers/collections.rb
@@ -6,6 +6,14 @@ module Dataverse::Handlers
       @collection_id = object_id
     end
 
+    def params_schema
+      [
+        :repo_url,
+        :page,
+        :query
+      ]
+    end
+
     def show(request_params)
       dataverse_url = request_params[:repo_url].server_url
       page = request_params[:page] ? request_params[:page].to_i : 1
@@ -47,3 +55,4 @@ module Dataverse::Handlers
     end
   end
 end
+

--- a/application/app/connectors/dataverse/handlers/connector_edit.rb
+++ b/application/app/connectors/dataverse/handlers/connector_edit.rb
@@ -6,6 +6,13 @@ module Dataverse::Handlers
       @object_id = object_id
     end
 
+    def params_schema
+      [
+        :api_key,
+        :key_scope
+      ]
+    end
+
     def edit(upload_bundle, request_params)
       ConnectorResult.new(
         template: '/connectors/dataverse/connector_edit_form',

--- a/application/app/connectors/dataverse/handlers/dataset_create.rb
+++ b/application/app/connectors/dataverse/handlers/dataset_create.rb
@@ -6,6 +6,16 @@ module Dataverse::Handlers
       @object_id = object_id
     end
 
+    def params_schema
+      [
+        :title,
+        :author,
+        :description,
+        :contact_email,
+        :subject
+      ]
+    end
+
     def edit(upload_bundle, request_params)
       raise NotImplementedError, 'Only update is supported for DatasetCreate'
     end

--- a/application/app/connectors/dataverse/handlers/dataset_form_tabs.rb
+++ b/application/app/connectors/dataverse/handlers/dataset_form_tabs.rb
@@ -6,6 +6,10 @@ module Dataverse::Handlers
       @object_id = object_id
     end
 
+    def params_schema
+      []
+    end
+
     def edit(upload_bundle, request_params)
       datasets = datasets(upload_bundle)
       subjects = subjects(upload_bundle)

--- a/application/app/connectors/dataverse/handlers/dataset_select.rb
+++ b/application/app/connectors/dataverse/handlers/dataset_select.rb
@@ -6,6 +6,12 @@ module Dataverse::Handlers
       @object_id = object_id
     end
 
+    def params_schema
+      [
+        :dataset_id
+      ]
+    end
+
     def edit(upload_bundle, request_params)
       raise NotImplementedError, 'Only update is supported for DatasetSelect'
     end

--- a/application/app/connectors/dataverse/handlers/dataset_versions.rb
+++ b/application/app/connectors/dataverse/handlers/dataset_versions.rb
@@ -6,6 +6,12 @@ module Dataverse::Handlers
       @persistent_id = object_id
     end
 
+    def params_schema
+      [
+        :repo_url
+      ]
+    end
+
     def show(request_params)
       repo_url = request_params[:repo_url]
       dataverse_url = repo_url.server_url
@@ -26,3 +32,4 @@ module Dataverse::Handlers
     end
   end
 end
+

--- a/application/app/connectors/dataverse/handlers/datasets.rb
+++ b/application/app/connectors/dataverse/handlers/datasets.rb
@@ -6,6 +6,17 @@ module Dataverse::Handlers
       @persistent_id = object_id
     end
 
+    def params_schema
+      [
+        :repo_url,
+        :version,
+        :page,
+        :query,
+        :project_id,
+        { file_ids: [] }
+      ]
+    end
+
     def show(request_params)
       repo_url = request_params[:repo_url]
       dataverse_url = repo_url.server_url
@@ -116,3 +127,4 @@ module Dataverse::Handlers
     end
   end
 end
+

--- a/application/app/connectors/dataverse/handlers/landing.rb
+++ b/application/app/connectors/dataverse/handlers/landing.rb
@@ -6,6 +6,13 @@ module Dataverse::Handlers
       @object_id = object_id
     end
 
+    def params_schema
+      [
+        :page,
+        :query
+      ]
+    end
+
     def show(request_params)
       begin
         hub_registry = DataverseHubRegistry.registry
@@ -28,3 +35,4 @@ module Dataverse::Handlers
     end
   end
 end
+

--- a/application/app/connectors/dataverse/handlers/upload_bundle_create.rb
+++ b/application/app/connectors/dataverse/handlers/upload_bundle_create.rb
@@ -8,6 +8,12 @@ module Dataverse::Handlers
       @object_id = object_id
     end
 
+    def params_schema
+      [
+        :object_url
+      ]
+    end
+
     def create(project, request_params)
       remote_repo_url = request_params[:object_url]
       url_data = Dataverse::DataverseUrl.parse(remote_repo_url)

--- a/application/app/connectors/zenodo/handlers/connector_edit.rb
+++ b/application/app/connectors/zenodo/handlers/connector_edit.rb
@@ -6,6 +6,13 @@ module Zenodo::Handlers
       @object_id = object_id
     end
 
+    def params_schema
+      [
+        :api_key,
+        :key_scope
+      ]
+    end
+
     def edit(upload_bundle, request_params)
       ConnectorResult.new(
         template: '/connectors/zenodo/connector_edit_form',

--- a/application/app/connectors/zenodo/handlers/deposition_fetch.rb
+++ b/application/app/connectors/zenodo/handlers/deposition_fetch.rb
@@ -8,6 +8,10 @@ module Zenodo::Handlers
       @object_id = object_id
     end
 
+    def params_schema
+      []
+    end
+
     def edit(upload_bundle, request_params)
       raise NotImplementedError, 'Only update is supported for DepositionFetch'
     end

--- a/application/app/connectors/zenodo/handlers/depositions.rb
+++ b/application/app/connectors/zenodo/handlers/depositions.rb
@@ -6,6 +6,14 @@ module Zenodo::Handlers
       @deposition_id = object_id
     end
 
+    def params_schema
+      [
+        :repo_url,
+        :project_id,
+        { file_ids: [] }
+      ]
+    end
+
     def show(request_params)
       repo_url = request_params[:repo_url]
       repo_info = RepoRegistry.repo_db.get(repo_url.server_url)
@@ -80,3 +88,4 @@ module Zenodo::Handlers
     end
   end
 end
+

--- a/application/app/connectors/zenodo/handlers/landing.rb
+++ b/application/app/connectors/zenodo/handlers/landing.rb
@@ -6,6 +6,14 @@ module Zenodo::Handlers
       @object_id = object_id
     end
 
+    def params_schema
+      [
+        :query,
+        :page,
+        :repo_url
+      ]
+    end
+
     def show(request_params)
       query = request_params[:query]
       page = request_params[:page]&.to_i || 1
@@ -26,3 +34,4 @@ module Zenodo::Handlers
     end
   end
 end
+

--- a/application/app/connectors/zenodo/handlers/records.rb
+++ b/application/app/connectors/zenodo/handlers/records.rb
@@ -6,6 +6,14 @@ module Zenodo::Handlers
       @record_id = object_id
     end
 
+    def params_schema
+      [
+        :repo_url,
+        :project_id,
+        { file_ids: [] }
+      ]
+    end
+
     def show(request_params)
       repo_url = request_params[:repo_url]
       log_info('Record show', { record_id: @record_id, repo_url: repo_url })
@@ -67,3 +75,4 @@ module Zenodo::Handlers
     end
   end
 end
+

--- a/application/app/connectors/zenodo/handlers/upload_bundle_create.rb
+++ b/application/app/connectors/zenodo/handlers/upload_bundle_create.rb
@@ -8,6 +8,12 @@ module Zenodo::Handlers
       @object_id = object_id
     end
 
+    def params_schema
+      [
+        :object_url
+      ]
+    end
+
     def create(project, request_params)
       remote_repo_url = request_params[:object_url]
       url_data = Zenodo::ZenodoUrl.parse(remote_repo_url)

--- a/application/test/connectors/dataverse/handlers/collection_select_test.rb
+++ b/application/test/connectors/dataverse/handlers/collection_select_test.rb
@@ -10,6 +10,10 @@ class Dataverse::Handlers::CollectionSelectTest < ActiveSupport::TestCase
     @action = Dataverse::Handlers::CollectionSelect.new
   end
 
+  test 'params schema includes expected keys' do
+    assert_includes @action.params_schema, :collection_id
+  end
+
   test 'edit returns form' do
     json = { success: true, data: { items: [], total_count: 0 } }.to_json
     response = Dataverse::MyDataverseCollectionsResponse.new(json)

--- a/application/test/connectors/dataverse/handlers/collections_test.rb
+++ b/application/test/connectors/dataverse/handlers/collections_test.rb
@@ -10,6 +10,12 @@ class Dataverse::Handlers::CollectionsTest < ActiveSupport::TestCase
     @search_response = Dataverse::SearchResponse.new(search_json, 1, 20)
   end
 
+  test 'params schema includes expected keys' do
+    assert_includes @explorer.params_schema, :repo_url
+    assert_includes @explorer.params_schema, :page
+    assert_includes @explorer.params_schema, :query
+  end
+
   test 'show returns collection and search results' do
     service = mock('service')
     Dataverse::CollectionService.expects(:new).with(@repo_url.server_url).returns(service)

--- a/application/test/connectors/dataverse/handlers/connector_edit_test.rb
+++ b/application/test/connectors/dataverse/handlers/connector_edit_test.rb
@@ -8,6 +8,11 @@ class Dataverse::Handlers::ConnectorEditTest < ActiveSupport::TestCase
     @action = Dataverse::Handlers::ConnectorEdit.new
   end
 
+  test 'params schema includes expected keys' do
+    assert_includes @action.params_schema, :api_key
+    assert_includes @action.params_schema, :key_scope
+  end
+
   test 'edit returns connector edit form' do
     result = @action.edit(@bundle, {})
     assert_equal '/connectors/dataverse/connector_edit_form', result.template

--- a/application/test/connectors/dataverse/handlers/dataset_create_test.rb
+++ b/application/test/connectors/dataverse/handlers/dataset_create_test.rb
@@ -10,6 +10,12 @@ class Dataverse::Handlers::DatasetCreateTest < ActiveSupport::TestCase
     @action = Dataverse::Handlers::DatasetCreate.new
   end
 
+  test 'params schema includes expected keys' do
+    [:title, :author, :description, :contact_email, :subject].each do |key|
+      assert_includes @action.params_schema, key
+    end
+  end
+
   test 'edit not implemented' do
     assert_raises(NotImplementedError) { @action.edit(@bundle, {}) }
   end

--- a/application/test/connectors/dataverse/handlers/dataset_form_tabs_test.rb
+++ b/application/test/connectors/dataverse/handlers/dataset_form_tabs_test.rb
@@ -8,6 +8,10 @@ class Dataverse::Handlers::DatasetFormTabsTest < ActiveSupport::TestCase
     @action = Dataverse::Handlers::DatasetFormTabs.new
   end
 
+  test 'params schema is empty' do
+    assert_empty @action.params_schema
+  end
+
   test 'edit returns tabs form partial' do
     @action.stubs(:datasets).returns(OpenStruct.new(items: []))
     @action.stubs(:subjects).returns([])

--- a/application/test/connectors/dataverse/handlers/dataset_select_test.rb
+++ b/application/test/connectors/dataverse/handlers/dataset_select_test.rb
@@ -10,6 +10,10 @@ class Dataverse::Handlers::DatasetSelectTest < ActiveSupport::TestCase
     @action = Dataverse::Handlers::DatasetSelect.new
   end
 
+  test 'params schema includes expected keys' do
+    assert_includes @action.params_schema, :dataset_id
+  end
+
   test 'edit not implemented' do
     assert_raises(NotImplementedError) { @action.edit(@bundle, {}) }
   end

--- a/application/test/connectors/dataverse/handlers/dataset_versions_test.rb
+++ b/application/test/connectors/dataverse/handlers/dataset_versions_test.rb
@@ -4,8 +4,12 @@ class Dataverse::Handlers::DatasetVersionsTest < ActiveSupport::TestCase
   def setup
     @repo_url = Repo::RepoUrl.parse('https://dataverse.org')
     repo_info = OpenStruct.new(metadata: OpenStruct.new(auth_key: 'key'))
-    RepoRegistry.stubs(:repo_db).returns(mock('db', get: repo_info))
+    RepoRegistry.stubs(:repo_db).returns(stub(get: repo_info))
     @explorer = Dataverse::Handlers::DatasetVersions.new('pid')
+  end
+
+  test 'params schema includes expected keys' do
+    assert_includes @explorer.params_schema, :repo_url
   end
 
   test 'show renders versions list' do

--- a/application/test/connectors/dataverse/handlers/datasets_test.rb
+++ b/application/test/connectors/dataverse/handlers/datasets_test.rb
@@ -4,8 +4,15 @@ class Dataverse::Handlers::DatasetsTest < ActiveSupport::TestCase
   def setup
     @repo_url = Repo::RepoUrl.parse('https://dataverse.org')
     repo_info = OpenStruct.new(metadata: OpenStruct.new(auth_key: 'key'))
-    RepoRegistry.stubs(:repo_db).returns(mock('db', get: repo_info))
+    RepoRegistry.stubs(:repo_db).returns(stub(get: repo_info))
     @explorer = Dataverse::Handlers::Datasets.new('pid')
+  end
+
+  test 'params schema includes expected keys' do
+    [:repo_url, :version, :page, :query, :project_id].each do |key|
+      assert_includes @explorer.params_schema, key
+    end
+    assert @explorer.params_schema.any? { |p| p.is_a?(Hash) && p.key?(:file_ids) }
   end
 
   test 'show renders dataset when found' do

--- a/application/test/connectors/dataverse/handlers/landing_test.rb
+++ b/application/test/connectors/dataverse/handlers/landing_test.rb
@@ -5,6 +5,11 @@ class Dataverse::Handlers::LandingTest < ActiveSupport::TestCase
     @action = Dataverse::Handlers::Landing.new
   end
 
+  test 'params schema includes expected keys' do
+    assert_includes @action.params_schema, :page
+    assert_includes @action.params_schema, :query
+  end
+
   test 'show loads installations' do
     dvs = [
       { id: 'dv-test-01', name: 'DV Test 01', hostname: 'https://dv-01.org' },

--- a/application/test/connectors/dataverse/handlers/upload_bundle_create_test.rb
+++ b/application/test/connectors/dataverse/handlers/upload_bundle_create_test.rb
@@ -8,6 +8,10 @@ class Dataverse::Handlers::UploadBundleCreateTest < ActiveSupport::TestCase
     @action = Dataverse::Handlers::UploadBundleCreate.new
   end
 
+  test 'params schema includes expected keys' do
+    assert_includes @action.params_schema, :object_url
+  end
+
   test 'create handles Dataverse url' do
     Dataverse::CollectionService.stubs(:new).returns(stub(find_collection_by_id: OpenStruct.new(data: OpenStruct.new(name: 'root'))))
     result = @action.create(@project, object_url: 'http://dv.org')

--- a/application/test/connectors/zenodo/handlers/connector_edit_test.rb
+++ b/application/test/connectors/zenodo/handlers/connector_edit_test.rb
@@ -9,6 +9,11 @@ class Zenodo::Handlers::ConnectorEditTest < ActiveSupport::TestCase
     @action = Zenodo::Handlers::ConnectorEdit.new
   end
 
+  test 'params schema includes expected keys' do
+    assert_includes @action.params_schema, :api_key
+    assert_includes @action.params_schema, :key_scope
+  end
+
   test 'edit returns connector form' do
     result = @action.edit(@bundle, {})
     assert_equal '/connectors/zenodo/connector_edit_form', result.template

--- a/application/test/connectors/zenodo/handlers/deposition_fetch_test.rb
+++ b/application/test/connectors/zenodo/handlers/deposition_fetch_test.rb
@@ -11,6 +11,10 @@ class Zenodo::Handlers::DepositionFetchTest < ActiveSupport::TestCase
     @action = Zenodo::Handlers::DepositionFetch.new
   end
 
+  test 'params schema is empty' do
+    assert_empty @action.params_schema
+  end
+
   test 'update fetches deposition and stores data' do
     dep = OpenStruct.new(title: 't', bucket_url: 'b', draft?: false)
     service = mock('service')

--- a/application/test/connectors/zenodo/handlers/depositions_test.rb
+++ b/application/test/connectors/zenodo/handlers/depositions_test.rb
@@ -6,6 +6,12 @@ class Zenodo::Handlers::DepositionsTest < ActiveSupport::TestCase
     @repo_url = OpenStruct.new(server_url: 'https://zenodo.org')
   end
 
+  test 'params schema includes expected keys' do
+    assert_includes @explorer.params_schema, :repo_url
+    assert_includes @explorer.params_schema, :project_id
+    assert @explorer.params_schema.any? { |p| p.is_a?(Hash) && p.key?(:file_ids) }
+  end
+
   test 'show loads deposition using repo db api key' do
     repo_info = OpenStruct.new(metadata: OpenStruct.new(auth_key: 'KEY'))
     RepoRegistry.repo_db.stubs(:get).with('https://zenodo.org').returns(repo_info)

--- a/application/test/connectors/zenodo/handlers/landing_test.rb
+++ b/application/test/connectors/zenodo/handlers/landing_test.rb
@@ -6,6 +6,12 @@ class Zenodo::Handlers::LandingTest < ActiveSupport::TestCase
     @repo_url = OpenStruct.new(server_url: 'https://zenodo.org')
   end
 
+  test 'params schema includes expected keys' do
+    assert_includes @explorer.params_schema, :query
+    assert_includes @explorer.params_schema, :page
+    assert_includes @explorer.params_schema, :repo_url
+  end
+
   test 'show runs search when query present' do
     service = mock('search')
     results = OpenStruct.new(items: [])

--- a/application/test/connectors/zenodo/handlers/records_test.rb
+++ b/application/test/connectors/zenodo/handlers/records_test.rb
@@ -6,6 +6,12 @@ class Zenodo::Handlers::RecordsTest < ActiveSupport::TestCase
     @explorer = Zenodo::Handlers::Records.new('123')
   end
 
+  test 'params schema includes expected keys' do
+    assert_includes @explorer.params_schema, :repo_url
+    assert_includes @explorer.params_schema, :project_id
+    assert @explorer.params_schema.any? { |p| p.is_a?(Hash) && p.key?(:file_ids) }
+  end
+
   test 'show renders record when found' do
     service = mock('service')
     service.expects(:find_record).with('123').returns(:record)

--- a/application/test/connectors/zenodo/handlers/upload_bundle_create_test.rb
+++ b/application/test/connectors/zenodo/handlers/upload_bundle_create_test.rb
@@ -8,6 +8,10 @@ class Zenodo::Handlers::UploadBundleCreateTest < ActiveSupport::TestCase
     @action = Zenodo::Handlers::UploadBundleCreate.new
   end
 
+  test 'params schema includes expected keys' do
+    assert_includes @action.params_schema, :object_url
+  end
+
   test 'url not deposition returns error' do
     result = @action.create(@project, object_url: 'http://example.com')
     refute result.success?


### PR DESCRIPTION
## Summary
- declare `params_schema` for Zenodo connector handlers
- declare `params_schema` for Dataverse connector handlers
- test coverage for new schemas

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6897d7563d448321a863122d165319c9