### PR TITLE
Ensure connector file views send project IDs

### DIFF
--- a/application/app/controllers/projects_controller.rb
+++ b/application/app/controllers/projects_controller.rb
@@ -15,7 +15,13 @@ class ProjectsController < ApplicationController
     project_name = params[:project_name] || ProjectNameGenerator.generate
     project = Project.new(id: project_name, name: project_name)
     if project.save
-      redirect_to  project_path(id: project.id), notice: t(".project_created", project_name: project_name)
+      notice = t(".project_created", project_name: project_name)
+      show = !params.key?(:show) || ActiveModel::Type::Boolean.new.cast(params[:show])
+      if show
+        redirect_to project_path(id: project.id), notice: notice
+      else
+        redirect_back fallback_location: projects_path, notice: notice
+      end
     else
       redirect_back fallback_location: projects_path, alert: t(".project_create_error", errors: project.errors.full_messages)
     end

--- a/application/app/controllers/projects_controller.rb
+++ b/application/app/controllers/projects_controller.rb
@@ -17,11 +17,10 @@ class ProjectsController < ApplicationController
     if project.save
       Current.settings.update_user_settings({ active_project: project.id.to_s })
       notice = t(".project_created", project_name: project_name)
-      show = !params.key?(:show) || ActiveModel::Type::Boolean.new.cast(params[:show])
-      if show
-        redirect_to project_path(id: project.id), notice: notice
-      else
+      if params.key?(:redirect_back)
         redirect_back fallback_location: projects_path, notice: notice
+      else
+        redirect_to project_path(id: project.id), notice: notice
       end
     else
       redirect_back fallback_location: projects_path, alert: t(".project_create_error", errors: project.errors.full_messages)

--- a/application/app/controllers/projects_controller.rb
+++ b/application/app/controllers/projects_controller.rb
@@ -15,6 +15,7 @@ class ProjectsController < ApplicationController
     project_name = params[:project_name] || ProjectNameGenerator.generate
     project = Project.new(id: project_name, name: project_name)
     if project.save
+      Current.settings.update_user_settings({ active_project: project.id.to_s })
       notice = t(".project_created", project_name: project_name)
       show = !params.key?(:show) || ActiveModel::Type::Boolean.new.cast(params[:show])
       if show

--- a/application/app/helpers/layout_helper.rb
+++ b/application/app/helpers/layout_helper.rb
@@ -9,4 +9,8 @@ module LayoutHelper
   def on_project_index?
     on_page?(controller: 'projects', action: 'index')
   end
+
+  def on_explore?
+    on_page?(controller: 'explore')
+  end
 end

--- a/application/app/views/connectors/dataverse/datasets/_dataset_files.html.erb
+++ b/application/app/views/connectors/dataverse/datasets/_dataset_files.html.erb
@@ -47,6 +47,7 @@
           <div class="d-flex align-items-center">
           <input type="text" id="active_project" class="form-control me-3" value="<%= t('.input_selected_project_default_value') %>"
                  data-select-project-listener-target="inputProjectName" disabled>
+          <input type="hidden" name="project_id" id="project_id" autocomplete="off" data-select-project-listener-target="inputProjectId">
           <!-- link to project details page -->
           <%= link_to projects_path,
                       class: 'btn btn-outline-secondary',

--- a/application/app/views/connectors/zenodo/shared/_zenodo_view_files.html.erb
+++ b/application/app/views/connectors/zenodo/shared/_zenodo_view_files.html.erb
@@ -49,6 +49,7 @@
           <div class="d-flex align-items-center">
             <input type="text" id="active_project" class="form-control me-3" value="<%= t('.input_selected_project_default_value') %>"
                    data-select-project-listener-target="inputProjectName" disabled>
+            <input type="hidden" name="project_id" id="project_id" autocomplete="off" data-select-project-listener-target="inputProjectId">
             <!-- link to project details page -->
             <%= link_to projects_path,
                         class: 'btn btn-outline-secondary',

--- a/application/app/views/layouts/_app_actions_bar.html.erb
+++ b/application/app/views/layouts/_app_actions_bar.html.erb
@@ -55,6 +55,7 @@
             title: t('project_selection.button_create_project_title'),
             icon: "bi bi-plus-square-fill"
           } do %>
+            <%= hidden_field_tag :redirect_back, true if on_explore? %>
           <% end %>
 
         </div>

