### PR TITLE
Add Zenodo dataset selection flow

### DIFF
--- a/application/app/connectors/zenodo/handlers/dataset_form_tabs.rb
+++ b/application/app/connectors/zenodo/handlers/dataset_form_tabs.rb
@@ -1,0 +1,36 @@
+module Zenodo::Handlers
+  class DatasetFormTabs
+    include LoggingCommon
+
+    def initialize(object_id = nil)
+      @object_id = object_id
+    end
+
+    def params_schema
+      []
+    end
+
+    def edit(upload_bundle, request_params)
+      depositions = depositions(upload_bundle)
+      log_info('Dataset form tabs', { upload_bundle: upload_bundle.id, depositions: depositions.length })
+
+      ConnectorResult.new(
+        template: '/connectors/zenodo/dataset_form_tabs',
+        locals: { upload_bundle: upload_bundle, depositions: depositions }
+      )
+    end
+
+    def update(upload_bundle, request_params)
+      raise NotImplementedError, 'Only edit is supported for DatasetFormTabs'
+    end
+
+    private
+
+    def depositions(upload_bundle)
+      connector_metadata = upload_bundle.connector_metadata
+      api_key = connector_metadata.api_key.value
+      service = Zenodo::UserService.new(connector_metadata.zenodo_url, api_key: api_key)
+      service.list_depositions
+    end
+  end
+end

--- a/application/app/connectors/zenodo/handlers/dataset_select.rb
+++ b/application/app/connectors/zenodo/handlers/dataset_select.rb
@@ -1,0 +1,54 @@
+module Zenodo::Handlers
+  class DatasetSelect
+    include LoggingCommon
+
+    def initialize(object_id = nil)
+      @object_id = object_id
+    end
+
+    def params_schema
+      [
+        :deposition_id
+      ]
+    end
+
+    def edit(upload_bundle, request_params)
+      raise NotImplementedError, 'Only update is supported for DatasetSelect'
+    end
+
+    def update(upload_bundle, request_params)
+      deposition_id = request_params[:deposition_id]
+      connector_metadata = upload_bundle.connector_metadata
+      api_key = connector_metadata.api_key.value
+      service = Zenodo::DepositionService.new(connector_metadata.zenodo_url, api_key: api_key)
+      deposition = service.find_deposition(deposition_id)
+      return error(I18n.t('connectors.zenodo.handlers.deposition_fetch.message_deposition_not_found', url: upload_bundle.repo_url)) unless deposition
+
+      metadata = upload_bundle.metadata
+      metadata[:deposition_id] = deposition.id
+      metadata[:title] = deposition.title
+      metadata[:bucket_url] = deposition.bucket_url
+      metadata[:draft] = deposition.draft?
+      upload_bundle.update({ metadata: metadata })
+
+      log_info('Dataset selected', { upload_bundle: upload_bundle.id, deposition_id: deposition.id })
+
+      ConnectorResult.new(
+        message: { notice: I18n.t('connectors.zenodo.handlers.dataset_select.message_success', title: deposition.title) },
+        success: true
+      )
+    rescue Zenodo::ApiService::UnauthorizedException => e
+      log_error('Auth error selecting deposition', { upload_bundle: upload_bundle.id, deposition_id: deposition_id }, e)
+      error(I18n.t('connectors.zenodo.handlers.deposition_create.message_auth_error'))
+    end
+
+    private
+
+    def error(message)
+      ConnectorResult.new(
+        message: { alert: message },
+        success: false
+      )
+    end
+  end
+end

--- a/application/app/connectors/zenodo/upload_bundle_connector_processor.rb
+++ b/application/app/connectors/zenodo/upload_bundle_connector_processor.rb
@@ -5,7 +5,7 @@ module Zenodo
     def initialize(object = nil); end
 
     def params_schema
-      %i[remote_repo_url form api_key key_scope title upload_type description creators]
+      %i[remote_repo_url form api_key key_scope title upload_type description creators deposition_id]
     end
 
     def create(project, request_params)
@@ -14,6 +14,8 @@ module Zenodo
 
     def edit(upload_bundle, request_params)
       case request_params[:form].to_s
