### PR TITLE
Set active project when handlers create new project

### DIFF
--- a/application/app/connectors/dataverse/handlers/datasets.rb
+++ b/application/app/connectors/dataverse/handlers/datasets.rb
@@ -109,6 +109,7 @@ module Dataverse::Handlers
           errors = project.errors.full_messages.join(', ')
           return ConnectorResult.new(message: { alert: I18n.t('connectors.dataverse.datasets.download.error_generating_project', errors: errors) }, success: false)
         end
+        Current.settings.update_user_settings({ active_project: project.id.to_s })
       end
 
       download_files = project_service.initialize_download_files(project, @persistent_id, dataset, files_page, file_ids)

--- a/application/app/connectors/zenodo/handlers/depositions.rb
+++ b/application/app/connectors/zenodo/handlers/depositions.rb
@@ -73,6 +73,7 @@ module Zenodo::Handlers
           errors = project.errors.full_messages.join(', ')
           return ConnectorResult.new(message: { alert: I18n.t('zenodo.depositions.message_project_error', errors: errors) }, success: false)
         end
+        Current.settings.update_user_settings({ active_project: project.id.to_s })
       end
 
       download_files = project_service.create_files_from_deposition(project, deposition, file_ids)

--- a/application/app/connectors/zenodo/handlers/records.rb
+++ b/application/app/connectors/zenodo/handlers/records.rb
@@ -59,6 +59,7 @@ module Zenodo::Handlers
           errors = project.errors.full_messages.join(', ')
           return ConnectorResult.new(message: { alert: I18n.t('zenodo.records.message_project_error', errors: errors) }, success: false)
         end
+        Current.settings.update_user_settings({ active_project: project.id.to_s })
       end
 
       download_files = project_service.create_files_from_record(project, record, file_ids)

--- a/application/test/connectors/dataverse/handlers/datasets_test.rb
+++ b/application/test/connectors/dataverse/handlers/datasets_test.rb
@@ -6,6 +6,9 @@ class Dataverse::Handlers::DatasetsTest < ActiveSupport::TestCase
     repo_info = OpenStruct.new(metadata: OpenStruct.new(auth_key: 'key'))
     RepoRegistry.stubs(:repo_db).returns(stub(get: repo_info))
     @explorer = Dataverse::Handlers::Datasets.new('pid')
+    @settings = mock('settings')
+    @settings.stubs(:update_user_settings)
+    Current.stubs(:settings).returns(@settings)
   end
 
   test 'params schema includes expected keys' do
@@ -78,6 +81,7 @@ class Dataverse::Handlers::DatasetsTest < ActiveSupport::TestCase
     proj_service.expects(:initialize_download_files).with(project, 'pid', dataset, files_page, ['f1']).returns([file])
     Dataverse::ProjectService.expects(:new).with('https://dataverse.org').returns(proj_service)
 
+    @settings.expects(:update_user_settings).with({ active_project: '1' })
     res = @explorer.create(repo_url: @repo_url, file_ids: ['f1'], project_id: '1')
     assert res.success?
   end

--- a/application/test/connectors/zenodo/handlers/depositions_test.rb
+++ b/application/test/connectors/zenodo/handlers/depositions_test.rb
@@ -4,6 +4,9 @@ class Zenodo::Handlers::DepositionsTest < ActiveSupport::TestCase
   def setup
     @explorer = Zenodo::Handlers::Depositions.new('10')
     @repo_url = OpenStruct.new(server_url: 'https://zenodo.org')
+    @settings = mock('settings')
+    @settings.stubs(:update_user_settings)
+    Current.stubs(:settings).returns(@settings)
   end
 
   test 'params schema includes expected keys' do
@@ -59,6 +62,7 @@ class Zenodo::Handlers::DepositionsTest < ActiveSupport::TestCase
     project = mock('project')
     project.stubs(:save).returns(true)
     project.stubs(:name).returns('Proj')
+    project.stubs(:id).returns('1')
 
     file = mock('file')
     file.stubs(:valid?).returns(true)
@@ -69,6 +73,7 @@ class Zenodo::Handlers::DepositionsTest < ActiveSupport::TestCase
     proj_service.expects(:create_files_from_deposition).with(project, :dataset, ['f1']).returns([file])
     Zenodo::ProjectService.expects(:new).with('https://zenodo.org').returns(proj_service)
 
+    @settings.expects(:update_user_settings).with({ active_project: project.id.to_s })
     result = @explorer.create(repo_url: @repo_url, file_ids: ['f1'], project_id: '1')
     assert result.success?
   end

--- a/application/test/connectors/zenodo/handlers/records_test.rb
+++ b/application/test/connectors/zenodo/handlers/records_test.rb
@@ -4,6 +4,9 @@ class Zenodo::Handlers::RecordsTest < ActiveSupport::TestCase
   def setup
     @repo_url = OpenStruct.new(server_url: 'https://zenodo.org')
     @explorer = Zenodo::Handlers::Records.new('123')
+    @settings = mock('settings')
+    @settings.stubs(:update_user_settings)
+    Current.stubs(:settings).returns(@settings)
   end
 
   test 'params schema includes expected keys' do
@@ -52,6 +55,7 @@ class Zenodo::Handlers::RecordsTest < ActiveSupport::TestCase
     proj_service.expects(:create_files_from_record).with(project, :dataset, ['f1']).returns([file])
     Zenodo::ProjectService.expects(:new).with('https://zenodo.org').returns(proj_service)
 
+    @settings.expects(:update_user_settings).with({ active_project: project.id.to_s })
     res = @explorer.create(repo_url: @repo_url, file_ids: ['f1'], project_id: '1')
     assert res.success?
   end


### PR DESCRIPTION
## Summary
- ensure Zenodo and Dataverse download handlers set a newly created project as the active project
- cover new behavior with tests for Zenodo and Dataverse handlers

## Testing
- `bundle exec rails test test/connectors/dataverse/handlers/datasets_test.rb test/connectors/zenodo/handlers/depositions_test.rb test/connectors/zenodo/handlers/records_test.rb`


------
https://chatgpt.com/codex/tasks/task_e_68ac749867b48321bb23bffc88880be5