### PR TITLE
Remove obsolete Zenodo feature flag

### DIFF
--- a/application/app/views/layouts/nav/_navigation.html.erb
+++ b/application/app/views/layouts/nav/_navigation.html.erb
@@ -51,18 +51,16 @@
               </a>
             </li>
 
-            <% if ::Configuration.zenodo_enabled %>
-              <li>
-                <a class="dropdown-item d-flex align-items-center gap-2"
-                   href="<%= explore_path(connector_type: ConnectorType::ZENODO.to_s, server_domain: Zenodo::ZenodoUrl::DEFAULT_SERVER, object_type: 'landing', object_id: ':root') %>"
-                   id="nav-zenodo">
-                  <span class="icon-wrapper bg-white rounded d-inline-flex align-items-center justify-content-center p-1" aria-hidden="true">
-                    <%= connector_icon(ConnectorType::ZENODO) %>
-                  </span>
-                  <%= t('.link_zenodo_text') %>
-                </a>
-              </li>
-            <% end %>
+            <li>
+              <a class="dropdown-item d-flex align-items-center gap-2"
+                 href="<%= explore_path(connector_type: ConnectorType::ZENODO.to_s, server_domain: Zenodo::ZenodoUrl::DEFAULT_SERVER, object_type: 'landing', object_id: ':root') %>"
+                 id="nav-zenodo">
+                <span class="icon-wrapper bg-white rounded d-inline-flex align-items-center justify-content-center p-1" aria-hidden="true">
+                  <%= connector_icon(ConnectorType::ZENODO) %>
+                </span>
+                <%= t('.link_zenodo_text') %>
+              </a>
+            </li>
 
             <li><hr class="dropdown-divider" role="separator"></li>
 

--- a/application/app/views/sitemap/index.html.erb
+++ b/application/app/views/sitemap/index.html.erb
@@ -8,9 +8,7 @@
     <li><%= t('layouts.nav.navigation.link_repositories_text') %></li>
     <ul>
       <li><%= link_to t('layouts.nav.navigation.link_dataverse_text'), link_to_landing(ConnectorType::DATAVERSE) %></li>
-      <% if ::Configuration.zenodo_enabled %>
-        <li><%= link_to t('layouts.nav.navigation.link_zenodo_text'), explore_path(connector_type: ConnectorType::ZENODO.to_s, server_domain: Zenodo::ZenodoUrl::DEFAULT_SERVER, object_type: 'landing', object_id: ':root') %></li>
-      <% end %>
+      <li><%= link_to t('layouts.nav.navigation.link_zenodo_text'), explore_path(connector_type: ConnectorType::ZENODO.to_s, server_domain: Zenodo::ZenodoUrl::DEFAULT_SERVER, object_type: 'landing', object_id: ':root') %></li>
       <li><%= link_to t('layouts.nav.navigation.link_repo_settings_text'), repository_settings_path %></li>
     </ul>
     <li><%= link_to t('layouts.nav.navigation.link_guide_text'), guide_url %></li>

--- a/application/config/configuration_singleton.rb
+++ b/application/config/configuration_singleton.rb
@@ -27,7 +27,6 @@ class ConfigurationSingleton
       ::ConfigurationProperty.integer(:detached_process_status_interval, default: 10 * 1000), # 10s in MILLISECONDS
       ::ConfigurationProperty.integer(:max_download_file_size, default: 10 * 1024 * 1024 * 1024), # 10 GIGABYTE
       ::ConfigurationProperty.integer(:max_upload_file_size, default: 1024 * 1024 * 1024), # 1 GIGABYTE
-      ::ConfigurationProperty.boolean(:zenodo_enabled, default: false),
       ::ConfigurationProperty.property(:guide_url, default: 'https://iqss.github.io/ondemand-loop/'),
       ::ConfigurationProperty.property(:http_proxy, read_from_env: false),
       ::ConfigurationProperty.integer(:default_connect_timeout, default: 5),

