### PR TITLE
Split upload bundle connectors

### DIFF
--- a/application/app/assets/stylesheets/projects.scss
+++ b/application/app/assets/stylesheets/projects.scss
@@ -7,6 +7,14 @@
     min-width: 400px;
   }
 
+  [data-upload-bundle-name-target="form"] {
+    min-height: 3rem;
+  }
+
+  [data-upload-bundle-name-target="form"] input {
+    min-width: 400px;
+  }
+
   .card {
     overflow: hidden;
   }

--- a/application/app/controllers/upload_bundles_connector_controller.rb
+++ b/application/app/controllers/upload_bundles_connector_controller.rb
@@ -35,7 +35,7 @@ class UploadBundlesConnectorController < ApplicationController
 
   def edit
     project_id = project_id_param
-    upload_bundle_id = params[:id]
+    upload_bundle_id = params[:upload_bundle_id]
     upload_bundle = UploadBundle.find(project_id, upload_bundle_id)
     if upload_bundle.nil?
       log_error('Invalid parameters for edit', { project_id: project_id, upload_bundle_id: upload_bundle_id })
@@ -53,7 +53,7 @@ class UploadBundlesConnectorController < ApplicationController
 
   def update
     project_id = project_id_param
-    upload_bundle_id = params[:id]
+    upload_bundle_id = params[:upload_bundle_id]
     upload_bundle = UploadBundle.find(project_id, upload_bundle_id)
 
     if upload_bundle.nil?

--- a/application/app/controllers/upload_bundles_connector_controller.rb
+++ b/application/app/controllers/upload_bundles_connector_controller.rb
@@ -1,0 +1,79 @@
+class UploadBundlesConnectorController < ApplicationController
+  include LoggingCommon
+  include TabsHelper
+
+  def create
+    project_id = project_id_param
+    project = Project.find(project_id)
+    if project.nil?
+      log_error('Invalid project', { project_id: project_id })
+      redirect_back fallback_location: root_path, alert: t('upload_bundles.create.invalid_project', id: project_id)
+      return
+    end
+
+    repo_url = params[:remote_repo_url]
+    repo_resolver = Repo::RepoResolverService.new(RepoRegistry.resolvers)
+    url_resolution = repo_resolver.resolve(repo_url)
+    log_info('Remote Repo resolution', { repo_url: repo_url, type: url_resolution.type })
+
+    if url_resolution.unknown?
+      log_error('Unknown repository URL', { repo_url: repo_url })
+      redirect_back fallback_location: root_path,  alert: t('upload_bundles.create.invalid_repo', url: repo_url)
+      return
+    end
+
+    processor = ConnectorClassDispatcher.upload_bundle_connector_processor(url_resolution.type)
+    processor_params = params.permit(*processor.params_schema).to_h
+    processor_params[:object_url] = url_resolution.object_url
+    result = processor.create(project, processor_params)
+    anchor = params[:anchor]
+    anchor ||= tab_anchor_for(result.resource) if result.resource
+
+    log_info('Upload bundle created', { project_id: project_id, upload_bundle_id: result.resource&.id })
+    redirect_to project_path(id: project_id, anchor: anchor), **result.message
+  end
+
+  def edit
+    project_id = project_id_param
+    upload_bundle_id = params[:id]
+    upload_bundle = UploadBundle.find(project_id, upload_bundle_id)
+    if upload_bundle.nil?
+      log_error('Invalid parameters for edit', { project_id: project_id, upload_bundle_id: upload_bundle_id })
+      redirect_back fallback_location: root_path, alert: t('upload_bundles.edit.invalid_parameters', project_id: project_id, upload_bundle_id: upload_bundle_id)
+      return
+    end
+
+    processor = ConnectorClassDispatcher.upload_bundle_connector_processor(upload_bundle.type)
+    processor_params = params.permit(*processor.params_schema).to_h
+    result = processor.edit(upload_bundle, processor_params)
+
+    log_info('Rendering connector edit', { project_id: project_id, upload_bundle_id: upload_bundle_id, template: result.template })
+    render partial: result.template, layout: false, locals: result.locals
+  end
+
+  def update
+    project_id = project_id_param
+    upload_bundle_id = params[:id]
+    upload_bundle = UploadBundle.find(project_id, upload_bundle_id)
+
+    if upload_bundle.nil?
+      log_error('Upload bundle not found', { project_id: project_id, upload_bundle_id: upload_bundle_id })
+      redirect_back fallback_location: root_path, alert: t('upload_bundles.update.not_found', upload_bundle_id: upload_bundle_id)
+      return
+    end
+
+    processor = ConnectorClassDispatcher.upload_bundle_connector_processor(upload_bundle.type)
+    processor_params = params.permit(*processor.params_schema).to_h
+    log_info('Updating upload bundle via connector', { project_id: project_id, upload_bundle_id: upload_bundle_id, params: processor_params })
+    result = processor.update(upload_bundle, processor_params)
+
+    redirect_back fallback_location: root_path, **result.message
+  end
+
+  private
+
+  def project_id_param
+    param = params[:project_id]
+    param == ':project_id' ? request.request_parameters[:project_id] : param
+  end
+end

--- a/application/app/controllers/upload_bundles_controller.rb
+++ b/application/app/controllers/upload_bundles_controller.rb
@@ -2,66 +2,35 @@ class UploadBundlesController < ApplicationController
   include LoggingCommon
   include TabsHelper
 
-  def create
-    project_id = project_id_param
-    project = Project.find(project_id)
-    if project.nil?
-      redirect_back fallback_location: root_path, alert: t(".invalid_project", id: project_id)
-      return
-    end
-
-    repo_url = params[:remote_repo_url]
-    repo_resolver = Repo::RepoResolverService.new(RepoRegistry.resolvers)
-    url_resolution = repo_resolver.resolve(repo_url)
-    log_info('Remote Repo resolution', { repo_url: repo_url, type: url_resolution.type })
-
-    if url_resolution.unknown?
-      redirect_back fallback_location: root_path,  alert: t(".invalid_repo", url: repo_url)
-      return
-    end
-
-    processor = ConnectorClassDispatcher.upload_bundle_connector_processor(url_resolution.type)
-    processor_params = params.permit(*processor.params_schema).to_h
-    processor_params[:object_url] = url_resolution.object_url
-    result = processor.create(project, processor_params)
-    anchor = params[:anchor]
-    anchor ||= tab_anchor_for(result.resource) if result.resource
-
-    redirect_to project_path(id: project_id, anchor: anchor), **result.message
-  end
-
-  def edit
-    project_id = project_id_param
-    upload_bundle_id = params[:id]
-    upload_bundle = UploadBundle.find(project_id, upload_bundle_id)
-    if upload_bundle.nil?
-      redirect_back fallback_location: root_path, alert: t(".invalid_parameters", project_id: project_id, upload_bundle_id: upload_bundle_id)
-      return
-    end
-
-    processor = ConnectorClassDispatcher.upload_bundle_connector_processor(upload_bundle.type)
-    processor_params = params.permit(*processor.params_schema).to_h
-    result = processor.edit(upload_bundle, processor_params)
-
-    render partial: result.template, layout: false, locals: result.locals
-  end
-
   def update
     project_id = project_id_param
     upload_bundle_id = params[:id]
     upload_bundle = UploadBundle.find(project_id, upload_bundle_id)
