### PR TITLE
feat: resume HTTP downloads

### DIFF
--- a/application/test/services/download/basic_http_ruby_downloader_test.rb
+++ b/application/test/services/download/basic_http_ruby_downloader_test.rb
@@ -25,6 +25,46 @@ class Download::BasicHttpRubyDownloadTest < ActiveSupport::TestCase
     
   end
 
+  test 'resumes download from existing temp file' do
+    download_file = fixture_path('/downloads/basic_http/sample_utf8.txt')
+    http_mock = HttpMock.new(file_path: download_file)
+
+    Dir.mktmpdir do |dir|
+      download_location = File.join(dir, 'output.txt')
+      temp_location = File.join(dir, 'output.txt.part')
+      original = File.read(download_file)
+      File.open(temp_location, 'wb') { |f| f.write(original[0, 5]) }
+
+      Net::HTTP.expects(:start).yields(http_mock)
+      target = Download::BasicHttpRubyDownloader.new('http://example', download_location, temp_location, headers: {})
+      target.download
+
+      assert File.exist?(download_location)
+      assert target.partial_downloads
+      assert_files_content_equal(download_file, download_location)
+    end
+  end
+
+  test 'server without range support restarts download and marks partial_downloads false' do
+    download_file = fixture_path('/downloads/basic_http/sample_utf8.txt')
+    http_mock = HttpMock.new(file_path: download_file, support_range: false)
+
+    Dir.mktmpdir do |dir|
+      download_location = File.join(dir, 'output.txt')
+      temp_location = File.join(dir, 'output.txt.part')
+      original = File.read(download_file)
+      File.open(temp_location, 'wb') { |f| f.write(original[0, 5]) }
+
+      Net::HTTP.expects(:start).yields(http_mock)
+      target = Download::BasicHttpRubyDownloader.new('http://example', download_location, temp_location, headers: {})
+      target.download
+
+      assert File.exist?(download_location)
+      refute target.partial_downloads
+      assert_files_content_equal(download_file, download_location)
+    end
+  end
+
   test 'follows redirects' do
     file = fixture_path('/downloads/basic_http/sample_utf8.txt')
     first = HttpMock.new(file_path: file, status_code:302, headers:{'location'=>'/next'})


### PR DESCRIPTION
## Summary
- allow `BasicHttpRubyDownloader` to resume downloads by using the temp file's size and HTTP Range requests
- support Range handling in test HttpMock, including ability to disable it
- expose `partial_downloads` flag reflecting server Range support and handle servers that cannot resume
- test resumed download and behavior when server lacks Range support

## Testing
- `bundle exec rake test TEST=test/services/download/basic_http_ruby_downloader_test.rb` *(fails: Could not find rubocop-rails-omakase-1.1.0, rubocop-1.75.2, rubocop-performance-1.25.0, rubocop-rails-2.31.0, rubocop-ast-1.44.1, prism-1.4.0)*
- `bundle exec rake test TEST=test/services/common/http_client_test.rb` *(fails: Could not find rubocop-rails-omakase-1.1.0, rubocop-1.75.2, rubocop-performance-1.25.0, rubocop-rails-2.31.0, rubocop-ast-1.44.1, prism-1.4.0)*
- `bundle exec rake test TEST=test/services/zenodo/zenodo_bucket_http_uploader_test.rb` *(fails: Could not find rubocop-rails-omakase-1.1.0, rubocop-1.75.2, rubocop-performance-1.25.0, rubocop-rails-2.31.0, rubocop-ast-1.44.1, prism-1.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_6899c827ebfc8321ae9c08a9bab0d52a