### PR TITLE
Refactor metadata folder links

### DIFF
--- a/application/app/views/layouts/_project_bar.html.erb
+++ b/application/app/views/layouts/_project_bar.html.erb
@@ -20,13 +20,9 @@
   </div>
 
   <div>
-    <a href="<%= files_app_url(Project.project_metadata_dir(project.id)) %>"
-       target="_blank"
-       class="btn btn-sm btn-outline-primary ms-3"
-       title="<%= t('.link_open_metadata_title') %>">
-      <i class="bi bi-card-list" aria-hidden="true"></i>
-      <span class="visually-hidden"><%= t('.link_open_metadata_title') %></span>
-    </a>
+    <%= render partial: '/shared/metadata_folder_link',
+               locals: { path: Project.project_metadata_dir(project.id),
+                         class: 'btn btn-sm btn-outline-primary ms-3' } %>
     <button class="btn btn-sm btn-outline-primary cursor-default" title="<%= t('.button_active_project_title') %>">
       <i class="bi bi-check-circle-fill" aria-hidden="true"></i>
       <span class="visually-hidden"><%= t('.button_active_project_title') %></span>

--- a/application/app/views/projects/index/_project_summary.html.erb
+++ b/application/app/views/projects/index/_project_summary.html.erb
@@ -13,13 +13,8 @@
     <strong><%= t('.button_toggle_label') %></strong>
   </a>
   <div>
-    <a href="<%= files_app_url(Project.project_metadata_dir(project.id)) %>"
-       target="_blank"
-       class="btn btn-sm btn-outline-secondary"
-       title="<%= t('.button_metadata_folder_title') %>">
-      <i class="bi bi-card-list" aria-hidden="true"></i>
-      <span class="visually-hidden"><%= t('.button_metadata_folder_title') %></span>
-    </a>
+    <%= render partial: '/shared/metadata_folder_link',
+               locals: { path: Project.project_metadata_dir(project.id) } %>
   </div>
 </div>
 

--- a/application/app/views/projects/show/_download_actions.html.erb
+++ b/application/app/views/projects/show/_download_actions.html.erb
@@ -19,20 +19,27 @@
         </div>
       </div>
 
-      <!-- edit workspace folder -->
-      <div data-controller="project-download-dir"
-           data-project-download-dir-browser-id-value="<%= file_browser_id %>">
-        <button type="button" class="btn btn-sm btn-outline-secondary"
-                data-controller="lazy-loader"
-                data-lazy-loader-container-id-value="<%= file_browser_id %>"
-                data-lazy-loader-url-value="<%= file_browser_path(path: project.download_dir) %>"
-                data-action="click->lazy-loader#load click->project-download-dir#open"
-                title="<%= t('.button_edit_download_dir_title') %>"
-                aria-label="<%= t('.button_edit_download_dir_label') %>">
-          <i class="bi bi-pencil-square" aria-hidden="true"></i>
-          <span class="visually-hidden"><%= t('.button_edit_download_dir_label') %></span>
-        </button>
-        <%= render partial: '/projects/show/edit_download_dir_modal', locals: { project: project, file_browser_id: file_browser_id } %>
+      <div class="d-flex align-items-center gap-2">
+        <!-- edit workspace folder -->
+        <div data-controller="project-download-dir"
+             data-project-download-dir-browser-id-value="<%= file_browser_id %>">
+          <button type="button" class="btn btn-sm btn-outline-secondary"
+                  data-controller="lazy-loader"
+                  data-lazy-loader-container-id-value="<%= file_browser_id %>"
+                  data-lazy-loader-url-value="<%= file_browser_path(path: project.download_dir) %>"
+                  data-action="click->lazy-loader#load click->project-download-dir#open"
+                  title="<%= t('.button_edit_download_dir_title') %>"
+                  aria-label="<%= t('.button_edit_download_dir_label') %>">
+            <i class="bi bi-pencil-square" aria-hidden="true"></i>
+            <span class="visually-hidden"><%= t('.button_edit_download_dir_label') %></span>
+          </button>
+          <%= render partial: '/projects/show/edit_download_dir_modal',
+                     locals: { project: project, file_browser_id: file_browser_id } %>
+        </div>
+
+        <!-- Open metadata link -->
+        <%= render partial: '/shared/metadata_folder_link',
+                   locals: { path: Project.download_files_directory(project.id) } %>
       </div>
     </div>
 

--- a/application/app/views/projects/show/_project_actions.html.erb
+++ b/application/app/views/projects/show/_project_actions.html.erb
@@ -98,11 +98,6 @@
   </div>
 
   <!-- Open metadata link -->
-  <a href="<%= files_app_url(Project.project_metadata_dir(project.id)) %>"
-     target="_blank"
-     class="btn btn-sm btn-outline-secondary"
-     title="<%= t('.button_open_project_metadata_title') %>">
-    <i class="bi bi-card-list" aria-hidden="true"></i>
-    <span class="visually-hidden"><%= t('.button_open_project_metadata_title') %></span>
-  </a>
+  <%= render partial: '/shared/metadata_folder_link',
+             locals: { path: Project.project_metadata_dir(project.id) } %>
 </div>

--- a/application/app/views/shared/_metadata_folder_link.html.erb
+++ b/application/app/views/shared/_metadata_folder_link.html.erb
@@ -1,11 +1,11 @@
 <%
+  path = local_assigns.fetch(:path)
   text = local_assigns.fetch(:text, t('.button_open_folder_text'))
   title = local_assigns.fetch(:title, t('.button_open_folder_title'))
   classes = local_assigns.fetch(:class, 'btn btn-sm btn-outline-secondary')
-
 %>
 <!-- Open metadata link -->
-<a href="<%= files_app_url(Project.project_metadata_dir(project.id)) %>"
+<a href="<%= files_app_url(path) %>"
    target="_blank"
    class="<%= classes %>"
    title="<%= title %>">

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -79,7 +79,6 @@ en:
       button_active_project_title: "Active Project"
       field_creation_date_title: "Creation date"
       link_open_downloads_title: "Open Project workspace folder"
-      link_open_metadata_title: "Open Project metadata folder"
     repo_resolver_bar:
       input_repo_url_placeholder: "Paste Repository URL"
       input_repo_url_label: "Repository URL"
@@ -121,7 +120,6 @@ en:
         button_delete_project_title: "Delete Project"
         button_open_project_folder_label: "Open Project workspace folder"
         button_open_project_folder_title: "Open Project workspace folder"
-        button_open_project_metadata_title: "Open Project metadata folder"
         field_creation_date_title: "Creation date"
         modal_delete_confirmation_title: "Delete Project"
         modal_delete_confirmation_content: "This will remove the project from the app. Files on disk and in remote repositories will remain untouched."
@@ -173,7 +171,6 @@ en:
         section_project_actions_label: "Project actions section"
         section_rename_project_label: "Rename project section"
       project_summary:
-        button_metadata_folder_title: "Open project metadata folder"
         button_toggle_label: "Project Summary"
         tab_download_label: "Download Files"
       project_summary_downloads:


### PR DESCRIPTION
## Summary
- accept path parameter in shared metadata folder link partial and build link via files_app_url
- update project bar, summary, and actions views to pass metadata folder path to the partial
- link to download file metadata folder from the project downloads panel

## Testing
- `bundle exec rails test`


------
https://chatgpt.com/codex/tasks/task_e_68a4c85c19e48321b7924d6b93c0fb0e