### PR TITLE
Update tests for Current settings changes

### DIFF
--- a/application/test/helpers/projects_helper_test.rb
+++ b/application/test/helpers/projects_helper_test.rb
@@ -6,12 +6,10 @@ class ProjectsHelperTest < ActionView::TestCase
 
   setup do
     @original_settings = Current.settings
-    @original_from_project = Current.from_project
   end
 
   teardown do
     Current.settings = @original_settings
-    Current.from_project = @original_from_project
   end
 
   test 'header and border classes respond to active' do
@@ -69,20 +67,6 @@ class ProjectsHelperTest < ActionView::TestCase
     result = select_project_list
 
     assert_equal [project2, project1], result
-  end
-
-  test 'select_project_list prioritizes current project over active project' do
-    project1 = OpenStruct.new(id: 1, name: 'Project A')
-    project2 = OpenStruct.new(id: 2, name: 'Project B')
-    project3 = OpenStruct.new(id: 3, name: 'Project C')
-    Project.stubs(:all).returns([project1, project2, project3])
-    Current.settings = OpenStruct.new(user_settings: OpenStruct.new(active_project: '2'))
-    self.stubs(:t).with('helpers.projects.active_project_text').returns('Active')
-
-    Current.from_project = '3'
-    result = select_project_list
-
-    assert_equal [project3, project2, project1], result
   end
 
   test 'select_project_list returns original order if no active match' do


### PR DESCRIPTION
## Summary
- adjust ApplicationController tests for new dynamic user settings
- drop obsolete from_project references in ProjectsHelper tests

## Testing
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_68a732960f0c8321a69e10cc32298dcf