-
     if upload_bundle.nil?
-      redirect_back fallback_location: root_path, alert: t(".not_found", upload_bundle_id: upload_bundle_id)
+      error_message = t('.not_found', upload_bundle_id: upload_bundle_id)
+      log_error('Upload bundle not found', { project_id: project_id, upload_bundle_id: upload_bundle_id })
+      respond_to do |format|
+        format.html { redirect_back fallback_location: root_path, alert: error_message }
+        format.json { render json: { error: error_message }, status: :not_found }
+      end
       return
     end
 
-    processor = ConnectorClassDispatcher.upload_bundle_connector_processor(upload_bundle.type)
-    processor_params = params.permit(*processor.params_schema).to_h
-    log_info("params", {params: processor_params})
-    result = processor.update(upload_bundle, processor_params)
+    update_params = params.permit(:name).to_h.compact
 
-    redirect_back fallback_location: root_path, **result.message
+    if upload_bundle.update(update_params)
+      log_info('Upload bundle updated successfully', { project_id: project_id, upload_bundle_id: upload_bundle_id })
+      respond_to do |format|
+        format.html { redirect_back fallback_location: root_path, notice: t('.success', bundle_name: upload_bundle.name) }
+        format.json { render json: upload_bundle.to_json, status: :ok }
+      end
+    else
+      log_error('Unable to update upload bundle', { project_id: project_id, upload_bundle_id: upload_bundle_id, errors: upload_bundle.errors.full_messages })
+      respond_to do |format|
+        format.html { redirect_back fallback_location: root_path, alert: t('.error', errors: upload_bundle.errors.full_messages) }
+        format.json { render json: { error: upload_bundle.errors.full_messages }, status: :unprocessable_entity }
+      end
+    end
   end
 
   def destroy
@@ -70,12 +39,14 @@ class UploadBundlesController < ApplicationController
     upload_bundle = UploadBundle.find(project_id, upload_bundle_id)
 
     if upload_bundle.nil?
-      redirect_back fallback_location: root_path, alert: t(".not_found", upload_bundle_id: upload_bundle_id)
+      log_error('Upload bundle not found for destroy', { project_id: project_id, upload_bundle_id: upload_bundle_id })
+      redirect_back fallback_location: root_path, alert: t('.not_found', upload_bundle_id: upload_bundle_id)
       return
     end
 
     upload_bundle.destroy
-    redirect_back fallback_location: root_path, notice: t(".success", bundle_name: upload_bundle.name)
+    log_info('Upload bundle destroyed', { project_id: project_id, upload_bundle_id: upload_bundle_id })
+    redirect_back fallback_location: root_path, notice: t('.success', bundle_name: upload_bundle.name)
   end
 
   private
@@ -84,5 +55,4 @@ class UploadBundlesController < ApplicationController
     param = params[:project_id]
     param == ':project_id' ? request.request_parameters[:project_id] : param
   end
-
 end

--- a/application/app/javascript/controllers/upload_bundle_name_controller.js
+++ b/application/app/javascript/controllers/upload_bundle_name_controller.js
@@ -1,0 +1,60 @@
+import { Controller } from "@hotwired/stimulus"
+import { showFlash } from 'utils/flash_message'
+
+export default class extends Controller {
+    static targets = ["display", "name", "form", "input"]
+    static values = {
+        initialName: String,
+        url: String
+    }
+
+    connect() {
+        this.inputTarget.value = this.initialNameValue
+    }
+
+    edit() {
+        this.displayTarget.classList.add("d-none")
+        this.formTarget.classList.remove("d-none")
+        this.inputTarget.focus()
+    }
+
+    save() {
+        const newName = this.inputTarget.value.trim()
+        if (!newName || newName === this.initialNameValue) {
+            return this.cancel()
+        }
+
+        const path = this.urlValue
+        const csrfToken = window.loop_app_config.csrf_token
+        fetch(path, {
+            method: "PUT",
+            headers: {
+                "X-CSRF-Token": csrfToken,
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                'X-Requested-With': 'XMLHttpRequest'
+            },
+            credentials: "same-origin",
+            body: JSON.stringify({ name: newName })
+        })
+            .then(response => {
+                if (!response.ok) throw new Error("Failed to update upload bundle name")
+                return response.json()
+            })
+            .then(data => {
+                this.nameTarget.textContent = newName
+                this.initialNameValue = newName
+                this.cancel()
+            })
+            .catch(error => {
+                console.error(error)
+                showFlash("error", window.loop_app_config.i18n.upload_bundle_name.save.error)
+            })
+    }
+
+    cancel() {
+        this.formTarget.classList.add("d-none")
+        this.displayTarget.classList.remove("d-none")
+        this.inputTarget.value = this.initialNameValue
+    }
+}

--- a/application/app/views/connectors/dataverse/_collection_select_form.html.erb
+++ b/application/app/views/connectors/dataverse/_collection_select_form.html.erb
@@ -1,5 +1,5 @@
 <div data-controller="list-filter">
-<%= form_with url: project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id), method: :put, data: { action: "submit->modal#showSpinner" }, local: true do |f| %>
+<%= form_with url: project_upload_bundle_connector_path(upload_bundle.project_id, upload_bundle.id), method: :put, data: { action: "submit->modal#showSpinner" }, local: true do |f| %>
   <%= hidden_field_tag :form, 'collection_select' %>
   <%= hidden_field_tag :anchor, tab_anchor_for(upload_bundle) %>
 

--- a/application/app/views/connectors/dataverse/_connector_edit_form.html.erb
+++ b/application/app/views/connectors/dataverse/_connector_edit_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id), method: :put, data: { action: "submit->modal#showSpinner" }, local: true do |f| %>
+<%= form_with url: project_upload_bundle_connector_path(upload_bundle.project_id, upload_bundle.id), method: :put, data: { action: "submit->modal#showSpinner" }, local: true do |f| %>
   <%= hidden_field_tag :form, 'connector_edit' %>
   <%= hidden_field_tag :anchor, tab_anchor_for(upload_bundle) %>
 

--- a/application/app/views/connectors/dataverse/_dataset_create_form.html.erb
+++ b/application/app/views/connectors/dataverse/_dataset_create_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id), method: :put, data: { action: "submit->modal#showSpinner" }, local: true do |f| %>
+<%= form_with url: project_upload_bundle_connector_path(upload_bundle.project_id, upload_bundle.id), method: :put, data: { action: "submit->modal#showSpinner" }, local: true do |f| %>
   <%= hidden_field_tag :form, 'dataset_create' %>
   <%= hidden_field_tag :anchor, tab_anchor_for(upload_bundle) %>
 

--- a/application/app/views/connectors/dataverse/_dataset_select_form.html.erb
+++ b/application/app/views/connectors/dataverse/_dataset_select_form.html.erb
@@ -1,5 +1,5 @@
 <div data-controller="list-filter">
