### PR TITLE
Use end or start dates for file sorting

### DIFF
--- a/application/app/services/common/file_sorter.rb
+++ b/application/app/services/common/file_sorter.rb
@@ -6,11 +6,16 @@ module Common
 
     def most_relevant(files)
       files.sort_by do |file|
-        [ status_priority(file.status), -to_time(file.creation_date).to_i ]
+        [ status_priority(file.status), -sort_date(file) ]
       end
     end
 
     private
+
+    def sort_date(file)
+      date = file.end_date || file.start_date || file.creation_date
+      to_time(date)&.to_i || 0
+    end
 
     def status_priority(status)
       case

--- a/application/test/services/common/file_sorter_test.rb
+++ b/application/test/services/common/file_sorter_test.rb
@@ -10,16 +10,16 @@ module Common
       @upload_bundle = create_upload_bundle(@project)
     end
 
-    test 'most_relevant sorts files by status and creation date' do
+    test 'most_relevant sorts files by status and available date' do
       times = (1..10).map { |i| format('2023-01-%02dT00:00:00', i) }
 
       in_progress_new = create_download_file(@project)
       in_progress_new.status = FileStatus::DOWNLOADING
-      in_progress_new.creation_date = times[9]
+      in_progress_new.start_date = times[9]
 
       in_progress_old = create_upload_file(@project, @upload_bundle)
       in_progress_old.status = FileStatus::UPLOADING
-      in_progress_old.creation_date = times[8]
+      in_progress_old.start_date = times[8]
 
       pending_new = create_upload_file(@project, @upload_bundle)
       pending_new.status = FileStatus::PENDING
@@ -31,27 +31,27 @@ module Common
 
       cancelled_new = create_upload_file(@project, @upload_bundle)
       cancelled_new.status = FileStatus::CANCELLED
-      cancelled_new.creation_date = times[5]
+      cancelled_new.end_date = times[5]
 
       cancelled_old = create_download_file(@project)
       cancelled_old.status = FileStatus::CANCELLED
-      cancelled_old.creation_date = times[4]
+      cancelled_old.end_date = times[4]
 
       error_new = create_download_file(@project)
       error_new.status = FileStatus::ERROR
-      error_new.creation_date = times[3]
+      error_new.end_date = times[3]
 
       error_old = create_upload_file(@project, @upload_bundle)
       error_old.status = FileStatus::ERROR
-      error_old.creation_date = times[2]
+      error_old.end_date = times[2]
 
       success_new = create_upload_file(@project, @upload_bundle)
       success_new.status = FileStatus::SUCCESS
-      success_new.creation_date = times[1]
+      success_new.end_date = times[1]
 
       success_old = create_download_file(@project)
       success_old.status = FileStatus::SUCCESS
-      success_old.creation_date = times[0]
+      success_old.end_date = times[0]
 
       expected = [
         in_progress_new,


### PR DESCRIPTION
## Summary
- sort files by `end_date`, then `start_date`, then `creation_date`
- update FileSorter test to cover new sorting logic

## Testing
- `bundle exec rails test`


------
https://chatgpt.com/codex/tasks/task_e_689cd8b881288321a834fd13fa1468e3