### PR TITLE
Remove repo URLs from Project model

### DIFF
--- a/application/app/connectors/dataverse/handlers/datasets.rb
+++ b/application/app/connectors/dataverse/handlers/datasets.rb
@@ -122,11 +122,6 @@ module Dataverse::Handlers
       if save_results.include?(false)
         return ConnectorResult.new(message: { alert: I18n.t('connectors.dataverse.datasets.download.error_generating_the_download_file') }, success: false)
       end
-
-      dataset_url = Dataverse::Concerns::DataverseUrlBuilder.build_dataset_url(repo_url.to_s, @persistent_id, version: version)
-      project.add_repo(dataset_url)
-      project.save
-
       ConnectorResult.new(message: { notice: I18n.t('connectors.dataverse.datasets.download.files_added_to_project', project_name: project.name) }, success: true)
     end
   end

--- a/application/app/connectors/zenodo/handlers/records.rb
+++ b/application/app/connectors/zenodo/handlers/records.rb
@@ -71,9 +71,6 @@ module Zenodo::Handlers
         return ConnectorResult.new(message: { alert: I18n.t('zenodo.records.message_save_file_error', project_name: project.name) }, success: false)
       end
       log_info('Download files created', { project_id: project.id, files: download_files.size })
-      record_url = Zenodo::Concerns::ZenodoUrlBuilder.build_record_url(repo_url.server_url, @record_id)
-      project.add_repo(record_url)
-      project.save
       ConnectorResult.new(message: { notice: I18n.t('zenodo.records.message_success', files: save_results.size, project_name: project.name) }, success: true)
     end
   end

--- a/application/app/models/project.rb
+++ b/application/app/models/project.rb
@@ -5,10 +5,8 @@ class Project < ApplicationDiskRecord
   include FileStatusSummary
   include LoggingCommon
 
-  MAX_REPO_URLS = 20
-
   REQUIRED_ATTRIBUTES = %w[id name download_dir creation_date].freeze
-  ATTRIBUTES = (REQUIRED_ATTRIBUTES + %w[repo_urls]).freeze
+  ATTRIBUTES = REQUIRED_ATTRIBUTES
 
   attr_accessor(*ATTRIBUTES)
 
@@ -31,24 +29,11 @@ class Project < ApplicationDiskRecord
     load_from_file(filename)
   end
 
-  def initialize(id: nil, name: nil, download_dir: nil, repo_urls: nil)
+  def initialize(id: nil, name: nil, download_dir: nil)
     self.id = id || Project.generate_id
     self.name = name || self.id
     self.download_dir = download_dir || File.join(Configuration.download_root, self.id.to_s)
     self.creation_date = DateTimeCommon.now
-    self.repo_urls = repo_urls || []
-  end
-
-  def repo_urls=(urls)
-    @repo_urls = Array(urls)
-  end
-
-  def add_repo(url)
-    return if url.blank?
-
-    repo_urls.delete(url)
-    repo_urls.unshift(url)
-    self.repo_urls = repo_urls.take(MAX_REPO_URLS)
   end
 
   def download_files

--- a/application/test/connectors/dataverse/handlers/datasets_test.rb
+++ b/application/test/connectors/dataverse/handlers/datasets_test.rb
@@ -65,9 +65,7 @@ class Dataverse::Handlers::DatasetsTest < ActiveSupport::TestCase
 
     Project.stubs(:find).with('1').returns(nil)
     project = mock('project')
-    project.expects(:save).twice.returns(true)
-    dataset_url = Dataverse::Concerns::DataverseUrlBuilder.build_dataset_url(@repo_url.to_s, 'pid', version: '1')
-    project.expects(:add_repo).with(dataset_url)
+    project.expects(:save).returns(true)
     project.stubs(:name).returns('Proj')
     project.stubs(:id).returns('1')
 

--- a/application/test/connectors/zenodo/handlers/records_test.rb
+++ b/application/test/connectors/zenodo/handlers/records_test.rb
@@ -36,9 +36,7 @@ class Zenodo::Handlers::RecordsTest < ActiveSupport::TestCase
 
     Project.stubs(:find).with('1').returns(nil)
     project = mock('project')