+      when 'dataset_form_tabs'
+        Zenodo::Handlers::DatasetFormTabs.new.edit(upload_bundle, request_params)
       when 'deposition_create'
         Zenodo::Handlers::DepositionCreate.new.edit(upload_bundle, request_params)
       else
@@ -27,6 +29,10 @@ module Zenodo
         Zenodo::Handlers::DepositionFetch.new.update(upload_bundle, request_params)
       when 'deposition_create'
         Zenodo::Handlers::DepositionCreate.new.update(upload_bundle, request_params)
+      when 'dataset_select'
+        Zenodo::Handlers::DatasetSelect.new.update(upload_bundle, request_params)
+      when 'dataset_form_tabs'
+        Zenodo::Handlers::DatasetFormTabs.new.update(upload_bundle, request_params)
       else
         Zenodo::Handlers::ConnectorEdit.new.update(upload_bundle, request_params)
       end

--- a/application/app/views/connectors/zenodo/_dataset_form_tabs.html.erb
+++ b/application/app/views/connectors/zenodo/_dataset_form_tabs.html.erb
@@ -1,0 +1,28 @@
+<!-- Dataset Form Tabs -->
+<div id="dataset-form-tabs" class="mb-3">
+  <ul class="nav nav-tabs" id="upload-dataset-tabs-<%= upload_bundle.id %>" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link text-secondary active" id="upload-select-dataset-tab" data-bs-toggle="tab"
+              data-bs-target="#tab-upload-select-dataset" type="button" role="tab"
+              aria-controls="project-metadata" aria-selected="true">
+        <i class="bi bi-folder2-open me-1"></i><%= t('connectors.zenodo.dataset_form_tabs.select_dataset') %>
+      </button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link text-secondary" id="upload-create-dataset-tab" data-bs-toggle="tab"
+              data-bs-target="#tab-upload-create-dataset" type="button" role="tab"
+              aria-controls="download-files" aria-selected="false">
+        <i class="bi bi-file-earmark-plus me-1"></i><%= t('connectors.zenodo.dataset_form_tabs.create_dataset') %>
+      </button>
+    </li>
+  </ul>
+</div>
+
+<div class="tab-content">
+  <div id="tab-upload-select-dataset" class="tab-pane fade show active" role="tabpanel" aria-labelledby="upload-select-dataset-tab">
+    <%= render partial: '/connectors/zenodo/dataset_select_form', locals: local_assigns %>
+  </div>
+  <div id="tab-upload-create-dataset" class="tab-pane fade show" role="tabpanel" aria-labelledby="upload-create-dataset-tab">
+    <%= render partial: '/connectors/zenodo/deposition_create_form', locals: local_assigns %>
+  </div>
+</div>

--- a/application/app/views/connectors/zenodo/_dataset_select_form.html.erb
+++ b/application/app/views/connectors/zenodo/_dataset_select_form.html.erb
@@ -1,0 +1,33 @@
+<div data-controller="list-filter">
+<%= form_with url: project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id), method: :put, data: { action: "submit->modal#showSpinner" }, local: true do |f| %>
+  <%= hidden_field_tag :form, 'dataset_select' %>
+  <%= hidden_field_tag :anchor, tab_anchor_for(upload_bundle) %>
+
+  <div class="mb-3">
+    <%= label_tag :search, t('connectors.zenodo.dataset_select_form.search_label'), class: 'form-label fw-bold' %>
+    <%= text_field_tag :search, nil, class: 'form-control', placeholder: t('connectors.zenodo.dataset_select_form.search_placeholder'), data: { action: "input->list-filter#apply" } %>
+  </div>
+
+  <div class="d-flex justify-content-end mb-2 me-2">
+    <small class="text-muted"><%= t('connectors.zenodo.dataset_select_form.total_depositions', total: depositions.length) %></small>
+  </div>
+  <div class="list-group mb-3" data-list-filter-target="list" style="max-height: 50vh; overflow-y: auto;">
+    <% depositions.each do |item| %>
+      <% title = item.dig('metadata', 'title') || item['title'] || 'Untitled' %>
+      <label class="list-group-item list-group-item-action d-flex align-items-center gap-2" data-filter-item>
+        <%= radio_button_tag :deposition_id, item['id'], false, class: 'form-check-input mt-0' %>
+        <span class="text-truncate" style="max-width: 800px;" title="<%= title %>"><%= title %></span>
+      </label>
+    <% end %>
+  </div>
+
+  <div class="d-flex justify-content-end gap-2">
+    <button type="submit" class="btn btn-sm btn-primary">
+      <i class="bi bi-save-fill me-1"></i> <%= t('connectors.zenodo.dataset_select_form.submit') %>
+    </button>
+    <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">
+      <%= t('connectors.zenodo.dataset_select_form.cancel') %>
+    </button>
+  </div>
+<% end %>
+</div>

