### PR TITLE
Use repository domain for upload bundle names

### DIFF
--- a/application/app/connectors/dataverse/handlers/upload_bundle_create.rb
+++ b/application/app/connectors/dataverse/handlers/upload_bundle_create.rb
@@ -57,7 +57,7 @@ module Dataverse::Handlers
       file_utils = Common::FileUtils.new
       upload_bundle = UploadBundle.new.tap do |bundle|
         bundle.id = file_utils.normalize_name(File.join(url_data.domain, UploadBundle.generate_code))
-        bundle.name = bundle.id
+        bundle.name = url_data.domain
         bundle.project_id = project.id
         bundle.remote_repo_url = remote_repo_url
         bundle.type = ConnectorType::DATAVERSE

--- a/application/app/connectors/zenodo/handlers/upload_bundle_create.rb
+++ b/application/app/connectors/zenodo/handlers/upload_bundle_create.rb
@@ -44,7 +44,7 @@ module Zenodo::Handlers
       file_utils = Common::FileUtils.new
       upload_bundle = UploadBundle.new.tap do |bundle|
         bundle.id = file_utils.normalize_name(File.join(url_data.domain, UploadBundle.generate_code))
-        bundle.name = bundle.id
+        bundle.name = url_data.domain
         bundle.project_id = project.id
         bundle.remote_repo_url = remote_repo_url
         bundle.type = ConnectorType::ZENODO

--- a/application/test/connectors/dataverse/handlers/upload_bundle_create_test.rb
+++ b/application/test/connectors/dataverse/handlers/upload_bundle_create_test.rb
@@ -14,8 +14,10 @@ class Dataverse::Handlers::UploadBundleCreateTest < ActiveSupport::TestCase
 
   test 'create handles Dataverse url' do
     Dataverse::CollectionService.stubs(:new).returns(stub(find_collection_by_id: OpenStruct.new(data: OpenStruct.new(name: 'root'))))
+    UploadBundle.any_instance.stubs(:save)
     result = @action.create(@project, object_url: 'http://dv.org')
     assert result.success?
+    assert_equal 'dv.org', result.resource.name
   end
 
   test 'create handles collection url' do

--- a/application/test/connectors/zenodo/handlers/upload_bundle_create_test.rb
+++ b/application/test/connectors/zenodo/handlers/upload_bundle_create_test.rb
@@ -22,6 +22,7 @@ class Zenodo::Handlers::UploadBundleCreateTest < ActiveSupport::TestCase
 
     result = @action.create(@project, object_url: 'https://zenodo.org/about')
     assert result.success?
+    assert_equal 'zenodo.org', result.resource.name
     assert_equal 'https://zenodo.org', result.resource.metadata[:zenodo_url]
     assert_nil result.resource.metadata[:record_id]
     assert_nil result.resource.metadata[:deposition_id]


### PR DESCRIPTION
## Summary
- name upload bundles using repo URL domain for Dataverse and Zenodo connectors
- verify bundle names in associated tests

## Testing
- `bundle exec rails test`


------
https://chatgpt.com/codex/tasks/task_e_68a230f2df488321901711a13788d99e