### PR TITLE
Store download errors and display error tooltips

### DIFF
--- a/application/app/connectors/dataverse/download_connector_processor.rb
+++ b/application/app/connectors/dataverse/download_connector_processor.rb
@@ -47,7 +47,7 @@ module Dataverse
         file.update({ metadata: connector_metadata.to_h })
         FileUtils.rm_f(temp_location) if download_processor.partial_downloads == false
         log_error('Download failed', { id: file.id, url: download_url, partial_downloads: download_processor.partial_downloads }, e)
-        return response(FileStatus::ERROR, 'file download failed')
+        return response(FileStatus::ERROR, e.message)
       end
 
       connector_metadata.partial_downloads = download_processor.partial_downloads

--- a/application/app/connectors/zenodo/download_connector_processor.rb
+++ b/application/app/connectors/zenodo/download_connector_processor.rb
@@ -39,7 +39,7 @@ module Zenodo
         file.update({ metadata: connector_metadata.to_h })
         FileUtils.rm_f(temp_location) if download_processor.partial_downloads == false
         log_error('Download failed', { id: file.id, url: download_url, partial_downloads: download_processor.partial_downloads }, e)
-        return response(FileStatus::ERROR, 'file download failed')
+        return response(FileStatus::ERROR, e.message)
       end
 
       connector_metadata.partial_downloads = download_processor.partial_downloads

--- a/application/app/models/download_file.rb
+++ b/application/app/models/download_file.rb
@@ -3,7 +3,7 @@
 class DownloadFile < ApplicationDiskRecord
   include ActiveModel::Model
 
-  ATTRIBUTES = %w[id project_id type filename status size creation_date start_date end_date metadata].freeze
+  ATTRIBUTES = %w[id project_id type filename status size creation_date start_date end_date metadata error_message].freeze
 
   attr_accessor *ATTRIBUTES
 

--- a/application/app/services/download/download_service.rb
+++ b/application/app/services/download/download_service.rb
@@ -28,13 +28,13 @@ module Download
         download_threads = batch.map do |file|
           download_processor = ConnectorClassDispatcher.download_processor(file)
           Thread.new do
-            file.update(start_date: now, end_date: nil, status: FileStatus::DOWNLOADING)
+            file.update(start_date: now, end_date: nil, status: FileStatus::DOWNLOADING, error_message: nil)
             stats[:progress] += 1
             result = download_processor.download
-            file.update(end_date: now, status: result.status)
+            file.update(end_date: now, status: result.status, error_message: result.status.error? ? result.message : nil)
           rescue => e
             log_error('Error while processing file', {file_id: file.id}, e)
-            file.update(end_date: now, status: FileStatus::ERROR)
+            file.update(end_date: now, status: FileStatus::ERROR, error_message: e.message)
           ensure
             stats[:completed] += 1
             stats[:progress] -= 1

--- a/application/app/views/download_status/_files.html.erb
+++ b/application/app/views/download_status/_files.html.erb
@@ -32,7 +32,9 @@
             <% if data.file.status.downloading? %>
               <%= render partial: '/shared/progress_bar', locals: { progress: data.file.connector_status.download_progress, file: data.file } %>
             <% else %>
-              <%= status_badge(data.file.status, filename: data.file.filename) %>
+              <%= status_badge(data.file.status,
+                               filename: data.file.filename,
+                               title: (data.file.error_message if data.file.status.error?)) %>
             <% end %>
             &nbsp;
             <% if retry_button_visible?(data.file) %>

--- a/application/test/models/download_file_test.rb
+++ b/application/test/models/download_file_test.rb
@@ -17,7 +17,8 @@ class DownloadFileTest < ActiveSupport::TestCase
         'filename' => '',
         'size' => '',
         'content_type' => '',
-      }
+      },
+      'error_message' => nil
     }
     @download_file = DownloadFile.new(@valid_attributes)
     @expected_filename = File.join(Project.download_files_directory('456-789'), '123-321.yml')

--- a/application/test/services/download/download_service_test.rb
+++ b/application/test/services/download/download_service_test.rb
@@ -48,8 +48,8 @@ class Download::DownloadServiceTest < ActiveSupport::TestCase
 
       now_time = file_now
       file = mock("download_file")
-      file.expects(:update).with(start_date: now_time, end_date: nil, status: FileStatus::DOWNLOADING).once
-      file.expects(:update).with(end_date: now_time, status: FileStatus::SUCCESS).once
+      file.expects(:update).with(start_date: now_time, end_date: nil, status: FileStatus::DOWNLOADING, error_message: nil).once
+      file.expects(:update).with(end_date: now_time, status: FileStatus::SUCCESS, error_message: nil).once
       files_provider = DownloadFilesProviderMock.new([file])
       target = Download::DownloadService.new(files_provider)
       target.stubs(:now).returns(now_time)
@@ -67,8 +67,8 @@ class Download::DownloadServiceTest < ActiveSupport::TestCase
 
       now_time = file_now
       file = mock("download_file")
-      file.expects(:update).with(start_date: now_time, end_date: nil, status: FileStatus::DOWNLOADING).once
-      file.expects(:update).with(end_date: now_time, status: FileStatus::ERROR).once
+      file.expects(:update).with(start_date: now_time, end_date: nil, status: FileStatus::DOWNLOADING, error_message: nil).once
+      file.expects(:update).with(end_date: now_time, status: FileStatus::ERROR, error_message: 'An error occurred').once
       # FOR LOGGING
       file.expects(:id).once
       files_provider = DownloadFilesProviderMock.new([file])


### PR DESCRIPTION
## Summary
- add `error_message` attribute to `DownloadFile`
- propagate and store download failure messages
- show error messages in download status badge tooltip

## Testing
- `bundle exec rake test` *(fails: Could not find rails-7.2.2.1 and other gems)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac74e3195c832badc041654ce12425