--- a/application/app/views/connectors/zenodo/_upload_bundle_actions_bar.html.erb
+++ b/application/app/views/connectors/zenodo/_upload_bundle_actions_bar.html.erb
@@ -40,7 +40,7 @@
                   title="<%= t('connectors.zenodo.upload_bundle_actions_bar.button_create_draft_title') %>"
                   data-controller="modal"
                   data-action="click->modal#load"
-                  data-modal-url-value="<%= edit_project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id, form: 'deposition_create') %>"
+                  data-modal-url-value="<%= edit_project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id, form: 'dataset_form_tabs') %>"
                   data-modal-title-value="<%= t('connectors.zenodo.upload_bundle_actions_bar.modal_create_draft_title') %>"
                   data-modal-id-value="global-modal">
             <i class="bi bi-database-add me-1"></i><%= t('connectors.zenodo.upload_bundle_actions_bar.button_create_draft_title') %>

--- a/application/config/locales/connectors/zenodo/en.yml
+++ b/application/config/locales/connectors/zenodo/en.yml
@@ -15,6 +15,8 @@ en:
         deposition_create:
           message_success: "Dataset created: %{id} > %{title}"
           message_auth_error: "Authorization error. A valid Zenodo access token is required to create datasets"
+        dataset_select:
+          message_success: "Dataset selected: %{title}"
         repository_settings_update:
           message_success: "Repository updated: %{url} type: %{type}"
         upload_bundle_create:
@@ -56,6 +58,17 @@ en:
         field_creators_placeholder: "e.g., Smith, John; Doe, Jane"
         field_creators_help: "Enter creator names separated by semicolons using \"Surname, First name\" format for individuals or full name for organizations."
         submit: "Create Dataset"
+        cancel: "Cancel"
+
+      dataset_form_tabs:
+        select_dataset: "Select Dataset"
+        create_dataset: "Create Dataset"
+
+      dataset_select_form:
+        search_label: "Filter datasets"
+        search_placeholder: "Type at least 3 characters to filter"
+        total_depositions: "%{total} datasets found"
+        submit: "Select Dataset"
         cancel: "Cancel"
 
       shared:

--- a/application/test/connectors/zenodo/handlers/dataset_form_tabs_test.rb
+++ b/application/test/connectors/zenodo/handlers/dataset_form_tabs_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class Zenodo::Handlers::DatasetFormTabsTest < ActiveSupport::TestCase
+  include ModelHelper
+
+  def setup
+    @bundle = create_upload_bundle(create_project)
+    @action = Zenodo::Handlers::DatasetFormTabs.new
+  end
+
+  test 'params schema is empty' do
+    assert_empty @action.params_schema
+  end
+
+  test 'edit returns tabs form partial' do
+    @action.stubs(:depositions).returns([])
+    result = @action.edit(@bundle, {})
+    assert_equal '/connectors/zenodo/dataset_form_tabs', result.template
+  end
+
+  test 'update not implemented' do
+    assert_raises(NotImplementedError) { @action.update(@bundle, {}) }
+  end
+
+  test 'depositions fetched via user service' do
+    meta = OpenStruct.new(zenodo_url: 'http://zen', api_key: OpenStruct.new(value: 'KEY'))
+    @bundle.stubs(:connector_metadata).returns(meta)
+    service = mock('service')
+    service.expects(:list_depositions).returns([1,2])
+    Zenodo::UserService.expects(:new).with('http://zen', api_key: 'KEY').returns(service)
+    assert_equal [1,2], @action.send(:depositions, @bundle)
+  end
+end

