### PR TITLE
Refactor Zenodo record views for new project selectors

### DIFF
--- a/application/app/views/connectors/zenodo/shared/_zenodo_record_actions.html.erb
+++ b/application/app/views/connectors/zenodo/shared/_zenodo_record_actions.html.erb
@@ -2,49 +2,20 @@
   <div class="d-flex align-items-center gap-2">
     <h2 class="mb-0 me-2 fs-4 h5 text-truncate cursor-default" style="max-width: 800px;" title="<%= record.title %>"><%= record.title %></h2>
   </div>
-  <div class="d-flex align-items-center gap-2">
+  <div class="d-flex align-items-center gap-2" data-controller="select-project-listener">
     <!-- create bundle button -->
-    <%= form_with url: connector_project_upload_bundles_path(':project_id'),
-                  method: :post,
-                  class: "d-inline",
-                  data: {
-                    controller: "submit-button select-files-project-listener",
-                    select_files_project_listener_enable_on_select_value: "true",
-                  } do %>
+    <%= render layout: "shared/button_to", locals: {
+      url: connector_project_upload_bundles_path(':project_id'),
+      method: 'POST',
+      label: t('.button_create_bundle_label'),
+      title:  t('.button_create_bundle_title'),
+      class: "btn-sm btn-outline-secondary",
+      icon: "bi bi-folder-plus",
+      button_data: {select_project_listener_target: 'button'}
+    } do %>
 
       <input type="hidden" name="remote_repo_url" id="remote_repo_url" autocomplete="off" value="<%= external_record_url(record.id) %>">
-      <input type="hidden" name="project_id" id="project_id" autocomplete="off" data-select-files-project-listener-target="field">
-
-      <%= button_tag type: 'submit',
-                     class: 'btn btn-sm btn-outline-secondary',
-                     title: t('.button_create_bundle_title'),
-                     "aria-label" => t('.button_create_bundle_title'),
-                     data: {
-                       action: 'click->submit-button#click',
-                       submit_button_target: 'button',
-                       select_files_project_listener_target: 'button'
-                     } do %>
-
-        <span data-submit-button-target="spinner"
-              class="spinner-border spinner-border-sm me-1 d-none"
-              role="status" aria-hidden="true"></span>
-
-        <span data-submit-button-target="label">
-          <i class="bi bi-folder-plus" aria-hidden="true"></i>
-          <span class="ps-1"><%= t('.button_create_bundle_label') %></span>
-        </span>
-
-      <% end %>
-    <% end %>
-
-    <!-- link to project details page -->
-    <%= link_to projects_path,
-                class: 'btn btn-sm btn-outline-secondary disabled',
-                title: t('.button_open_project_title'),
-                data: { controller: 'select-files-project-listener', select_files_project_listener_target: 'link' },
-                aria: { disabled: true } do %>
-      <i class="bi bi-display" aria-hidden="true"></i>
-      <span class="visually-hidden"><%= t('.button_open_project_label') %></span>
+      <input type="hidden" name="project_id" id="project_id" autocomplete="off" data-select-project-listener-target="inputProjectId">
     <% end %>
 
     <!-- link to external repository dataset -->

--- a/application/app/views/connectors/zenodo/shared/_zenodo_record_files.html.erb
+++ b/application/app/views/connectors/zenodo/shared/_zenodo_record_files.html.erb
@@ -4,7 +4,7 @@
     <%= t('zenodo.records.show.caption_files_text', count: record.files.size) %>
   </div>
   <% if record.files.any? %>
-    <%= form_with url: post_url, class: 'p-3 rounded bg-light', local: true, data: {controller: 'select-files-project', "select-files-project-external-targets-value": '["record_create_bundle"]'} do |f| %>
+    <%= form_with url: post_url, id: 'record-download-files-form', method: :post, local: true, class: "p-3 rounded bg-light", data: {controller: "select-files"} do %>
       <%= hidden_field_tag :id, record_id %>
       <div class="row">
         <h2 id="record-files-heading" class="visually-hidden"><%= t('.header_record_files_a11y_text') %></h2>
@@ -17,7 +17,7 @@
                 <label class="visually-hidden" for="select_all_files">
                   <%= t('.checkbox_select_all_label') %>
                 </label>
