### PR TITLE
Expose Zenodo dataset metadata to shared view

### DIFF
--- a/application/app/connectors/zenodo/handlers/depositions.rb
+++ b/application/app/connectors/zenodo/handlers/depositions.rb
@@ -40,7 +40,9 @@ module Zenodo::Handlers
         locals: {
           record: deposition,
           record_id: @deposition_id,
-          repo_url: repo_url
+          repo_url: repo_url,
+          dataset_title: deposition.title,
+          external_zenodo_url: Zenodo::Concerns::ZenodoUrlBuilder.build_deposition_url(repo_url.server_url, @deposition_id)
         },
         success: true
       )

--- a/application/app/connectors/zenodo/handlers/records.rb
+++ b/application/app/connectors/zenodo/handlers/records.rb
@@ -33,7 +33,9 @@ module Zenodo::Handlers
         locals: {
           record: record,
           record_id: @record_id,
-          repo_url: repo_url
+          repo_url: repo_url,
+          dataset_title: record.title,
+          external_zenodo_url: Zenodo::Concerns::ZenodoUrlBuilder.build_record_url(repo_url.server_url, @record_id)
         },
         success: true
       )

--- a/application/app/views/connectors/zenodo/depositions/show.html.erb
+++ b/application/app/views/connectors/zenodo/depositions/show.html.erb
@@ -7,7 +7,7 @@
 
   <div class="row">
     <div class="col-md-12">
-      <%= render partial: 'connectors/zenodo/shared/zenodo_record_actions', locals: { record: record, zenodo_url: repo_url.server_url } %>
+      <%= render partial: 'connectors/zenodo/shared/zenodo_view_actions', locals: { dataset_title: dataset_title, external_zenodo_url: external_zenodo_url } %>
     </div>
   </div>
 

--- a/application/app/views/connectors/zenodo/records/show.html.erb
+++ b/application/app/views/connectors/zenodo/records/show.html.erb
@@ -7,7 +7,7 @@
 
   <div class="row">
     <div class="col-md-12">
-      <%= render partial: 'connectors/zenodo/shared/zenodo_record_actions', locals: { record: record, zenodo_url: repo_url.server_url } %>
+      <%= render partial: 'connectors/zenodo/shared/zenodo_view_actions', locals: { dataset_title: dataset_title, external_zenodo_url: external_zenodo_url } %>
     </div>
   </div>
 

--- a/application/app/views/connectors/zenodo/shared/_zenodo_view_actions.html.erb
+++ b/application/app/views/connectors/zenodo/shared/_zenodo_view_actions.html.erb
@@ -1,6 +1,6 @@
 <div class="d-flex justify-content-between align-items-center mt-3" aria-label="<%= t('.actions_bar_title_a11y_label') %>">
   <div class="d-flex align-items-center gap-2">
-    <h2 class="mb-0 me-2 fs-4 h5 text-truncate cursor-default" style="max-width: 800px;" title="<%= record.title %>"><%= record.title %></h2>
+    <h2 class="mb-0 me-2 fs-4 h5 text-truncate cursor-default" style="max-width: 800px;" title="<%= dataset_title %>"><%= dataset_title %></h2>
   </div>
   <div class="d-flex align-items-center gap-2" data-controller="select-project-listener">
     <!-- create bundle button -->
@@ -14,12 +14,12 @@
       button_data: {select_project_listener_target: 'button'}
     } do %>
 
-      <input type="hidden" name="remote_repo_url" id="remote_repo_url" autocomplete="off" value="<%= external_record_url(record.id) %>">
+      <input type="hidden" name="remote_repo_url" id="remote_repo_url" autocomplete="off" value="<%= external_zenodo_url %>">
       <input type="hidden" name="project_id" id="project_id" autocomplete="off" data-select-project-listener-target="inputProjectId">
     <% end %>
 
     <!-- link to external repository dataset -->
-    <%= link_to external_record_url(record.id),
+    <%= link_to external_zenodo_url,
                 target: '_blank',
                 class: 'btn btn-sm btn-outline-secondary',
                 title: t('.link_open_record_title') do %>

--- a/application/config/locales/connectors/zenodo/en.yml
+++ b/application/config/locales/connectors/zenodo/en.yml
@@ -73,7 +73,7 @@ en:
         cancel: "Cancel"
 
       shared:
-        zenodo_record_actions:
+        zenodo_view_actions:
           actions_bar_title_a11y_label: "Record actions bar"
           link_open_record_title: "Open record on Zenodo"
           button_create_bundle_label: "Create Upload Bundle"

--- a/application/test/connectors/zenodo/handlers/depositions_test.rb
+++ b/application/test/connectors/zenodo/handlers/depositions_test.rb
@@ -17,11 +17,15 @@ class Zenodo::Handlers::DepositionsTest < ActiveSupport::TestCase
     RepoRegistry.repo_db.stubs(:get).with('https://zenodo.org').returns(repo_info)
 
     service = mock('service')
-    service.expects(:find_deposition).with('10').returns(:deposition)
+    deposition = OpenStruct.new(title: 'Deposition Title')
+    service.expects(:find_deposition).with('10').returns(deposition)
     Zenodo::DepositionService.expects(:new).with('https://zenodo.org', api_key: 'KEY').returns(service)
 
     result = @explorer.show(repo_url: @repo_url)
     assert result.success?
+    assert_equal deposition, result.locals[:record]
+    assert_equal 'Deposition Title', result.locals[:dataset_title]
+    assert_equal Zenodo::Concerns::ZenodoUrlBuilder.build_deposition_url('https://zenodo.org', '10'), result.locals[:external_zenodo_url]
   end
 
   test 'show returns error when api key missing' do

--- a/application/test/connectors/zenodo/handlers/records_test.rb
+++ b/application/test/connectors/zenodo/handlers/records_test.rb
@@ -14,11 +14,14 @@ class Zenodo::Handlers::RecordsTest < ActiveSupport::TestCase
 
   test 'show renders record when found' do
     service = mock('service')
-    service.expects(:find_record).with('123').returns(:record)
+    record = OpenStruct.new(title: 'Record Title')
+    service.expects(:find_record).with('123').returns(record)
     Zenodo::RecordService.expects(:new).with('https://zenodo.org').returns(service)
     res = @explorer.show(repo_url: @repo_url)
     assert res.success?
-    assert_equal :record, res.locals[:record]
+    assert_equal record, res.locals[:record]
+    assert_equal 'Record Title', res.locals[:dataset_title]
+    assert_equal Zenodo::Concerns::ZenodoUrlBuilder.build_record_url('https://zenodo.org', '123'), res.locals[:external_zenodo_url]
   end
 
   test 'show returns error when record missing' do

--- a/application/test/views/zenodo/view_actions_view_test.rb
+++ b/application/test/views/zenodo/view_actions_view_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ZenodoViewActionsViewTest < ActionView::TestCase
+  test 'renders dataset title and external link' do
+    html = render partial: 'connectors/zenodo/shared/zenodo_view_actions', locals: {
+      dataset_title: 'Dataset',
+      external_zenodo_url: 'https://zenodo.org/records/1'
+    }
+
+    assert_includes html, 'Dataset'
+    assert_includes html, 'https://zenodo.org/records/1'
+  end
+end


### PR DESCRIPTION
## Summary
- rename shared view to `zenodo_view_actions`
- handlers supply `dataset_title` and `external_zenodo_url`
- add tests for handler locals and view rendering

## Testing
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_68a84fff45e4832191b56b6c1604a622