-<%= form_with url: project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id), method: :put, data: { action: "submit->modal#showSpinner" }, local: true do |f| %>
+<%= form_with url: project_upload_bundle_connector_path(upload_bundle.project_id, upload_bundle.id), method: :put, data: { action: "submit->modal#showSpinner" }, local: true do |f| %>
   <%= hidden_field_tag :form, 'dataset_select' %>
   <%= hidden_field_tag :anchor, tab_anchor_for(upload_bundle) %>
 

--- a/application/app/views/connectors/dataverse/_upload_bundle_actions_bar.html.erb
+++ b/application/app/views/connectors/dataverse/_upload_bundle_actions_bar.html.erb
@@ -35,7 +35,7 @@
                     title="<%= t('connectors.dataverse.upload_bundle_actions_bar.button_select_collection_title') %>"
                     data-controller="modal"
                     data-action="click->modal#load"
-                    data-modal-url-value="<%= edit_project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id, form: 'collection_select') %>"
+                    data-modal-url-value="<%= edit_project_upload_bundle_connector_path(upload_bundle.project_id, upload_bundle.id, form: 'collection_select') %>"
                     data-modal-title-value="<%= t('connectors.dataverse.upload_bundle_actions_bar.modal_select_collection_title') %>"
                     data-modal-id-value="global-modal">
               <i class="bi bi-database-add me-1"></i><%= t('connectors.dataverse.upload_bundle_actions_bar.button_select_collection_title') %>
@@ -48,7 +48,7 @@
                     title="<%= t('connectors.dataverse.upload_bundle_actions_bar.button_dataset_form_tabs_title') %>"
                     data-controller="modal"
                     data-action="click->modal#load"
-                    data-modal-url-value="<%= edit_project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id, form: 'dataset_form_tabs') %>"
+                    data-modal-url-value="<%= edit_project_upload_bundle_connector_path(upload_bundle.project_id, upload_bundle.id, form: 'dataset_form_tabs') %>"
                     data-modal-title-value="<%= t('connectors.dataverse.upload_bundle_actions_bar.modal_dataset_form_tabs_title', collection: upload_bundle.connector_metadata.collection_title) %>"
                     data-modal-id-value="global-modal">
               <i class="bi bi-file-earmark-plus me-1" aria-hidden="true"></i><%= t('connectors.dataverse.upload_bundle_actions_bar.button_dataset_form_tabs_title') %>
@@ -74,7 +74,7 @@
             title="<%= t(".button_edit_key_title") %>"
             data-controller="modal"
             data-action="click->modal#load"
-            data-modal-url-value="<%= edit_project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id) %>"
+            data-modal-url-value="<%= edit_project_upload_bundle_connector_path(upload_bundle.project_id, upload_bundle.id) %>"
             data-modal-title-value="<%= t(".modal_edit_key_title") %>"
             data-modal-id-value="global-modal">
       <i class="bi bi-pencil-fill" aria-hidden="true"></i>

--- a/application/app/views/connectors/dataverse/collections/_collection_actions.html.erb
+++ b/application/app/views/connectors/dataverse/collections/_collection_actions.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="d-flex align-items-center gap-2">
     <% if Current.settings.user_settings.active_project.present? %>
-      <%= button_to project_upload_bundles_path(Current.settings.user_settings.active_project),
+      <%= button_to connector_project_upload_bundles_path(Current.settings.user_settings.active_project),
                     method: :post,
                     params: { remote_repo_url: external_collection_url(dataverse_url, collection.data.alias) },
                     class: 'btn btn-sm btn-outline-secondary',

--- a/application/app/views/connectors/dataverse/datasets/_dataset_actions.html.erb
+++ b/application/app/views/connectors/dataverse/datasets/_dataset_actions.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="d-flex align-items-center gap-2">
     <!-- create bundle button -->
-    <%= form_with url: project_upload_bundles_path(':project_id'),
+    <%= form_with url: connector_project_upload_bundles_path(':project_id'),
                   method: :post,
                   class: "d-inline",
                   data: {

--- a/application/app/views/connectors/zenodo/_connector_edit_form.html.erb
+++ b/application/app/views/connectors/zenodo/_connector_edit_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id), method: :put, data: { action: "submit->modal#showSpinner" }, local: true do |f| %>
+<%= form_with url: project_upload_bundle_connector_path(upload_bundle.project_id, upload_bundle.id), method: :put, data: { action: "submit->modal#showSpinner" }, local: true do |f| %>
   <%= hidden_field_tag :form, 'connector_edit' %>
   <%= hidden_field_tag :anchor, tab_anchor_for(upload_bundle) %>
 

--- a/application/app/views/connectors/zenodo/_dataset_select_form.html.erb
+++ b/application/app/views/connectors/zenodo/_dataset_select_form.html.erb
@@ -1,5 +1,5 @@
 <div data-controller="list-filter">
-<%= form_with url: project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id), method: :put, data: { action: "submit->modal#showSpinner" }, local: true do |f| %>
+<%= form_with url: project_upload_bundle_connector_path(upload_bundle.project_id, upload_bundle.id), method: :put, data: { action: "submit->modal#showSpinner" }, local: true do |f| %>
   <%= hidden_field_tag :form, 'dataset_select' %>
   <%= hidden_field_tag :anchor, tab_anchor_for(upload_bundle) %>
 

--- a/application/app/views/connectors/zenodo/_deposition_create_form.html.erb
+++ b/application/app/views/connectors/zenodo/_deposition_create_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id), method: :put, data: { action: "submit->modal#showSpinner" }, local: true do |f| %>
+<%= form_with url: project_upload_bundle_connector_path(upload_bundle.project_id, upload_bundle.id), method: :put, data: { action: "submit->modal#showSpinner" }, local: true do |f| %>
   <%= hidden_field_tag :form, 'deposition_create' %>
   <%= hidden_field_tag :anchor, tab_anchor_for(upload_bundle) %>
   <%= f.hidden_field :upload_type, value: 'dataset' %>

--- a/application/app/views/connectors/zenodo/_upload_bundle_actions_bar.html.erb
+++ b/application/app/views/connectors/zenodo/_upload_bundle_actions_bar.html.erb
@@ -24,7 +24,7 @@
         <small class="text-muted me-2"><%= upload_bundle.remote_repo_url %></small>
         <% if upload_bundle.connector_metadata.create_draft? %>
           <%= render layout: "shared/button_to", locals: {
-            url:  project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id),
+            url:  project_upload_bundle_connector_path(upload_bundle.project_id, upload_bundle.id),
             method: 'PUT',
             label: t('connectors.zenodo.upload_bundle_actions_bar.button_create_draft_title'),
             title: t('connectors.zenodo.upload_bundle_actions_bar.button_create_draft_title'),
@@ -40,14 +40,14 @@
                   title="<%= t('connectors.zenodo.upload_bundle_actions_bar.button_select_create_deposition_title') %>"
                   data-controller="modal"
                   data-action="click->modal#load"
