### PR TITLE
Refactor Event initialization to explicit parameters

### DIFF
--- a/application/app/controllers/projects_controller.rb
+++ b/application/app/controllers/projects_controller.rb
@@ -16,7 +16,7 @@ class ProjectsController < ApplicationController
     project_name = params[:project_name] || ProjectNameGenerator.generate
     project = Project.new(id: project_name, name: project_name)
     if project.save
-      record_event(project_event_attributes(project, { message: 'events.project.created' }))
+      record_event(**project_event_attributes(project, message: 'events.project.created'))
       Current.settings.update_user_settings({ active_project: project.id.to_s })
       notice = t(".project_created", project_name: project_name)
       if params.key?(:redirect_back)
@@ -44,7 +44,7 @@ class ProjectsController < ApplicationController
     update_params = params.permit(:name, :download_dir).to_h.compact
 
     if project.update(update_params)
-      record_event(project_event_attributes(project, { message: 'events.project.updated' }))
+      record_event(**project_event_attributes(project, message: 'events.project.updated'))
       respond_to do |format|
         format.html { redirect_back fallback_location: projects_path, notice: t(".project_updated_successfully", project_name: project.name) }
         format.json { render json: project.to_json, status: :ok }
@@ -72,7 +72,7 @@ class ProjectsController < ApplicationController
     end
 
     Current.settings.update_user_settings({active_project: project_id})
-    record_event(project_event_attributes(project, { message: 'events.project.active' }))
+    record_event(**project_event_attributes(project, message: 'events.project.active'))
     respond_to do |format|
       format.html { redirect_back fallback_location: projects_path, notice: t(".project_is_now_the_active_project", project_name: project.name) }
       format.json { render json: project.to_json, status: :ok }
@@ -93,8 +93,8 @@ class ProjectsController < ApplicationController
 
   private
 
-  def project_event_attributes(project, attrs={})
-    default_attributes = {
+  def project_event_attributes(project, attrs = {})
+    {
       project_id: project.id,
       message: 'events.project.updated',
       entity_type: 'project',
@@ -103,7 +103,6 @@ class ProjectsController < ApplicationController
         'name' => project.name,
         'download_dir' => project.download_dir
       }
-    }
-    default_attributes.merge!(attrs)
+    }.merge(attrs)
   end
 end

--- a/application/app/lib/event_logger.rb
+++ b/application/app/lib/event_logger.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
 module EventLogger
-  def record_event(attributes)
-    list = ProjectEventList.new(project_id: attributes[:project_id])
-    event = Event.new(attributes)
+  def record_event(project_id:, entity_type:, entity_id:, message:, metadata:)
+    attributes = {
+      project_id: project_id,
+      entity_type: entity_type,
+      entity_id: entity_id,
+      message: message,
+      metadata: metadata
+    }
+
+    list = ProjectEventList.new(project_id: project_id)
+    event = Event.new(**attributes)
     event_saved = list.add(event)
     if event_saved
       LoggingCommon.log_info("Event saved", event_saved.to_h)

--- a/application/app/models/event.rb
+++ b/application/app/models/event.rb
@@ -3,15 +3,18 @@ class Event
 
   ATTRIBUTES = %w[id project_id message entity_type entity_id creation_date metadata].freeze
 
-  attr_accessor(*ATTRIBUTES)
+  attr_reader(*ATTRIBUTES)
 
   validates_presence_of :id, :project_id, :message, :entity_type, :creation_date
 
-  def initialize(attributes = {})
-    super
-    self.id = SecureRandom.uuid.to_s if id.blank?
-    self.creation_date ||= DateTimeCommon.now
-    self.metadata ||= {}
+  def initialize(project_id:, entity_type:, entity_id: nil, message:, metadata: {})
+    @id = SecureRandom.uuid.to_s
+    @project_id = project_id
+    @entity_type = entity_type
+    @entity_id = entity_id
+    @message = message
+    @creation_date = DateTimeCommon.now
+    @metadata = metadata || {}
   end
 
   def to_h
@@ -21,10 +24,13 @@ class Event
   end
 
   def self.from_hash(data)
-    new.tap do |instance|
-      ATTRIBUTES.each do |attr|
-        instance.public_send("#{attr}=", data[attr.to_s])
-      end
+    new(project_id: data['project_id'],
+        entity_type: data['entity_type'],
+        entity_id: data['entity_id'],
+        message: data['message'],
+        metadata: data['metadata']).tap do |instance|
+      instance.instance_variable_set(:@id, data['id'])
+      instance.instance_variable_set(:@creation_date, data['creation_date'])
     end
   end
 end

