### PR TITLE
Add standalone select files Stimulus controller

### DIFF
--- a/application/app/javascript/controllers/select_files_controller.js
+++ b/application/app/javascript/controllers/select_files_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static targets = ["item", "selectAll", "submitButton"]
+
+    connect() {
+        // Delay update to allow other controllers to connect
+        requestAnimationFrame(() => {
+            this.updateState()
+        })
+    }
+
+    toggleSelectAll(event) {
+        const isChecked = event.target.checked
+        this.itemTargets.forEach(checkbox => {
+            checkbox.checked = isChecked
+        })
+        this.updateState()
+    }
+
+    updateState() {
+        const allChecked = this.itemTargets.every(checkbox => checkbox.checked)
+        const anyChecked = this.itemTargets.some(checkbox => checkbox.checked)
+
+        if (this.hasSelectAllTarget) {
+            this.selectAllTarget.checked = allChecked
+            this.selectAllTarget.indeterminate = !allChecked && anyChecked
+        }
+
+        this.submitButtonTargets.forEach(button => {
+            button.disabled = !anyChecked
+        })
+    }
+}
+


### PR DESCRIPTION
## Summary
- add select_files_controller Stimulus controller to manage file selection without project handling

## Testing
- `make test` *(fails: docker: No such file or directory)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7a04ff74c8321b42336be512d3fff