-                  data-modal-url-value="<%= edit_project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id, form: 'dataset_form_tabs') %>"
+                  data-modal-url-value="<%= edit_project_upload_bundle_connector_path(upload_bundle.project_id, upload_bundle.id, form: 'dataset_form_tabs') %>"
                   data-modal-title-value="<%= t('connectors.zenodo.upload_bundle_actions_bar.modal_select_create_deposition_title') %>"
                   data-modal-id-value="global-modal">
             <i class="bi bi-database-add me-1"></i><%= t('connectors.zenodo.upload_bundle_actions_bar.button_select_create_deposition_title') %>
           </button>
         <% elsif upload_bundle.connector_metadata.fetch_deposition? %>
           <%= render layout: "shared/button_to", locals: {
-            url:  project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id),
+            url:  project_upload_bundle_connector_path(upload_bundle.project_id, upload_bundle.id),
             method: 'PUT',
             label: t('connectors.zenodo.upload_bundle_actions_bar.button_deposition_fetch_label'),
             title: t('connectors.zenodo.upload_bundle_actions_bar.button_deposition_fetch_title'),
@@ -84,7 +84,7 @@
             title="<%= t(".button_edit_key_title") %>"
             data-controller="modal"
             data-action="click->modal#load"
-            data-modal-url-value="<%= edit_project_upload_bundle_path(upload_bundle.project_id, upload_bundle.id) %>"
+            data-modal-url-value="<%= edit_project_upload_bundle_connector_path(upload_bundle.project_id, upload_bundle.id) %>"
             data-modal-title-value="<%= t(".modal_edit_key_title") %>"
             data-modal-id-value="global-modal">
       <i class="bi bi-pencil-fill"></i>

--- a/application/app/views/connectors/zenodo/shared/_zenodo_record_actions.html.erb
+++ b/application/app/views/connectors/zenodo/shared/_zenodo_record_actions.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="d-flex align-items-center gap-2">
     <!-- create bundle button -->