--- a/application/test/controllers/projects_controller_test.rb
+++ b/application/test/controllers/projects_controller_test.rb
@@ -55,10 +55,10 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_match "Project manual_project created", flash[:notice]
   end
 
-  test "should create project without showing when show is false" do
+  test "should create project and redirect back when redirect_back param provided" do
     @user_settings_mock.expects(:update_user_settings).with({active_project: 'hidden_project'})
     post projects_url,
-         params: { project_name: "hidden_project", show: false },
+         params: { project_name: "hidden_project", redirect_back: true },
          headers: { "HTTP_REFERER": root_url }
     assert_redirected_to root_url
     follow_redirect!

--- a/application/test/controllers/projects_controller_test.rb
+++ b/application/test/controllers/projects_controller_test.rb
@@ -40,6 +40,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
 
   test "should create project with generated name" do
     ProjectNameGenerator.stubs(:generate).returns("generated_project")
+    @user_settings_mock.expects(:update_user_settings).with({active_project: 'generated_project'})
     post projects_url
     assert_redirected_to project_url(id: 'generated_project')
     follow_redirect!
@@ -47,6 +48,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should create project with provided name" do
+    @user_settings_mock.expects(:update_user_settings).with({active_project: 'manual_project'})
     post projects_url, params: { project_name: "manual_project" }
     assert_redirected_to project_url(id: 'manual_project')
     follow_redirect!
@@ -54,6 +56,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should create project without showing when show is false" do
+    @user_settings_mock.expects(:update_user_settings).with({active_project: 'hidden_project'})
     post projects_url,
          params: { project_name: "hidden_project", show: false },
          headers: { "HTTP_REFERER": root_url }

--- a/application/test/controllers/projects_controller_test.rb
+++ b/application/test/controllers/projects_controller_test.rb
@@ -53,6 +53,15 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_match "Project manual_project created", flash[:notice]
   end
 
+  test "should create project without showing when show is false" do
+    post projects_url,
+         params: { project_name: "hidden_project", show: false },
+         headers: { "HTTP_REFERER": root_url }
+    assert_redirected_to root_url
+    follow_redirect!
+    assert_match "Project hidden_project created", flash[:notice]
+  end
+
   test "should set active project" do
     @user_settings_mock.expects(:update_user_settings).with({active_project: @project.id.to_s})
     post set_active_project_url(id: @project.id)

--- a/application/test/helpers/layout_helper_test.rb
+++ b/application/test/helpers/layout_helper_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class LayoutHelperTest < ActionView::TestCase
+  include LayoutHelper
+
+  test 'on_page? matches controller and action' do
+    self.stubs(:params).returns(controller: 'projects', action: 'index')
+    assert on_page?(controller: 'projects', action: 'index')
+    refute on_page?(controller: 'projects', action: 'show')
+  end
+
+  test 'on_project_index? is true only on projects index' do
+    self.stubs(:params).returns(controller: 'projects', action: 'index')
+    assert on_project_index?
+    self.stubs(:params).returns(controller: 'projects', action: 'show')
+    refute on_project_index?
+  end
+
+  test 'on_explore? detects explore controller' do
+    self.stubs(:params).returns(controller: 'explore', action: 'index')
+    assert on_explore?
+    self.stubs(:params).returns(controller: 'projects', action: 'index')
+    refute on_explore?
+  end
+end

--- a/application/test/views/layouts/app_actions_bar_view_test.rb
+++ b/application/test/views/layouts/app_actions_bar_view_test.rb
@@ -40,4 +40,16 @@ class AppActionsBarViewTest < ActionView::TestCase
     assert_includes html, 'data-select-project-target="spinner"'
     assert_includes html, 'spinner-border spinner-border-sm'
   end
+
+  test 'includes redirect_back field when on explore page' do
+    view.stubs(:on_explore?).returns(true)
+    html = render partial: 'layouts/app_actions_bar', locals: { show_images: false }
+    assert_includes html, "type=\"hidden\" name=\"redirect_back\""
+  end
+
+  test 'omits redirect_back field when not on explore page' do
+    view.stubs(:on_explore?).returns(false)
+    html = render partial: 'layouts/app_actions_bar', locals: { show_images: false }
+    refute_includes html, "name=\"redirect_back\""
+  end
 end


### PR DESCRIPTION
## Summary
- add hidden project_id field to Dataverse dataset file view
- add hidden project_id field to Zenodo file view

## Testing
- `bundle exec rails test`


------
https://chatgpt.com/codex/tasks/task_e_68ac4ace06fc83219af97c18d612104b