-                <input type="checkbox" id="select_all_files" class="form-check-input m-0" data-select-files-project-target="selectAll" data-action="select-files-project#toggleSelectAll">
+                <input type="checkbox" id="select_all_files" class="form-check-input m-0" data-select-files-target="selectAll" data-action="select-files#toggleSelectAll">
               </div>
             </th>
             <th scope="col"><%= t('.col_file_name_text') %></th>
@@ -28,22 +28,45 @@
             <% record.files.each do |file| %>
               <tr>
                 <td class="text-center">
-                  <input type="checkbox" id="file_checkbox_<%= file.id %>" name="file_ids[]" class="form-check-input" value="<%= file.id %>" data-select-files-project-target="item" data-action="select-files-project#updateState">
+                  <input type="checkbox" id="file_checkbox_<%= file.id %>" name="file_ids[]" class="form-check-input" value="<%= file.id %>" data-select-files-target="item" data-action="select-files#updateState">
                 </td>
                 <td>
-                  <label for="file_checkbox_<%= file.id %>">
+                  <label for="file_checkbox_<%= file.id %>" class="d-block mb-1">
                     <%= file.filename %>
                   </label>
                 </td>
-                <td><%= number_to_human_size(file.filesize) %></td>
+                <td class="text-nowrap"><%= number_to_human_size(file.filesize) %></td>
               </tr>
             <% end %>
           </tbody>
         </table>
       </div>
-      <div class="text-center">
-        <%= render partial: '/shared/project_selection' %>
+
+      <div class="row g-3 align-items-end p-3">
+        <div class="col-md-9 text-start mt-0" data-controller="select-project-listener">
+          <label for="active_project" class="form-label small mb-1 ms-1"><%= t('.label_selected_project_text') %></label>
+
+          <div class="d-flex align-items-center">
+            <input type="text" id="active_project" class="form-control me-3" value="<%= t('.input_selected_project_default_value') %>"
+                   data-select-project-listener-target="inputProjectName" disabled>
+            <!-- link to project details page -->
+            <%= link_to projects_path,
+                        class: 'btn btn-outline-secondary',
+                        title: t('.button_open_project_title'),
+                        data: { select_project_listener_target: 'link' } do %>
+              <i class="bi bi-display" aria-hidden="true"></i>
+              <span class="visually-hidden"><%= t('.button_open_project_label') %></span>
+            <% end %>
+          </div>
+        </div>
+        <div class="col-md-3 text-center">
+          <button id="files_submit" type="submit" class="btn btn-primary" data-select-files-target="submitButton">
+            <i class="bi bi-download me-1" aria-hidden="true"></i>
+            <%= t('.button_submit_form_text') %>
+          </button>
+        </div>
       </div>
+
     <% end %>
   <% else %>
     <div class="list-group list-group-flush">

--- a/application/config/locales/connectors/zenodo/en.yml
+++ b/application/config/locales/connectors/zenodo/en.yml
@@ -78,8 +78,6 @@ en:
           link_open_record_title: "Open record on Zenodo"
           button_create_bundle_label: "Create Upload Bundle"
           button_create_bundle_title: "Create Upload Bundle from this record on the selected project"
-          button_open_project_title: "Open selected project details page"
-          button_open_project_label: "Open selected project"
         zenodo_record_info:
           header_record_text: "Record"
           badge_draft_text: "Draft"
@@ -94,6 +92,11 @@ en:
           header_record_files_a11y_text: "Record files"
           msg_empty_record_text: "The record does not contain files to download"
           table_record_files_caption: "Record files"
+          label_selected_project_text: "Selected project:"
+          input_selected_project_default_value: "➕ A new project will be automatically created"
+          button_open_project_title: "Open selected project details page"
+          button_open_project_label: "Open selected project"
+          button_submit_form_text: "Add Files to Project"
 
   zenodo:
     depositions:


### PR DESCRIPTION
## Summary
- update Zenodo record/deposition actions to use `select-project-listener` and shared `button_to`
- rework record files table to use `select-files` and new project selection display
- add translations for project selection UI in Zenodo connector

## Testing
- `bundle exec rails test`

------
https://chatgpt.com/codex/tasks/task_e_68a83ba9c21083219af103f72d8323c0