-    <%= form_with url: project_upload_bundles_path(':project_id'),
+    <%= form_with url: connector_project_upload_bundles_path(':project_id'),
                   method: :post,
                   class: "d-inline",
                   data: {

--- a/application/app/views/projects/show/_project_actions.html.erb
+++ b/application/app/views/projects/show/_project_actions.html.erb
@@ -93,7 +93,7 @@
 <!-- Create Upload Bundle inline form -->
 <div class="d-flex justify-content-end gap-2 mt-2 mb-2">
     <%= render partial: 'shared/inline_field_submit', locals: {
-      url: project_upload_bundles_path(project_id: project.id),
+      url: connector_project_upload_bundles_path(project_id: project.id),
       type: 'form',
       field_name: 'remote_repo_url',
       label: t('.button_create_upload_bundle_label'),

--- a/application/app/views/projects/show/_upload_actions.html.erb
+++ b/application/app/views/projects/show/_upload_actions.html.erb
@@ -4,19 +4,20 @@
          data-upload-bundle-name-initial-name-value="<%= bundle.name %>"
          data-upload-bundle-name-url-value="<%= project_upload_bundle_path(project_id: bundle.project_id, id: bundle.id) %>">
       <div class="d-flex justify-content-between align-items-center p-2">
-        <div class="d-flex align-items-center gap-3">
+        <div class="d-flex align-items-center gap-3 me-2">
           <%= render partial: '/shared/file_row_date', locals: { date: bundle.creation_date, title: t('.field_creation_date_title') } if bundle.creation_date %>
 
-          <div class="d-flex flex-column" data-upload-bundle-name-target="display">
-            <h3 class="mb-0 h5" data-upload-bundle-name-target="name"><%= bundle.name %></h3>
-          </div>
+          <h3 class="mb-0 h5" data-upload-bundle-name-target="name display"><%= bundle.name %></h3>
+        </div>
 
+        <div class="d-flex align-items-center gap-2 flex-wrap justify-content-end flex-grow-1">
           <div data-upload-bundle-name-target="form"
                class="d-flex align-items-center gap-2 d-none"
+               style="flex-grow: 1000;"
                role="group"
                aria-label="<%= t('.section_rename_bundle_label') %>">
             <input type="text"
-                   class="form-control form-control-sm"
+                   class="form-control form-control-sm flex-grow-1"
                    data-upload-bundle-name-target="input"
                    value="<%= bundle.name %>">
 
@@ -35,9 +36,7 @@
               <span class="visually-hidden"><%= t('.button_cancel_bundle_name_title') %></span>
             </button>
           </div>
-        </div>
 
-        <div class="d-flex align-items-center gap-2">
           <button class="btn btn-sm btn-outline-secondary"
                   data-action="click->upload-bundle-name#edit"
                   title="<%= t('.button_edit_bundle_name_title') %>">

--- a/application/app/views/projects/show/_upload_actions.html.erb
+++ b/application/app/views/projects/show/_upload_actions.html.erb
@@ -1,18 +1,70 @@
 <section class="card mb-3 shadow-sm rounded overflow-hidden">
-  <div class="card-header d-flex justify-content-between align-items-center bg-light-darker">
-    <div class="d-flex align-items-center gap-3">
-      <%= render partial: '/shared/file_row_date', locals: { date: bundle.creation_date, title: t('.field_creation_date_title') } if bundle.creation_date %>
+  <div class="card-header p-0 bg-light-darker">
+    <div data-controller="upload-bundle-name"
+         data-upload-bundle-name-initial-name-value="<%= bundle.name %>"
+         data-upload-bundle-name-url-value="<%= project_upload_bundle_path(project_id: bundle.project_id, id: bundle.id) %>">
+      <div class="d-flex justify-content-between align-items-center p-2">
+        <div class="d-flex align-items-center gap-3">
+          <%= render partial: '/shared/file_row_date', locals: { date: bundle.creation_date, title: t('.field_creation_date_title') } if bundle.creation_date %>
 
-      <div>
-        <!-- PROJECT METADATA -->
-        <div class="d-flex flex-column">
-          <h3 class="mb-0 h5"><%= bundle.name %></h3>
+          <div class="d-flex flex-column" data-upload-bundle-name-target="display">
+            <h3 class="mb-0 h5" data-upload-bundle-name-target="name"><%= bundle.name %></h3>
+          </div>
+
+          <div data-upload-bundle-name-target="form"
+               class="d-flex align-items-center gap-2 d-none"
+               role="group"
+               aria-label="<%= t('.section_rename_bundle_label') %>">
+            <input type="text"
+                   class="form-control form-control-sm"
+                   data-upload-bundle-name-target="input"
+                   value="<%= bundle.name %>">
+
+            <button class="btn btn-sm btn-outline-primary"
+                    data-action="click->upload-bundle-name#save"
+                    title="<%= t('.button_save_bundle_name_title') %>">
+              <i class="bi bi-check-lg" aria-hidden="true"></i>
+              <span class="visually-hidden"><%= t('.button_save_bundle_name_title') %></span>
+            </button>
+
+            <button class="btn btn-sm btn-outline-danger"
+                    type="button"
+                    data-action="click->upload-bundle-name#cancel"
+                    title="<%= t('.button_cancel_bundle_name_title') %>">
+              <i class="bi bi-x-lg" aria-hidden="true"></i>
+              <span class="visually-hidden"><%= t('.button_cancel_bundle_name_title') %></span>
+            </button>
+          </div>
+        </div>
+
+        <div class="d-flex align-items-center gap-2">
+          <button class="btn btn-sm btn-outline-secondary"
+                  data-action="click->upload-bundle-name#edit"
+                  title="<%= t('.button_edit_bundle_name_title') %>">
+            <i class="bi bi-pencil-fill" aria-hidden="true"></i>
+            <span class="visually-hidden"><%= t('.button_edit_bundle_name_title') %></span>
+          </button>
+
+          <%= render layout: "shared/button_to", locals: {
+            url: project_upload_bundle_path(project_id: bundle.project_id, id: bundle.id),
+            method: 'DELETE',
+            title: t('.button_delete_title'),
+            class: 'btn btn-sm btn-outline-secondary icon-hover-danger',
+            icon: "bi bi-trash",
+            modal_id: 'modal-delete-confirmation',
+            modal_title: t('.modal_delete_confirmation_title'),
+            modal_subtitle: bundle.name,
+            modal_content: t('.modal_delete_confirmation_content'),
+          } do %>
+            <%= hidden_field_tag :anchor, '' %>
+          <% end %>
         </div>
       </div>
-
     </div>
 
-    <div class="d-flex align-items-center gap-2">
+    <hr class="m-0">
+
+    <div class="d-flex justify-content-between align-items-center p-2">
       <div class="me-4" data-controller="lazy-loader"
            data-lazy-loader-url-value="<%= widgets_path(widget_path: 'upload_bundle_summary', project_id: project.id, upload_bundle_id: bundle.id) %>"
            data-lazy-loader-event-name-value="file-drop:file-submitted:<%= file_target_id %>">
@@ -30,20 +82,6 @@
         <i class="bi bi-plus-square-fill" aria-hidden="true"></i>
         <span class="ps-1"><%= t('.button_add_files_text') %></span>
       </button>
-
-      <%= render layout: "shared/button_to", locals: {
-        url: project_upload_bundle_path(project_id: bundle.project_id, id: bundle.id),
-        method: 'DELETE',
-        title: t('.button_delete_title'),
-        class: 'btn btn-sm btn-outline-secondary icon-hover-danger',
-        icon: "bi bi-trash",
-        modal_id: 'modal-delete-confirmation',
-        modal_title: t('.modal_delete_confirmation_title'),
-        modal_subtitle: bundle.name,
-        modal_content: t('.modal_delete_confirmation_content'),
-      } do %>
-        <%= hidden_field_tag :anchor, '' %>
-      <% end %>
     </div>
   </div>
 

--- a/application/app/views/projects/show/_upload_actions.html.erb
+++ b/application/app/views/projects/show/_upload_actions.html.erb
@@ -1,9 +1,9 @@
 <section class="card mb-3 shadow-sm rounded overflow-hidden">
-  <div class="card-header p-0 bg-light-darker">
+  <div class="card-header bg-light-darker">
     <div data-controller="upload-bundle-name"
          data-upload-bundle-name-initial-name-value="<%= bundle.name %>"
          data-upload-bundle-name-url-value="<%= project_upload_bundle_path(project_id: bundle.project_id, id: bundle.id) %>">
-      <div class="d-flex justify-content-between align-items-center p-2">
+      <div class="d-flex justify-content-between align-items-center py-2">
         <div class="d-flex align-items-center gap-3 me-2">
           <%= render partial: '/shared/file_row_date', locals: { date: bundle.creation_date, title: t('.field_creation_date_title') } if bundle.creation_date %>
 
@@ -63,7 +63,7 @@
 
     <hr class="m-0">
 
-    <div class="d-flex justify-content-between align-items-center p-2">
+    <div class="d-flex justify-content-between align-items-center py-2">
       <div class="me-4" data-controller="lazy-loader"
            data-lazy-loader-url-value="<%= widgets_path(widget_path: 'upload_bundle_summary', project_id: project.id, upload_bundle_id: bundle.id) %>"
            data-lazy-loader-event-name-value="file-drop:file-submitted:<%= file_target_id %>">

--- a/application/config/locales/controllers/en.yml
+++ b/application/config/locales/controllers/en.yml
@@ -49,6 +49,8 @@ en:
       invalid_parameters: "Invalid parameters project_id: %{project_id} upload_bundle_id: %{upload_bundle_id}"
     update:
       not_found: "Upload Bundle not found: %{upload_bundle_id}"
+      success: "Upload bundle updated: %{bundle_name}"
+      error: "Failed to update upload bundle: %{errors}"
     destroy:
       not_found: "Upload Bundle not found: %{upload_bundle_id}"
       success: "Upload bundle deleted: %{bundle_name}"

--- a/application/config/locales/shared/en.yml
+++ b/application/config/locales/shared/en.yml
@@ -41,3 +41,6 @@ en:
     project_name:
       save:
         error: "Could not update project name."
+    upload_bundle_name:
+      save:
+        error: "Could not update upload bundle name."

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -135,6 +135,10 @@ en:
         button_add_files_title: "Add Files"
         button_delete_title: "Delete Bundle"
         field_creation_date_title: "Creation date"
+        button_edit_bundle_name_title: "Edit Upload Bundle name"
+        button_save_bundle_name_title: "Save bundle name"
+        button_cancel_bundle_name_title: "Cancel"
+        section_rename_bundle_label: "Rename upload bundle section"
         modal_delete_confirmation_title: "Delete Upload Bundle"
         modal_delete_confirmation_content: "This will remove the upload bundle from the app. Files on disk and any already uploaded files will remain unchanged. To upload again, you’ll need to create a new bundle."
       upload_files:

--- a/application/config/routes.rb
+++ b/application/config/routes.rb
@@ -19,7 +19,14 @@ Rails.application.routes.draw do
 
     # post /projects/:project_id/uploads => create new upload batch
     # get /projects/:project_id/uploads => get batches from a project
-    resources :upload_bundles, path: 'uploads', only: [:create, :index, :edit, :update, :destroy ] do
+    resources :upload_bundles, path: 'uploads', only: [:index, :update, :destroy] do
+      # POST /projects/:project_id/uploads/connector => create new upload bundle via connector
+      post :connector, on: :collection, to: 'upload_bundles_connector#create'
+
+      # GET /projects/:project_id/uploads/:upload_bundle_id/connector/edit => edit connector form
+      # PUT /projects/:project_id/uploads/:upload_bundle_id/connector => update via connector
+      resource :connector, only: [:edit, :update], controller: 'upload_bundles_connector'
+
       # post /projects/:project_id/uploads/:upload_bundle_id/files => create new upload_file
       # get /projects/:project_id/uploads/:upload_bundle_id/files => gets upload_files from a collection
       # delete /projects/:project_id/uploads/:upload_bundle_id/files/:id => delete upload_file

--- a/application/test/controllers/upload_bundles_connector_controller_test.rb
+++ b/application/test/controllers/upload_bundles_connector_controller_test.rb
@@ -73,7 +73,7 @@ class UploadBundlesConnectorControllerTest < ActionDispatch::IntegrationTest
     processor.stubs(:edit).returns(ConnectorResult.new(partial: '/p', locals: {}))
     ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).returns(processor)
     UploadBundlesConnectorController.any_instance.stubs(:render).returns(true)
-    get edit_project_upload_bundle_connector_url('p', bundle.id, format: :html)
+    get edit_project_upload_bundle_connector_url(project_id: 'p', upload_bundle_id: bundle.id, format: :html)
     assert_response :not_acceptable
   end
 
@@ -84,7 +84,7 @@ class UploadBundlesConnectorControllerTest < ActionDispatch::IntegrationTest
     processor.stubs(:params_schema).returns([])
     processor.stubs(:update).returns(ConnectorResult.new(message: {notice: 'ok'}))
     ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).returns(processor)