--- a/application/test/lib/event_logger_test.rb
+++ b/application/test/lib/event_logger_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class EventLoggerTest < ActiveSupport::TestCase
+  test 'record_event builds event and adds it to list' do
+    list = mock('ProjectEventList')
+    ProjectEventList.expects(:new).with(project_id: '123').returns(list)
+
+    event = mock('Event')
+    Event.expects(:new).with(project_id: '123',
+                             entity_type: 'project',
+                             entity_id: '456',
+                             message: 'events.project.test',
+                             metadata: { 'foo' => 'bar' }).returns(event)
+
+    list.expects(:add).with(event).returns(event)
+    LoggingCommon.stubs(:log_info)
+
+    assert EventLogger.record_event(project_id: '123',
+                                    entity_type: 'project',
+                                    entity_id: '456',
+                                    message: 'events.project.test',
+                                    metadata: { 'foo' => 'bar' })
+  end
+end

--- a/application/test/models/event_test.rb
+++ b/application/test/models/event_test.rb
@@ -3,7 +3,10 @@ require "test_helper"
 class EventTest < ActiveSupport::TestCase
 
   test "initializes defaults" do
-    event = Event.new(project_id: 'p1', message: 'message', entity_type: 'project')
+    event = Event.new(project_id: 'p1',
+                      entity_type: 'project',
+                      entity_id: nil,
+                      message: 'message')
     assert event.id.present?
     assert event.creation_date.present?
     assert_equal({}, event.metadata)
@@ -11,7 +14,11 @@ class EventTest < ActiveSupport::TestCase
 
   test "to_h and from_hash preserve metadata" do
     metadata = { 'foo' => 'bar', 'count' => 1 }
-    event = Event.new(project_id: 'p1', message: 'm', entity_type: 'file', entity_id: 'e1', metadata: metadata)
+    event = Event.new(project_id: 'p1',
+                      entity_type: 'file',
+                      entity_id: 'e1',
+                      message: 'm',
+                      metadata: metadata)
 
     hash = event.to_h
     assert_equal metadata, hash['metadata']
@@ -20,6 +27,13 @@ class EventTest < ActiveSupport::TestCase
     assert_equal metadata, reconstructed.metadata
     assert_equal event.message, reconstructed.message
     assert_equal event.entity_id, reconstructed.entity_id
+  end
+
+  test "attributes are read-only" do
+    event = Event.new(project_id: 'p1', entity_type: 'project', message: 'm')
+    assert_raises(NoMethodError) { event.id = 'new-id' }
+    assert_raises(NoMethodError) { event.project_id = 'other' }
+    assert_raises(NoMethodError) { event.metadata = {} }
   end
 
 end

--- a/application/test/models/project_event_list_test.rb
+++ b/application/test/models/project_event_list_test.rb
@@ -8,9 +8,9 @@ class ProjectEventListTest < ActiveSupport::TestCase
       list = ProjectEventList.new(project_id: project_id)
 
       event = Event.new(project_id: project_id,
-                        message: 'created',
                         entity_type: 'project',
                         entity_id: project_id,
+                        message: 'created',
                         metadata: { 'foo' => 'bar' })
 
       list.add(event)
@@ -29,8 +29,14 @@ class ProjectEventListTest < ActiveSupport::TestCase
       project_id = 'p456'
       list = ProjectEventList.new(project_id: project_id)
 
-      e1 = Event.new(project_id: project_id, message: 'm1', entity_type: 'file', entity_id: '1')
-      e2 = Event.new(project_id: project_id, message: 'm2', entity_type: 'file', entity_id: '2')
+      e1 = Event.new(project_id: project_id,
+                     entity_type: 'file',
+                     entity_id: '1',
+                     message: 'm1')
+      e2 = Event.new(project_id: project_id,
+                     entity_type: 'file',
+                     entity_id: '2',
+                     message: 'm2')
       list.add(e1)
       list.add(e2)
 

--- a/application/test/models/project_test.rb
+++ b/application/test/models/project_test.rb
@@ -279,9 +279,9 @@ class ProjectTest < ActiveSupport::TestCase
       saved_project = Project.find(project.id)
 
       event = Event.new(project_id: project.id,
-                        message: 'created',
                         entity_type: 'project',
                         entity_id: project.id,
+                        message: 'created',
                         metadata: { 'user' => 'alice' })
       saved_project.event_list.add(event)
 


### PR DESCRIPTION
## Summary
- Refactor `EventLogger.record_event` to accept keyword arguments matching `Event.new`
- Forward keyword args from `ProjectsController` via `project_event_attributes`
- Add unit test verifying `EventLogger` records events with the new API

## Testing
- `bundle exec rake test` *(fails: Could not find rails-7.2.2.1, sprockets-rails-3.5.2, ...)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b71e16b460832bacc9619dd6f0b820