### PR TITLE
Narrow progress bar and expand status text columns

### DIFF
--- a/application/app/views/download_status/_files.html.erb
+++ b/application/app/views/download_status/_files.html.erb
@@ -9,7 +9,7 @@
       <% files.each_with_index do |data, index| %>
         <div class="row py-2 align-items-center <%= 'custom-stripe' if index.even? %>" role="row">
           <!-- info for medium and large screens -->
-          <div class="col-md-8" role="cell">
+          <div class="col-md-9" role="cell">
             <div class="d-flex align-items-center">
               <%= link_to(files_app_url(data.project.download_dir), class: 'btn btn-sm btn-outline-secondary me-2',
                           title: t('.button_browse_file_title'), target: '_blank') do %>
@@ -18,7 +18,7 @@
               <% end %>
               <%= render partial: '/shared/file_row_date', locals: { date: data.file.creation_date, title: t('.field_creation_date_title'), classes: "mx-2" } %>
               <span class="me-2"><%= connector_icon(data.file.type) %></span>
-              <span class="text-truncate cursor-default" style="max-width: 560px;" >
+              <span class="text-truncate cursor-default" style="max-width: 620px;" >
                 <%= link_to project_path(id: data.project.id), class: "position-relative project-name-link text-reset text-decoration-none rounded-end", title: t('.field_project_title', name: data.project.name) do %>
                   <%= data.project.name %>
                   <span class="text-muted">&raquo;</span>
@@ -30,7 +30,7 @@
           </div>
           <!-- end info for medium and large screens -->
 
-          <div class="col-md-2" role="cell">
+          <div class="col-md-1" role="cell">
             <% if data.file.status.downloading? %>
               <%= render partial: '/shared/progress_bar', locals: { progress: data.file.connector_status.download_progress, file: data.file } %>
             <% end %>

--- a/application/app/views/shared/_progress_bar.html.erb
+++ b/application/app/views/shared/_progress_bar.html.erb
@@ -1,5 +1,5 @@
 <% progress ||= 0 %>
-<div class="progress" aria-live="polite" style="height: 20px; max-width: 4rem;">
+<div class="progress" aria-live="polite" style="height: 20px; max-width: 8rem;">
   <div class="progress-bar progress-bar-striped progress-bar-animated bg-info"
        role="progressbar"
        style="width: <%= progress %>%"

--- a/application/app/views/shared/_progress_bar.html.erb
+++ b/application/app/views/shared/_progress_bar.html.erb
@@ -1,5 +1,5 @@
 <% progress ||= 0 %>
-<div class="progress" aria-live="polite" style="height: 20px;">
+<div class="progress" aria-live="polite" style="height: 20px; max-width: 4rem;">
   <div class="progress-bar progress-bar-striped progress-bar-animated bg-info"
        role="progressbar"
        style="width: <%= progress %>%"

--- a/application/app/views/upload_status/_files.html.erb
+++ b/application/app/views/upload_status/_files.html.erb
@@ -8,7 +8,7 @@
       <% files.each_with_index do |data, index| %>
         <div class="row py-2 align-items-center <%= 'custom-stripe' if index.even? %>" role="row">
           <!-- info for medium and large screens -->
-          <div class="col-md-8" role="cell">
+          <div class="col-md-9" role="cell">
             <div class="d-flex align-items-center">
               <%= link_to(files_app_url(data.project.download_dir), class: 'btn btn-sm btn-outline-secondary me-2',
                           title: t('.button_browse_file_title'), target: '_blank') do %>
@@ -17,7 +17,7 @@
               <% end %>
               <%= render partial: '/shared/file_row_date', locals: { date: data.file.creation_date, title: t('.field_creation_date_title'), classes: "mx-2" } %>
               <span class="me-2"><%= connector_icon(data.upload_bundle.type) %></span>
-              <span class="text-truncate cursor-default" style="max-width: 600px;">
+                <span class="text-truncate cursor-default" style="max-width: 660px;">
                 <%= link_to project_path(id: data.project.id, anchor: tab_anchor_for(data.upload_bundle)), class: "position-relative project-name-link text-reset text-decoration-none rounded-end" do %>
                   <span class="" title="<%= t('.field_project_title', name: data.project.name) %>"><%= data.project.name %></span>
                   <span class="text-muted">&raquo;</span>
@@ -31,7 +31,7 @@
           </div>
           <!-- end info for medium and large screens -->
 
-          <div class="col-md-2" role="cell">
+          <div class="col-md-1" role="cell">
             <% if data.file.status.uploading? %>
               <%= render partial: '/shared/progress_bar', locals: { progress: data.file.connector_status.upload_progress, file: data.file } %>
             <% end %>


### PR DESCRIPTION
## Summary
- Narrow progress bar component with a maximum width
- Allocate more column space for download status text and shrink progress bar column
- Allocate more column space for upload status text and shrink progress bar column

## Testing
- `bundle exec rails test test/controllers/download_status_controller_test.rb test/controllers/upload_status_controller_test.rb` *(fails: command not found: rails)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a5de9366e0832b981246c618885044