-    patch project_upload_bundle_connector_url('p', bundle.id)
+    patch project_upload_bundle_connector_url(project_id: 'p', upload_bundle_id: bundle.id)
     assert_redirected_to root_path
   end
 
@@ -104,7 +104,7 @@ class UploadBundlesConnectorControllerTest < ActionDispatch::IntegrationTest
     processor.stubs(:edit).returns(result)
     ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).with(ConnectorType::DATAVERSE).returns(processor)
 
-    get edit_project_upload_bundle_connector_url(project.id, bundle.id, form: 'dataset_create')
+    get edit_project_upload_bundle_connector_url(project_id: project.id, upload_bundle_id: bundle.id, form: 'dataset_create')
 
     assert_response :success
     assert_select 'form'
@@ -123,7 +123,7 @@ class UploadBundlesConnectorControllerTest < ActionDispatch::IntegrationTest
     processor.stubs(:edit).returns(result)
     ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).with(ConnectorType::DATAVERSE).returns(processor)
 
-    get edit_project_upload_bundle_connector_url(project.id, bundle.id, form: 'dataset_select')
+    get edit_project_upload_bundle_connector_url(project_id: project.id, upload_bundle_id: bundle.id, form: 'dataset_select')
 
     assert_response :success
     assert_select 'input[type=radio][name=dataset_id]'
@@ -143,7 +143,7 @@ class UploadBundlesConnectorControllerTest < ActionDispatch::IntegrationTest
     processor.stubs(:edit).returns(result)
     ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).with(ConnectorType::DATAVERSE).returns(processor)
 
-    get edit_project_upload_bundle_connector_url(project.id, bundle.id, form: 'collection_select')
+    get edit_project_upload_bundle_connector_url(project_id: project.id, upload_bundle_id: bundle.id, form: 'collection_select')
 
     assert_response :success
     assert_select 'input[type=radio][name=collection_id]'
@@ -162,7 +162,7 @@ class UploadBundlesConnectorControllerTest < ActionDispatch::IntegrationTest
     processor.stubs(:edit).returns(result)
     ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).with(ConnectorType::ZENODO).returns(processor)
 
-    get edit_project_upload_bundle_connector_url(project.id, bundle.id)
+    get edit_project_upload_bundle_connector_url(project_id: project.id, upload_bundle_id: bundle.id)
 
     assert_response :success
     assert_select 'input[name="api_key"]'

--- a/application/test/controllers/upload_bundles_connector_controller_test.rb
+++ b/application/test/controllers/upload_bundles_connector_controller_test.rb
@@ -1,0 +1,170 @@
+require 'test_helper'
+
+class UploadBundlesConnectorControllerTest < ActionDispatch::IntegrationTest
+  include ModelHelper
+
+  test 'create resolves repo and delegates to processor' do
+    project = create_project
+    project.save
+    Project.stubs(:find).with(project.id.to_s).returns(project)
+    ApplicationController.any_instance.stubs(:load_user_settings)
+
+    resolver = mock('resolver')
+    url_res = OpenStruct.new(type: ConnectorType::ZENODO, object_url: 'u', unknown?: false)
+    resolver.stubs(:resolve).with('u').returns(url_res)
+    Repo::RepoResolverService.stubs(:new).returns(resolver)
+
+    processor = mock('proc')
+    processor.stubs(:params_schema).returns([:remote_repo_url])
+    processor.stubs(:create).returns(ConnectorResult.new(resource: UploadBundle.new, message: {notice: 'ok'}, success: true))
+    ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).with(ConnectorType::ZENODO).returns(processor)
+
+    post connector_project_upload_bundles_url(project.id), params: { remote_repo_url: 'u' }
+    assert_response :redirect
+  end
+
+
+  test 'create redirects on invalid project' do
+    Project.stubs(:find).returns(nil)
+    post connector_project_upload_bundles_url('1'), params: { remote_repo_url: 'u' }
+    assert_redirected_to root_path
+    follow_redirect!
+    assert_match 'Invalid project id', flash[:alert]
+  end
+
+  test 'create handles unknown repo url' do
+    project = create_project
+    Project.stubs(:find).returns(project)
+    resolver = mock('resolver')
+    resolver.stubs(:resolve).with('u').returns(OpenStruct.new(unknown?: true))
+    Repo::RepoResolverService.stubs(:new).returns(resolver)
+
+    post connector_project_upload_bundles_url(project.id), params: { remote_repo_url: 'u' }
+    assert_redirected_to root_path
+    follow_redirect!
+    assert_match 'URL not supported', flash[:alert]
+  end
+
+  test 'create uses project_id from request body if route param is placeholder' do
+    project = create_project
+    Project.stubs(:find).with('').returns(nil)
+    Project.stubs(:find).with(project.id.to_s).returns(project)
+    resolver = mock('resolver')
+    url_res = OpenStruct.new(type: ConnectorType::ZENODO, object_url: 'u', unknown?: false)
+    resolver.stubs(:resolve).with('u').returns(url_res)
+    Repo::RepoResolverService.stubs(:new).returns(resolver)
+
+    processor = mock('proc')
+    processor.stubs(:params_schema).returns([:remote_repo_url])
+    processor.stubs(:create).returns(ConnectorResult.new(resource: UploadBundle.new({id: 'bundle_id'}), message: {notice: 'expected message'}, success: true))
+    ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).with(ConnectorType::ZENODO).returns(processor)
+    post connector_project_upload_bundles_url(':project_id'), params: { project_id: project.id.to_s, remote_repo_url: 'u' }
+
+    assert_redirected_to project_path(id: project.id.to_s, anchor: 'tab-link-bundle_id')
+    follow_redirect!
+    assert_match 'expected message', flash[:notice]
+  end
+
+  test 'edit renders partial' do
+    bundle = create_upload_bundle(create_project)
+    UploadBundle.stubs(:find).returns(bundle)
+    processor = mock('proc')
+    processor.stubs(:params_schema).returns([])
+    processor.stubs(:edit).returns(ConnectorResult.new(partial: '/p', locals: {}))
+    ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).returns(processor)
+    UploadBundlesConnectorController.any_instance.stubs(:render).returns(true)
+    get edit_project_upload_bundle_connector_url('p', bundle.id, format: :html)
+    assert_response :not_acceptable
+  end
+
+  test 'update redirects with processor result' do
+    bundle = create_upload_bundle(create_project)
+    UploadBundle.stubs(:find).returns(bundle)
+    processor = mock('proc')
+    processor.stubs(:params_schema).returns([])
+    processor.stubs(:update).returns(ConnectorResult.new(message: {notice: 'ok'}))
+    ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).returns(processor)
+    patch project_upload_bundle_connector_url('p', bundle.id)
+    assert_redirected_to root_path
+  end
+
+  test 'edit renders dataverse dataset create form partial' do
+    project = create_project
+    bundle = create_upload_bundle(project, type: ConnectorType::DATAVERSE)
+    UploadBundle.stubs(:find).returns(bundle)
+    processor = stub('proc', params_schema: [])
+    result = ConnectorResult.new(
+      template: '/connectors/dataverse/dataset_create_form',
+      locals: {
+        upload_bundle: bundle,
+        profile: OpenStruct.new(full_name: 'User', email: 'user@example.com'),
+        subjects: []
+      }
+    )
+    processor.stubs(:edit).returns(result)
+    ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).with(ConnectorType::DATAVERSE).returns(processor)
+
+    get edit_project_upload_bundle_connector_url(project.id, bundle.id, form: 'dataset_create')
+
+    assert_response :success
+    assert_select 'form'
+  end
+
+  test 'edit renders dataverse dataset select form partial' do
+    project = create_project
+    bundle = create_upload_bundle(project, type: ConnectorType::DATAVERSE)
+    UploadBundle.stubs(:find).returns(bundle)
+    processor = stub('proc', params_schema: [])
+    data = OpenStruct.new(total_count: 1, items: [OpenStruct.new(global_id: 'ds1', name: 'Dataset 1')])
+    result = ConnectorResult.new(
+      template: '/connectors/dataverse/dataset_select_form',
+      locals: { upload_bundle: bundle, data: data }
+    )
+    processor.stubs(:edit).returns(result)
+    ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).with(ConnectorType::DATAVERSE).returns(processor)
+
+    get edit_project_upload_bundle_connector_url(project.id, bundle.id, form: 'dataset_select')
+
+    assert_response :success
+    assert_select 'input[type=radio][name=dataset_id]'
+  end
+
+  test 'edit renders dataverse collection select form partial' do
+    project = create_project
+    bundle = create_upload_bundle(project, type: ConnectorType::DATAVERSE)
+    UploadBundle.stubs(:find).returns(bundle)
+    processor = stub('proc', params_schema: [])
+    data = OpenStruct.new(total_count: 1,
+                          items: [OpenStruct.new(identifier: 'c1', name: 'Col1', parent_dataverse_name: 'Root')])
+    result = ConnectorResult.new(
+      template: '/connectors/dataverse/collection_select_form',
+      locals: { upload_bundle: bundle, data: data }
+    )
+    processor.stubs(:edit).returns(result)
+    ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).with(ConnectorType::DATAVERSE).returns(processor)
+
+    get edit_project_upload_bundle_connector_url(project.id, bundle.id, form: 'collection_select')
+
+    assert_response :success
+    assert_select 'input[type=radio][name=collection_id]'
+  end
+
+  test 'edit renders zenodo connector edit form partial' do
+    project = create_project
+    bundle = create_upload_bundle(project, type: ConnectorType::ZENODO)
+    bundle.metadata = { auth_key: 'abc' }
+    UploadBundle.stubs(:find).returns(bundle)
+    processor = stub('proc', params_schema: [])
+    result = ConnectorResult.new(
+      template: '/connectors/zenodo/connector_edit_form',
+      locals: { upload_bundle: bundle }
+    )
+    processor.stubs(:edit).returns(result)
+    ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).with(ConnectorType::ZENODO).returns(processor)
+
+    get edit_project_upload_bundle_connector_url(project.id, bundle.id)
+
+    assert_response :success
+    assert_select 'input[name="api_key"]'
+  end
+end

