### PR TITLE
Add GitHub workflow for Cypress automated tests

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -1,0 +1,34 @@
+name: Automated Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  cypress:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build application
+        run: make loop_build
+
+      - name: Start testing environment
+        working-directory: automated_tests
+        run: make env_app
+
+      - name: Run Cypress tests
+        working-directory: automated_tests
+        run: make cypress_run
+
+      - name: Upload Cypress artifacts
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: cypress-artifacts
+          path: |
+            automated_tests/cypress/screenshots
+            automated_tests/cypress/results
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- run automated Cypress tests in GitHub Actions
- build loop app, start env, and run tests with Make targets
- upload Cypress artifacts on failure

## Testing
- `make test` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a99d53e08321acd38493f99f02ef