-    project.expects(:save).twice.returns(true)
-    record_url = Zenodo::Concerns::ZenodoUrlBuilder.build_record_url(@repo_url.server_url, '123')
-    project.expects(:add_repo).with(record_url)
+    project.expects(:save).returns(true)
     project.stubs(:name).returns('Proj')
     project.stubs(:id).returns(1)
 

--- a/application/test/models/project_test.rb
+++ b/application/test/models/project_test.rb
@@ -8,12 +8,6 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal 'test_project', target.name
     assert_equal '/tmp/test_project', target.download_dir
     assert_not_nil target.creation_date
-    assert_equal [], target.repo_urls
-  end
-
-  test "initializer stores empty repo_urls when nil provided" do
-    target = create_valid_project(repo_urls: nil)
-    assert_equal [], target.repo_urls
   end
 
   test "should be valid when all fields are populated" do
@@ -115,7 +109,6 @@ class ProjectTest < ActiveSupport::TestCase
       assert_equal 'ab12345', saved_project.id
       assert_equal 'test_project', saved_project.name
       assert_equal '/tmp/test_project', saved_project.download_dir
-      assert_equal [], saved_project.repo_urls
     end
   end
 
@@ -135,7 +128,6 @@ class ProjectTest < ActiveSupport::TestCase
       assert_equal target2.id, saved_project.id
       assert_equal target2.name, saved_project.name
       assert_equal target2.download_dir, saved_project.download_dir
-      assert_equal [], saved_project.repo_urls
     end
   end
 
@@ -155,7 +147,6 @@ class ProjectTest < ActiveSupport::TestCase
       assert_equal 'ab12345', saved_project.id
       assert_equal 'test_project', saved_project.name
       assert_equal '/tmp/test_project', saved_project.download_dir
-      assert_equal [], saved_project.repo_urls
     end
   end
 
@@ -272,46 +263,14 @@ class ProjectTest < ActiveSupport::TestCase
     end
   end
 
-  test "repo_urls default to empty and add_repo handles MRU" do
-    target = create_valid_project
-    assert_equal [], target.repo_urls
-
-    target.add_repo('http://example.com/one')
-    target.add_repo('http://example.com/two')
-    target.add_repo('http://example.com/one')
-
-    assert_equal ['http://example.com/one', 'http://example.com/two'], target.repo_urls
-  end
-
-  test "add_repo enforces max of 20 repo_urls" do
-    target = create_valid_project
-    urls = (1..21).map { |i| "http://example.com/repo#{i}" }
-    urls.each { |u| target.add_repo(u) }
-
-    assert_equal 20, target.repo_urls.size
-    assert_equal urls.last(20).reverse, target.repo_urls
-  end
-
-  test "repo_urls persist when saved" do
-    in_temp_directory do
-      target = create_valid_project
-      target.add_repo('http://example.com/a')
-      target.add_repo('http://example.com/b')
-      assert target.save
-
-      saved = Project.find(target.id)
-      assert_equal ['http://example.com/b', 'http://example.com/a'], saved.repo_urls
-    end
-  end
-
   private
 
-  def create_valid_project(id: 'ab12345', name: 'test_project', download_dir: '/tmp/test_project', repo_urls: [])
-    Project.new(id: id, name: name, download_dir: download_dir, repo_urls: repo_urls)
+  def create_valid_project(id: 'ab12345', name: 'test_project', download_dir: '/tmp/test_project')
+    Project.new(id: id, name: name, download_dir: download_dir)
   end
 
   def project_hash(project)
-    {id: project.id, name: project.name, download_dir: project.download_dir, creation_date: project.creation_date, repo_urls: project.repo_urls}.stringify_keys
+    {id: project.id, name: project.name, download_dir: project.download_dir, creation_date: project.creation_date}.stringify_keys
   end
 
   def in_temp_directory
@@ -324,3 +283,4 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
 end
+


### PR DESCRIPTION
## Summary
- drop `repo_urls` attribute and `add_repo` from `Project`
- stop connectors from recording repository URLs on projects
- update tests for simplified Project model

## Testing
- `bundle exec rubocop`
- `bundle exec rails test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e6d3134c832194e8498a5335bd6e