--- a/application/test/controllers/upload_bundles_controller_test.rb
+++ b/application/test/controllers/upload_bundles_controller_test.rb
@@ -3,89 +3,24 @@ require 'test_helper'
 class UploadBundlesControllerTest < ActionDispatch::IntegrationTest
   include ModelHelper
 
-  test 'create resolves repo and delegates to processor' do
+  test 'update changes name' do
     project = create_project
-    project.save
-    Project.stubs(:find).with(project.id.to_s).returns(project)
-    ApplicationController.any_instance.stubs(:load_user_settings)
+    bundle = create_upload_bundle(project)
+    bundle.name = 'old'
+    UploadBundle.stubs(:find).with(project.id, bundle.id).returns(bundle)
+    bundle.expects(:update).with('name' => 'new').returns(true)
 
-    resolver = mock('resolver')
-    url_res = OpenStruct.new(type: ConnectorType::ZENODO, object_url: 'u', unknown?: false)
-    resolver.stubs(:resolve).with('u').returns(url_res)
-    Repo::RepoResolverService.stubs(:new).returns(resolver)
-
-    processor = mock('proc')
-    processor.stubs(:params_schema).returns([:remote_repo_url])
-    processor.stubs(:create).returns(ConnectorResult.new(resource: UploadBundle.new, message: {notice: 'ok'}, success: true))
-    ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).with(ConnectorType::ZENODO).returns(processor)
-
-    post project_upload_bundles_url(project.id), params: { remote_repo_url: 'u' }
-    assert_response :redirect
+    patch project_upload_bundle_url(project.id, bundle.id), params: { name: 'new', ignored: 'x' }
+    assert_redirected_to root_path
   end
 
+  test 'update handles not found bundle' do
+    UploadBundle.stubs(:find).returns(nil)
 
-  test 'create redirects on invalid project' do
-    Project.stubs(:find).returns(nil)
-    post project_upload_bundles_url('1'), params: { remote_repo_url: 'u' }
+    patch project_upload_bundle_url('p', 'b'), params: { name: 'new' }
     assert_redirected_to root_path
     follow_redirect!
-    assert_match 'Invalid project id', flash[:alert]
-  end
-
-  test 'create handles unknown repo url' do
-    project = create_project
-    Project.stubs(:find).returns(project)
-    resolver = mock('resolver')
-    resolver.stubs(:resolve).with('u').returns(OpenStruct.new(unknown?: true))
-    Repo::RepoResolverService.stubs(:new).returns(resolver)
-
-    post project_upload_bundles_url(project.id), params: { remote_repo_url: 'u' }
-    assert_redirected_to root_path
-    follow_redirect!
-    assert_match 'URL not supported', flash[:alert]
-  end
-
-  test 'create uses project_id from request body if route param is placeholder' do
-    project = create_project
-    Project.stubs(:find).with('').returns(nil)
-    Project.stubs(:find).with(project.id.to_s).returns(project)
-    resolver = mock('resolver')
-    url_res = OpenStruct.new(type: ConnectorType::ZENODO, object_url: 'u', unknown?: false)
-    resolver.stubs(:resolve).with('u').returns(url_res)
-    Repo::RepoResolverService.stubs(:new).returns(resolver)
-
-    processor = mock('proc')
-    processor.stubs(:params_schema).returns([:remote_repo_url])
-    processor.stubs(:create).returns(ConnectorResult.new(resource: UploadBundle.new({id: 'bundle_id'}), message: {notice: 'expected message'}, success: true))
-    ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).with(ConnectorType::ZENODO).returns(processor)
-    post project_upload_bundles_url(':project_id'), params: { project_id: project.id.to_s, remote_repo_url: 'u' }
-
-    assert_redirected_to project_path(id: project.id.to_s, anchor: 'tab-link-bundle_id')
-    follow_redirect!
-    assert_match 'expected message', flash[:notice]
-  end
-
-  test 'edit renders partial' do
-    bundle = create_upload_bundle(create_project)
-    UploadBundle.stubs(:find).returns(bundle)
-    processor = mock('proc')
-    processor.stubs(:params_schema).returns([])
-    processor.stubs(:edit).returns(ConnectorResult.new(partial: '/p', locals: {}))
-    ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).returns(processor)
-    UploadBundlesController.any_instance.stubs(:render).returns(true)
-    get edit_project_upload_bundle_url('p', bundle.id, format: :html)
-    assert_response :not_acceptable
-  end
-
-  test 'update redirects with processor result' do
-    bundle = create_upload_bundle(create_project)
-    UploadBundle.stubs(:find).returns(bundle)
-    processor = mock('proc')
-    processor.stubs(:params_schema).returns([])
-    processor.stubs(:update).returns(ConnectorResult.new(message: {notice: 'ok'}))
-    ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).returns(processor)
-    patch project_upload_bundle_url('p', bundle.id)
-    assert_redirected_to root_path
+    assert_match 'Upload Bundle not found', flash[:alert]
   end
 
   test 'destroy removes upload bundle' do