--- a/application/test/connectors/zenodo/handlers/dataset_select_test.rb
+++ b/application/test/connectors/zenodo/handlers/dataset_select_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class Zenodo::Handlers::DatasetSelectTest < ActiveSupport::TestCase
+  include ModelHelper
+
+  def setup
+    @bundle = create_upload_bundle(create_project)
+    meta = OpenStruct.new(zenodo_url: 'http://zenodo.org', api_key: OpenStruct.new(value: 'KEY'))
+    @bundle.stubs(:connector_metadata).returns(meta)
+    @action = Zenodo::Handlers::DatasetSelect.new
+  end
+
+  test 'params schema includes deposition_id' do
+    assert_includes @action.params_schema, :deposition_id
+  end
+
+  test 'edit not implemented' do
+    assert_raises(NotImplementedError) { @action.edit(@bundle, {}) }
+  end
+
+  test 'update stores deposition information' do
+    deposition = OpenStruct.new(id: '10', title: 'Test', bucket_url: 'burl', draft?: true)
+    service = mock('service')
+    service.expects(:find_deposition).with('10').returns(deposition)
+    Zenodo::DepositionService.expects(:new).with('http://zenodo.org', api_key: 'KEY').returns(service)
+    result = @action.update(@bundle, {deposition_id: '10'})
+    assert result.success?
+    assert_equal '10', @bundle.reload.metadata[:deposition_id]
+    assert_equal 'Test', @bundle.metadata[:title]
+  end
+end

--- a/application/test/connectors/zenodo/upload_bundle_connector_processor_test.rb
+++ b/application/test/connectors/zenodo/upload_bundle_connector_processor_test.rb
@@ -26,11 +26,11 @@ class Zenodo::UploadBundleConnectorProcessorTest < ActiveSupport::TestCase
     assert_equal({upload_bundle: @bundle}, result.locals)
   end
 
-  test 'edit uses deposition_create form' do
+  test 'edit uses dataset_form_tabs form' do
     action = mock('action')
-    Zenodo::Handlers::DepositionCreate.expects(:new).returns(action)
-    action.expects(:edit).with(@bundle, {form: 'deposition_create'}).returns(:ok)
-    assert_equal :ok, @processor.edit(@bundle, {form: 'deposition_create'})
+    Zenodo::Handlers::DatasetFormTabs.expects(:new).returns(action)
+    action.expects(:edit).with(@bundle, {form: 'dataset_form_tabs'}).returns(:ok)
+    assert_equal :ok, @processor.edit(@bundle, {form: 'dataset_form_tabs'})
   end
 
   test 'update uses deposition_fetch form' do
@@ -45,6 +45,13 @@ class Zenodo::UploadBundleConnectorProcessorTest < ActiveSupport::TestCase
     Zenodo::Handlers::DepositionCreate.expects(:new).returns(action)
     action.expects(:update).with(@bundle, {form: 'deposition_create'}).returns(:ok)
     assert_equal :ok, @processor.update(@bundle, {form: 'deposition_create'})
+  end
+
+  test 'update uses dataset_select form' do
+    action = mock('action')
+    Zenodo::Handlers::DatasetSelect.expects(:new).returns(action)
+    action.expects(:update).with(@bundle, {form: 'dataset_select'}).returns(:ok)
+    assert_equal :ok, @processor.update(@bundle, {form: 'dataset_select'})
   end
 
   test 'update default routes to connector edit' do


### PR DESCRIPTION
## Summary
- Add dataset selection and form tabs handlers for Zenodo upload bundles
- Provide UI to pick existing depositions or create new dataset
- Swap create dataset action to use dataset form tabs

## Testing
- `bundle exec rake test` *(fails: Could not find gems)*
- `bundle install` *(fails: requires bundler downgrade and gem installation)*

------
https://chatgpt.com/codex/tasks/task_e_689c7d5fa94083218d0c81d03bc65df3