--- a/application/test/config/configuration_singleton_test.rb
+++ b/application/test/config/configuration_singleton_test.rb
@@ -65,18 +65,6 @@ class ConfigurationSingletonTest < ActiveSupport::TestCase
     ENV.delete('OOD_LOOP_MAX_UPLOAD_FILE_SIZE')
   end
 
-  test 'should return default boolean values when ENV is not set' do
-    assert_equal false, @config_instance.zenodo_enabled
-  end
-
-  test 'should override boolean values from ENV' do
-    ENV['OOD_LOOP_ZENODO_ENABLED'] = 'true'
-    config = ConfigurationSingleton.new
-    assert_equal true, config.zenodo_enabled
-  ensure
-    ENV.delete('OOD_LOOP_ZENODO_ENABLED')
-  end
-
   test 'should return default guide_url when not set' do
     assert_equal 'https://iqss.github.io/ondemand-loop/', @config_instance.guide_url
   end

--- a/docs/guide/content/admin.md
+++ b/docs/guide/content/admin.md
@@ -20,7 +20,7 @@ You can override the default configuration values in **two supported ways**:
 
 Create one or more `.yml` files in the directory: `/etc/loop/config/loop.d`
 
-Each file should contain a simple key-value structure where the keys match the configuration property names (e.g. `download_root`, `zenodo_enabled`). These files are loaded **once at application startup**, so any changes require a restart.
+Each file should contain a simple key-value structure where the keys match the configuration property names (e.g. `download_root`). These files are loaded **once at application startup**, so any changes require a restart.
 
 #### 2. Environment Variables
 
@@ -75,7 +75,6 @@ You can define environment variables in one of the following ways:
 - [detached_process_status_interval](#detached_process_status_interval)
 - [max_download_file_size](#max_download_file_size)
 - [max_upload_file_size](#max_upload_file_size)
-- [zenodo_enabled](#zenodo_enabled)
 - [guide_url](#guide_url)
 - [http_proxy](#http_proxy)
 - [default_connect_timeout](#default_connect_timeout)
@@ -229,18 +228,6 @@ Defines the maximum allowed size (in bytes) for an individual file upload. Files
 
 - **Default**: `1_073_741_824` (1 GB)
 - **Environment Variable**: `OOD_LOOP_MAX_UPLOAD_FILE_SIZE`
-
----
-
-<a id="zenodo_enabled"></a>
-**`zenodo_enabled`**  
-Boolean flag to enable or disable the Zenodo connector in the application. If set to `false`, Zenodo integration will be hidden and inactive.
-
-- **Default**: `false`
-- **Environment Variable**: `OOD_LOOP_ZENODO_ENABLED`
-
----
-
 <a id="guide_url"></a>
 **`guide_url`**  
 URL to the external documentation site. This is used for help links in the interface and should point to the current user or admin guide for your Loop deployment.
@@ -365,7 +352,6 @@ detached_controller_interval: 5
 detached_process_status_interval: 2_000
 max_download_file_size: 15_000_000_000
 max_upload_file_size: 2_000_000_000
-zenodo_enabled: true
 guide_url: https://example.com/loop
 ```
 
@@ -392,6 +378,5 @@ OOD_LOOP_DETACHED_CONTROLLER_INTERVAL=5
 OOD_LOOP_DETACHED_PROCESS_STATUS_INTERVAL=2_000
 OOD_LOOP_MAX_DOWNLOAD_FILE_SIZE=15_000_000_000
 OOD_LOOP_MAX_UPLOAD_FILE_SIZE=2_000_000_000
-OOD_LOOP_ZENODO_ENABLED=true
 OOD_LOOP_GUIDE_URL=https://example.com/loop
 ```


### PR DESCRIPTION
## Summary
- drop unused `zenodo_enabled` configuration property
- always display Zenodo links in navigation and sitemap
- update admin guide to remove zenodo flag references

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_68b84c7eab108321abe97f9b2284d502