@@ -98,85 +33,5 @@ class UploadBundlesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
     follow_redirect!
     assert_match 'Upload bundle deleted', flash[:notice]
-  end
-
-  test 'edit renders dataverse dataset create form partial' do
-    project = create_project
-    bundle = create_upload_bundle(project, type: ConnectorType::DATAVERSE)
-    UploadBundle.stubs(:find).returns(bundle)
-    processor = stub('proc', params_schema: [])
-    result = ConnectorResult.new(
-      template: '/connectors/dataverse/dataset_create_form',
-      locals: {
-        upload_bundle: bundle,
-        profile: OpenStruct.new(full_name: 'User', email: 'user@example.com'),
-        subjects: []
-      }
-    )
-    processor.stubs(:edit).returns(result)
-    ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).with(ConnectorType::DATAVERSE).returns(processor)
-
-    get edit_project_upload_bundle_url(project.id, bundle.id, form: 'dataset_create')
-
-    assert_response :success
-    assert_select 'form'
-  end
-
-  test 'edit renders dataverse dataset select form partial' do
-    project = create_project
-    bundle = create_upload_bundle(project, type: ConnectorType::DATAVERSE)
-    UploadBundle.stubs(:find).returns(bundle)
-    processor = stub('proc', params_schema: [])
-    data = OpenStruct.new(total_count: 1, items: [OpenStruct.new(global_id: 'ds1', name: 'Dataset 1')])
-    result = ConnectorResult.new(
-      template: '/connectors/dataverse/dataset_select_form',
-      locals: { upload_bundle: bundle, data: data }
-    )
-    processor.stubs(:edit).returns(result)
-    ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).with(ConnectorType::DATAVERSE).returns(processor)
-
-    get edit_project_upload_bundle_url(project.id, bundle.id, form: 'dataset_select')
-
-    assert_response :success
-    assert_select 'input[type=radio][name=dataset_id]'
-  end
-
-  test 'edit renders dataverse collection select form partial' do
-    project = create_project
-    bundle = create_upload_bundle(project, type: ConnectorType::DATAVERSE)
-    UploadBundle.stubs(:find).returns(bundle)
-    processor = stub('proc', params_schema: [])
-    data = OpenStruct.new(total_count: 1,
-                          items: [OpenStruct.new(identifier: 'c1', name: 'Col1', parent_dataverse_name: 'Root')])
-    result = ConnectorResult.new(
-      template: '/connectors/dataverse/collection_select_form',
-      locals: { upload_bundle: bundle, data: data }
-    )
-    processor.stubs(:edit).returns(result)
-    ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).with(ConnectorType::DATAVERSE).returns(processor)
-
-    get edit_project_upload_bundle_url(project.id, bundle.id, form: 'collection_select')
-
-    assert_response :success
-    assert_select 'input[type=radio][name=collection_id]'
-  end
-
-  test 'edit renders zenodo connector edit form partial' do
-    project = create_project
-    bundle = create_upload_bundle(project, type: ConnectorType::ZENODO)
-    bundle.metadata = { auth_key: 'abc' }
-    UploadBundle.stubs(:find).returns(bundle)
-    processor = stub('proc', params_schema: [])
-    result = ConnectorResult.new(
-      template: '/connectors/zenodo/connector_edit_form',
-      locals: { upload_bundle: bundle }
-    )
-    processor.stubs(:edit).returns(result)
-    ConnectorClassDispatcher.stubs(:upload_bundle_connector_processor).with(ConnectorType::ZENODO).returns(processor)
-
-    get edit_project_upload_bundle_url(project.id, bundle.id)
-
-    assert_response :success
-    assert_select 'input[name="api_key"]'
   end
 end

--- a/application/test/views/projects/upload_actions_view_test.rb
+++ b/application/test/views/projects/upload_actions_view_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UploadActionsViewTest < ActionView::TestCase
+  include ModelHelper
+
+  test 'renders edit upload bundle name button' do
+    project = create_project
+    bundle = create_upload_bundle(project)
+
+    html = render partial: 'projects/show/upload_actions', locals: { project: project, bundle: bundle, file_browser_id: 'fb', file_target_id: 'ft' }
+
+    assert_includes html, t('projects.show.upload_actions.button_edit_bundle_name_title')
+    assert_includes html, 'data-controller="upload-bundle-name"'
+  end
+end

--- a/docs/guide/content/user_guide/uploading_files.md
+++ b/docs/guide/content/user_guide/uploading_files.md
@@ -88,7 +88,7 @@ Each **upload bundle** tab provides controls for managing uploads, reviewing rep
 
 #### Upload Bundle Tab Header
 - **Creation Date** – The data when the bundle was created.
-- **Bundle Name** – The name of the bundle based on the repository domain.
+- **Bundle Name** – The name of the bundle based on the repository domain. Use the **Edit Name** button (pencil icon) to rename the bundle if needed.
 - **File Summary Widget** – Displays counts for pending, completed, or failed files. The large circular indicator highlights the percentage of completed downloads.
 - **Add Files** – Opens the [upload file selector](./upload_file_selector.md) to choose files from your HPC filesystem.
 - **Delete Bundle** – Removes the bundle and its associated uploads from the interface.


### PR DESCRIPTION
## Summary
- move connector operations into new `UploadBundlesConnectorController`
- support renaming bundles and add logging in `UploadBundlesController`
- update routes, views and tests to use connector-specific paths
- add UI to rename upload bundles inline

## Testing
- `bundle exec bin/rails test test/controllers/upload_bundles_controller_test.rb test/controllers/upload_bundles_connector_controller_test.rb test/views/projects/upload_actions_view_test.rb`
- `bundle exec bin/rails test`

------
https://chatgpt.com/codex/tasks/task_e_68a0fb14a7c08321bd8bf4303386c919