### PR TITLE
Use repository activity modal for add files

### DIFF
--- a/application/app/connectors/zenodo/download_connector_metadata.rb
+++ b/application/app/connectors/zenodo/download_connector_metadata.rb
@@ -8,13 +8,14 @@ module Zenodo
       @metadata = ActiveSupport::OrderedOptions.new
       @metadata.merge!(download_file.metadata.to_h.deep_symbolize_keys)
       @project_id = download_file.project_id
+      @download_file = download_file
     end
 
     def repo_name
       "Zenodo"
     end
 
-    def files_url
+    def explore_url
       repo_url = Repo::RepoUrl.parse(zenodo_url)
       Rails.application.routes.url_helpers.explore_path(
         connector_type: ConnectorType::ZENODO.to_s,
@@ -24,6 +25,31 @@ module Zenodo
         server_scheme: repo_url.scheme_override,
         server_port: repo_url.port_override,
         active_project: @project_id
+      )
+    end
+
+    def external_url
+      return nil unless zenodo_url && type_id
+
+      case type
+      when 'records'
+        Zenodo::Concerns::ZenodoUrlBuilder.build_record_url(zenodo_url, type_id)
+      when 'depositions'
+        Zenodo::Concerns::ZenodoUrlBuilder.build_deposition_url(zenodo_url, type_id)
+      else
+        zenodo_url
+      end
+    end
+
+    def repo_summary
+      return nil unless external_url
+
+      OpenStruct.new(
+        type: @download_file.type,
+        date: @download_file.creation_date,
+        title: title,
+        url: external_url,
+        note: type
       )
     end
 

--- a/application/app/helpers/projects_helper.rb
+++ b/application/app/helpers/projects_helper.rb
@@ -16,7 +16,7 @@ module ProjectsHelper
   def most_recent_explore_url(project)
     files = project.download_files
     most_recent = Common::FileSorter.new.most_recent(files).first
-    most_recent.connector_metadata.files_url if most_recent
+    most_recent.connector_metadata.explore_url if most_recent
   end
 
   def project_header_class(active)

--- a/application/app/services/dataverse/project_service.rb
+++ b/application/app/services/dataverse/project_service.rb
@@ -28,6 +28,7 @@ module Dataverse
             dataverse_url: @dataverse_url,
             dataset_id: dataset_id,
             version: dataset.version,
+            title: dataset.title,
             parents: dataset.data.parents,
             id: dataset_file.data_file.id.to_s,
             content_type: dataset_file.content_type,

--- a/application/app/services/repo/repo_activity_service.rb
+++ b/application/app/services/repo/repo_activity_service.rb
@@ -16,7 +16,7 @@ module Repo
       end
     end
 
-    def project_download_repos(project_id)
+    def project_downloads(project_id)
       return [] if project_id.blank?
 
       project = Project.find_by(id: project_id)
@@ -24,8 +24,16 @@ module Repo
 
       files = project.download_files
       Common::FileSorter.new.most_recent(files).map do |file|
-        file.connector_metadata.files_url
-      end.compact.uniq
+        next unless file.connector_metadata&.files_url
+
+        OpenStruct.new(
+          type: file.type,
+          date: file.creation_date,
+          title: 'downloads',
+          url: file.connector_metadata.files_url,
+          note: 'dataset'
+        )
+      end.compact.uniq { |item| item.url }
     end
   end
 end

--- a/application/app/services/repo/repo_activity_service.rb
+++ b/application/app/services/repo/repo_activity_service.rb
@@ -15,5 +15,17 @@ module Repo
         )
       end
     end
+
+    def project_download_repos(project_id)
+      return [] if project_id.blank?
+
+      project = Project.find_by(id: project_id)
+      return [] unless project
+
+      files = project.download_files
+      Common::FileSorter.new.most_recent(files).map do |file|
+        file.connector_metadata.files_url
+      end.compact.uniq
+    end
   end
 end

--- a/application/app/services/repo/repo_activity_service.rb
+++ b/application/app/services/repo/repo_activity_service.rb
@@ -19,20 +19,12 @@ module Repo
     def project_downloads(project_id)
       return [] if project_id.blank?
 
-      project = Project.find_by(id: project_id)
+      project = Project.find(project_id)
       return [] unless project
 
       files = project.download_files
       Common::FileSorter.new.most_recent(files).map do |file|
-        next unless file.connector_metadata&.files_url
-
-        OpenStruct.new(
-          type: file.type,
-          date: file.creation_date,
-          title: 'downloads',
-          url: file.connector_metadata.files_url,
-          note: 'dataset'
-        )
+        file.connector_metadata.repo_summary
       end.compact.uniq { |item| item.url }
     end
   end

--- a/application/app/services/zenodo/project_service.rb
+++ b/application/app/services/zenodo/project_service.rb
@@ -48,6 +48,7 @@ module Zenodo
             zenodo_url: @zenodo_url,
             type: type,
             type_id: source.id,
+            title: source.title,
             id: file.id,
             download_url: file.download_url,
             temp_location: nil

--- a/application/app/views/projects/show/_download_actions.html.erb
+++ b/application/app/views/projects/show/_download_actions.html.erb
@@ -61,7 +61,7 @@
                 data-modal-url-value="<%= widgets_path('repository_activity', project_id: project.id) %>"
                 data-modal-title-value="<%= t('widgets.repository_activity.modal_title') %>"
                 data-modal-id-value="global-modal">
-          <i class="bi bi-folder-symlink-fill" style="font-size: 1.1rem;" aria-hidden="true"></i>
+          <i class="bi bi-folder-symlink-fill" aria-hidden="true"></i>
           <span><%= t('.button_add_files_text') %></span>
         </button>
 

--- a/application/app/views/projects/show/_download_actions.html.erb
+++ b/application/app/views/projects/show/_download_actions.html.erb
@@ -52,15 +52,18 @@
 
       <div>
 
-        <% explore_url = most_recent_explore_url(project) %>
-        <a href="<%= explore_url if explore_url %>"
-           class="btn btn-sm btn-outline-secondary <%= 'disabled' unless explore_url %>"
-           aria-label="<%= t('.button_add_files_title') %>"
-           title="<%= t('.button_add_files_title') %>"
-           aria-disabled="<%= explore_url.nil? %>">
-          <i class="bi bi-files" aria-hidden="true"></i>
+        <button type="button"
+                class="btn btn-sm btn-outline-secondary"
+                aria-label="<%= t('.button_add_files_title') %>"
+                title="<%= t('.button_add_files_title') %>"
+                data-controller="modal"
+                data-action="click->modal#load"
+                data-modal-url-value="<%= widgets_path('repository_activity') %>"
+                data-modal-title-value="<%= t('widgets.repository_activity.modal_title') %>"
+                data-modal-id-value="global-modal">
+          <i class="bi bi-folder-symlink-fill" style="font-size: 1.1rem;" aria-hidden="true"></i>
           <span><%= t('.button_add_files_text') %></span>
-        </a>
+        </button>
 
         <button data-controller="utils--icon-toggle"
                 data-utils--icon-toggle-icon-on-value="bi-plus-square-fill"

--- a/application/app/views/projects/show/_download_actions.html.erb
+++ b/application/app/views/projects/show/_download_actions.html.erb
@@ -58,7 +58,7 @@
                 title="<%= t('.button_add_files_title') %>"
                 data-controller="modal"
                 data-action="click->modal#load"
-                data-modal-url-value="<%= widgets_path('repository_activity') %>"
+                data-modal-url-value="<%= widgets_path('repository_activity', project_id: project.id) %>"
                 data-modal-title-value="<%= t('widgets.repository_activity.modal_title') %>"
                 data-modal-id-value="global-modal">
           <i class="bi bi-folder-symlink-fill" style="font-size: 1.1rem;" aria-hidden="true"></i>

--- a/application/app/views/projects/show/_download_files.html.erb
+++ b/application/app/views/projects/show/_download_files.html.erb
@@ -15,7 +15,7 @@
             <%= render partial: '/shared/file_row_date', locals: { date: file.creation_date, title: t('.field_schedule_date_title'), classes: 'mx-2'} %>
 
             <%= render partial: 'shared/repo_badge', locals: {
-              badge_url: file.connector_metadata.files_url,
+              badge_url: file.connector_metadata.explore_url,
               type: file.type,
               text: file.connector_metadata.repo_name,
               tooltip: t('.badge_repository_files_tooltip')

--- a/application/app/views/widgets/_repository_activity.html.erb
+++ b/application/app/views/widgets/_repository_activity.html.erb
@@ -2,7 +2,7 @@
 <%
   service = Repo::RepoActivityService.new
   global = service.global
-  project_download_urls = service.project_download_repos(params[:project_id])
+  project_downloads = service.project_downloads(params[:project_id])
 %>
 <div id="repository-items-tabs">
   <%# Tab Labels %>
@@ -10,7 +10,7 @@
     <li class="nav-item" role="presentation">
       <button class="nav-link text-secondary active" id="repository-items-global-tab" data-bs-toggle="tab" data-bs-target="#repository-items-global" type="button" role="tab" aria-controls="repository-items-global" aria-selected="true"><%= t('.tab_global_label') %></button>
     </li>
-    <% if project_download_urls.any? %>
+    <% if project_downloads.any? %>
       <li class="nav-item" role="presentation">
         <button class="nav-link text-secondary" id="repository-items-project-tab" data-bs-toggle="tab" data-bs-target="#repository-items-project" type="button" role="tab" aria-controls="repository-items-project" aria-selected="false"><%= t('.tab_project_label') %></button>
       </li>
@@ -52,19 +52,35 @@
         <% end %>
       </ul>
     </div>
-    <% if project_download_urls.any? %>
+    <% if project_downloads.any? %>
       <div id="repository-items-project" class="tab-pane fade" role="tabpanel" aria-labelledby="repository-items-project-tab">
         <ul class="list-unstyled m-0">
-          <% project_download_urls.each do |url| %>
+          <% project_downloads.each do |item| %>
             <li class="card mb-2 shadow-sm rounded">
               <header class="card-header d-flex justify-content-between align-items-center gap-3">
-                <div class="d-flex flex-column flex-grow-1">
-                  <h2 class="mb-0 h6"><%= url %></h2>
+                <div class="d-flex align-items-center gap-3 flex-grow-1">
+                  <%= render partial: '/shared/file_row_date', locals: { date: item.date, title: t('.field_date_title') } if item.date %>
+                  <span class="lh-1" aria-hidden="true"><%= connector_icon(item.type) %></span>
+                  <div class="d-flex flex-column flex-grow-1">
+                    <h2 class="mb-0 h6"><%= item.title %></h2>
+                    <small class="text-muted"><%= item.url %></small>
+                  </div>
+                  <span class="badge bg-secondary flex-shrink-0"><%= item.note %></span>
                 </div>
-                <%= link_to url, target: '_blank', class: 'btn btn-sm btn-outline-dark', title: t('.button_open_repository_title') do %>
-                  <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
-                  <span class="visually-hidden"><%= t('.button_open_repository_title') %></span>
-                <% end %>
+                <div class="d-flex align-items-center gap-2" role="group" aria-label="<%= t('.section_item_actions_label') %>">
+                  <%= render layout: "shared/button_to", locals: {
+                    url: repo_resolver_path,
+                    title: t('.button_explore_item_title'),
+                    class: 'btn-sm btn-outline-dark',
+                    icon: 'bi bi-folder2-open'
+                  } do %>
+                    <input type="hidden" name="repo_url" value="<%= item.url %>">
+                  <% end %>
+                  <%= link_to item.url, target: '_blank', class: 'btn btn-sm btn-outline-dark', title: t('.button_open_repository_title') do %>
+                    <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
+                    <span class="visually-hidden"><%= t('.button_open_repository_title') %></span>
+                  <% end %>
+                </div>
               </header>
             </li>
           <% end %>

--- a/application/app/views/widgets/_repository_activity.html.erb
+++ b/application/app/views/widgets/_repository_activity.html.erb
@@ -2,6 +2,7 @@
 <%
   service = Repo::RepoActivityService.new
   global = service.global
+  project_download_urls = service.project_download_repos(params[:project_id])
 %>
 <div id="repository-items-tabs">
   <%# Tab Labels %>
@@ -9,6 +10,11 @@
     <li class="nav-item" role="presentation">
       <button class="nav-link text-secondary active" id="repository-items-global-tab" data-bs-toggle="tab" data-bs-target="#repository-items-global" type="button" role="tab" aria-controls="repository-items-global" aria-selected="true"><%= t('.tab_global_label') %></button>
     </li>
+    <% if project_download_urls.any? %>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link text-secondary" id="repository-items-project-tab" data-bs-toggle="tab" data-bs-target="#repository-items-project" type="button" role="tab" aria-controls="repository-items-project" aria-selected="false"><%= t('.tab_project_label') %></button>
+      </li>
+    <% end %>
   </ul>
 
   <div class="tab-content mt-3">
@@ -46,6 +52,24 @@
         <% end %>
       </ul>
     </div>
-
+    <% if project_download_urls.any? %>
+      <div id="repository-items-project" class="tab-pane fade" role="tabpanel" aria-labelledby="repository-items-project-tab">
+        <ul class="list-unstyled m-0">
+          <% project_download_urls.each do |url| %>
+            <li class="card mb-2 shadow-sm rounded">
+              <header class="card-header d-flex justify-content-between align-items-center gap-3">
+                <div class="d-flex flex-column flex-grow-1">
+                  <h2 class="mb-0 h6"><%= url %></h2>
+                </div>
+                <%= link_to url, target: '_blank', class: 'btn btn-sm btn-outline-dark', title: t('.button_open_repository_title') do %>
+                  <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
+                  <span class="visually-hidden"><%= t('.button_open_repository_title') %></span>
+                <% end %>
+              </header>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -295,7 +295,7 @@ en:
       button_open_modal_title: "Open repository activity"
       modal_title: "Recent Repository Activity"
       tab_global_label: "Across All Projects"
-      tab_project_label: "This Project"
+      tab_project_label: "This Project Downloads"
       field_date_title: "Last used date"
       section_item_actions_label: "Item actions"
       button_explore_item_title: "Browse repository"

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -295,6 +295,7 @@ en:
       button_open_modal_title: "Open repository activity"
       modal_title: "Recent Repository Activity"
       tab_global_label: "Across All Projects"
+      tab_project_label: "This Project"
       field_date_title: "Last used date"
       section_item_actions_label: "Item actions"
       button_explore_item_title: "Browse repository"

--- a/application/test/connectors/dataverse/download_connector_metadata_test.rb
+++ b/application/test/connectors/dataverse/download_connector_metadata_test.rb
@@ -70,7 +70,7 @@ class Dataverse::DownloadConnectorMetadataTest < ActiveSupport::TestCase
     assert_equal 'N/A', target.repo_name
   end
 
-  test 'files_url return nil when no dataset_id' do
+  test 'explore_url return nil when no dataset_id' do
     metadata = {
       dataverse_url: 'http://demo.dv:8080',
       dataset_id: nil,
@@ -79,10 +79,10 @@ class Dataverse::DownloadConnectorMetadataTest < ActiveSupport::TestCase
     file.metadata = metadata
 
     target = Dataverse::DownloadConnectorMetadata.new(file)
-    assert_nil target.files_url
+    assert_nil target.explore_url
   end
 
-  test 'files_url overrides' do
+  test 'explore_url overrides' do
     metadata = {
       dataverse_url: 'http://demo.dv:8080',
       dataset_id: 'doi:1',
@@ -93,9 +93,112 @@ class Dataverse::DownloadConnectorMetadataTest < ActiveSupport::TestCase
     file.metadata = metadata
 
     target = Dataverse::DownloadConnectorMetadata.new(file)
-    assert_includes target.files_url, 'server_scheme=http'
-    assert_includes target.files_url, 'server_port=8080'
-    assert_includes target.files_url, 'version=2.0'
-    assert_includes target.files_url, 'active_project=123'
+    assert_includes target.explore_url, 'server_scheme=http'
+    assert_includes target.explore_url, 'server_port=8080'
+    assert_includes target.explore_url, 'version=2.0'
+    assert_includes target.explore_url, 'active_project=123'
+  end
+
+  test 'external_url returns nil when no dataverse_url' do
+    metadata = {
+      dataverse_url: nil,
+      dataset_id: 'doi:10.7910/DVN/ABC123'
+    }
+    file = DownloadFile.new
+    file.metadata = metadata
+
+    target = Dataverse::DownloadConnectorMetadata.new(file)
+    assert_nil target.external_url
+  end
+
+  test 'external_url returns nil when no dataset_id' do
+    metadata = {
+      dataverse_url: 'http://demo.dv:8080',
+      dataset_id: nil
+    }
+    file = DownloadFile.new
+    file.metadata = metadata
+
+    target = Dataverse::DownloadConnectorMetadata.new(file)
+    assert_nil target.external_url
+  end
+
+  test 'external_url builds correct dataset URL' do
+    metadata = {
+      dataverse_url: 'https://dataverse.example.com',
+      dataset_id: 'doi:10.7910/DVN/ABC123'
+    }
+    file = DownloadFile.new
+    file.metadata = metadata
+
+    target = Dataverse::DownloadConnectorMetadata.new(file)
+    expected_url = 'https://dataverse.example.com/dataset.xhtml?persistentId=doi%3A10.7910%2FDVN%2FABC123'
+    assert_equal expected_url, target.external_url
+  end
+
+  test 'external_url includes version when provided' do
+    metadata = {
+      dataverse_url: 'https://dataverse.example.com',
+      dataset_id: 'doi:10.7910/DVN/ABC123',
+      version: '2.0'
+    }
+    file = DownloadFile.new
+    file.metadata = metadata
+
+    target = Dataverse::DownloadConnectorMetadata.new(file)
+    expected_url = 'https://dataverse.example.com/dataset.xhtml?persistentId=doi%3A10.7910%2FDVN%2FABC123&version=2.0'
+    assert_equal expected_url, target.external_url
+  end
+
+  test 'external_url handles different URL schemes and ports' do
+    metadata = {
+      dataverse_url: 'http://localhost:8080',
+      dataset_id: 'doi:10.7910/DVN/XYZ789',
+      version: '1.5'
+    }
+    file = DownloadFile.new
+    file.metadata = metadata
+
+    target = Dataverse::DownloadConnectorMetadata.new(file)
+    expected_url = 'http://localhost:8080/dataset.xhtml?persistentId=doi%3A10.7910%2FDVN%2FXYZ789&version=1.5'
+    assert_equal expected_url, target.external_url
+  end
+
+  test 'repo_summary returns nil when no external_url' do
+    metadata = {
+      dataverse_url: nil,
+      dataset_id: 'doi:10.7910/DVN/ABC123',
+      title: 'Test Dataset'
+    }
+    file = DownloadFile.new
+    file.type = ConnectorType::DATAVERSE
+    file.creation_date = Date.current
+    file.metadata = metadata
+
+    target = Dataverse::DownloadConnectorMetadata.new(file)
+    assert_nil target.repo_summary
+  end
+
+  test 'repo_summary returns OpenStruct with correct attributes' do
+    metadata = {
+      dataverse_url: 'https://dataverse.example.com',
+      dataset_id: 'doi:10.7910/DVN/ABC123',
+      title: 'Test Dataset',
+      version: '2.0'
+    }
+    file = DownloadFile.new
+    file.type = ConnectorType::DATAVERSE
+    file.creation_date = Date.current
+    file.metadata = metadata
+
+    target = Dataverse::DownloadConnectorMetadata.new(file)
+    result = target.repo_summary
+
+    assert_not_nil result
+    assert_equal ConnectorType::DATAVERSE, result.type
+    assert_equal Date.current, result.date
+    assert_equal 'Test Dataset', result.title
+    assert_equal 'https://dataverse.example.com/dataset.xhtml?persistentId=doi%3A10.7910%2FDVN%2FABC123&version=2.0', result.url
+    assert_equal '2.0', result.note
   end
 end

--- a/application/test/connectors/zenodo/download_connector_metadata_test.rb
+++ b/application/test/connectors/zenodo/download_connector_metadata_test.rb
@@ -12,12 +12,126 @@ class Zenodo::DownloadConnectorMetadataTest < ActiveSupport::TestCase
     assert_equal 'Zenodo', @meta.repo_name
   end
 
-  test 'files_url uses type and id' do
-    assert_equal '/explore/zenodo/zenodo_server.com/records/1?active_project=123', @meta.files_url
+  test 'explore_url uses type and id' do
+    assert_equal '/explore/zenodo/zenodo_server.com/records/1?active_project=123', @meta.explore_url
   end
 
   test 'to_h and missing methods' do
     assert_nil @meta.unknown
     assert_equal({'type'=>'records', 'type_id'=>1, "zenodo_url"=>"https://zenodo_server.com"}, @meta.to_h)
+  end
+
+  test 'external_url returns nil when no zenodo_url' do
+    file = DownloadFile.new
+    file.project_id = '123'
+    file.metadata = {type: 'records', type_id: 1, zenodo_url: nil}
+    meta = Zenodo::DownloadConnectorMetadata.new(file)
+    
+    assert_nil meta.external_url
+  end
+
+  test 'external_url returns nil when no type_id' do
+    file = DownloadFile.new
+    file.project_id = '123'
+    file.metadata = {type: 'records', type_id: nil, zenodo_url: 'https://zenodo.org'}
+    meta = Zenodo::DownloadConnectorMetadata.new(file)
+    
+    assert_nil meta.external_url
+  end
+
+  test 'external_url builds correct deposition URL for depositions type' do
+    file = DownloadFile.new
+    file.project_id = '123'
+    file.metadata = {type: 'depositions', type_id: 54321, zenodo_url: 'https://zenodo.org'}
+    meta = Zenodo::DownloadConnectorMetadata.new(file)
+    
+    expected_url = 'https://zenodo.org/uploads/54321'
+    assert_equal expected_url, meta.external_url
+  end
+
+  test 'external_url returns zenodo_url for unsupported types' do
+    file = DownloadFile.new
+    file.project_id = '123'
+    file.metadata = {type: 'files', type_id: 1, zenodo_url: 'https://zenodo.org'}
+    meta = Zenodo::DownloadConnectorMetadata.new(file)
+    
+    assert_equal 'https://zenodo.org', meta.external_url
+  end
+
+  test 'external_url builds correct record URL for records type' do
+    file = DownloadFile.new
+    file.project_id = '123'
+    file.metadata = {type: 'records', type_id: 12345, zenodo_url: 'https://zenodo.org'}
+    meta = Zenodo::DownloadConnectorMetadata.new(file)
+    
+    expected_url = 'https://zenodo.org/records/12345'
+    assert_equal expected_url, meta.external_url
+  end
+
+  test 'external_url works with different zenodo instances' do
+    file = DownloadFile.new
+    file.project_id = '123'
+    file.metadata = {type: 'records', type_id: 67890, zenodo_url: 'https://sandbox.zenodo.org'}
+    meta = Zenodo::DownloadConnectorMetadata.new(file)
+    
+    expected_url = 'https://sandbox.zenodo.org/records/67890'
+    assert_equal expected_url, meta.external_url
+  end
+
+  test 'external_url works with custom port zenodo instance' do
+    file = DownloadFile.new
+    file.project_id = '123'
+    file.metadata = {type: 'records', type_id: 999, zenodo_url: 'http://localhost:5000'}
+    meta = Zenodo::DownloadConnectorMetadata.new(file)
+    
+    expected_url = 'http://localhost:5000/records/999'
+    assert_equal expected_url, meta.external_url
+  end
+
+  test 'repo_summary returns nil when no external_url' do
+    file = DownloadFile.new
+    file.project_id = '123'
+    file.type = ConnectorType::ZENODO
+    file.creation_date = Date.current
+    file.metadata = {type: 'records', type_id: nil, zenodo_url: 'https://zenodo.org', title: 'Test Record'}
+    meta = Zenodo::DownloadConnectorMetadata.new(file)
+    
+    assert_nil meta.repo_summary
+  end
+
+  test 'repo_summary returns OpenStruct with correct attributes for records' do
+    file = DownloadFile.new
+    file.project_id = '123'
+    file.type = ConnectorType::ZENODO
+    file.creation_date = Date.current
+    file.metadata = {type: 'records', type_id: 12345, zenodo_url: 'https://zenodo.org', title: 'Test Record'}
+    meta = Zenodo::DownloadConnectorMetadata.new(file)
+    
+    result = meta.repo_summary
+    
+    assert_not_nil result
+    assert_equal ConnectorType::ZENODO, result.type
+    assert_equal Date.current, result.date
+    assert_equal 'Test Record', result.title
+    assert_equal 'https://zenodo.org/records/12345', result.url
+    assert_equal 'records', result.note
+  end
+
+  test 'repo_summary returns OpenStruct with correct attributes for depositions' do
+    file = DownloadFile.new
+    file.project_id = '123'
+    file.type = ConnectorType::ZENODO
+    file.creation_date = Date.current
+    file.metadata = {type: 'depositions', type_id: 54321, zenodo_url: 'https://zenodo.org', title: 'Test Deposition'}
+    meta = Zenodo::DownloadConnectorMetadata.new(file)
+    
+    result = meta.repo_summary
+    
+    assert_not_nil result
+    assert_equal ConnectorType::ZENODO, result.type
+    assert_equal Date.current, result.date
+    assert_equal 'Test Deposition', result.title
+    assert_equal 'https://zenodo.org/uploads/54321', result.url
+    assert_equal 'depositions', result.note
   end
 end

--- a/application/test/helpers/projects_helper_test.rb
+++ b/application/test/helpers/projects_helper_test.rb
@@ -82,9 +82,9 @@ class ProjectsHelperTest < ActionView::TestCase
 
   test 'most_recent_explore_url returns url of most recent file' do
     file_old = OpenStruct.new(end_date: '2023-01-01T00:00:00', start_date: nil, creation_date: nil,
-                              connector_metadata: OpenStruct.new(files_url: '/old'))
+                              connector_metadata: OpenStruct.new(explore_url: '/old'))
     file_new = OpenStruct.new(end_date: '2023-01-02T00:00:00', start_date: nil, creation_date: nil,
-                              connector_metadata: OpenStruct.new(files_url: '/new'))
+                              connector_metadata: OpenStruct.new(explore_url: '/new'))
     project = OpenStruct.new(download_files: [file_old, file_new])
 
     assert_equal '/new', most_recent_explore_url(project)

--- a/application/test/services/dataverse/project_service_test.rb
+++ b/application/test/services/dataverse/project_service_test.rb
@@ -48,6 +48,7 @@ class Dataverse::ProjectServiceTest < ActiveSupport::TestCase
     assert_equal '4', download_files[0].metadata[:id]
     assert_equal 'https://example.com', download_files[0].metadata[:dataverse_url]
     assert_equal '2.0', download_files[0].metadata[:version]
+    assert_equal dataset.title, download_files[0].metadata[:title]
     assert_equal 'local://1946f5acedb-fdf849a8d0f3', download_files[0].metadata[:storage]
     assert_equal '13035cba04a51f54dd8101fe726cda5c', download_files[0].metadata[:md5]
     assert_equal 'image/png', download_files[0].metadata[:content_type]

--- a/application/test/services/repo/repo_activity_service_test.rb
+++ b/application/test/services/repo/repo_activity_service_test.rb
@@ -17,14 +17,19 @@ class Repo::RepoActivityServiceTest < ActiveSupport::TestCase
 
   test 'project_downloads returns sorted project items' do
     project = OpenStruct.new(id: '123')
+    
+    old_summary = OpenStruct.new(type: 'old', date: Time.zone.now - 2.days, title: 'downloads', url: '/old', note: 'dataset')
+    new_summary = OpenStruct.new(type: 'new', date: Time.zone.now, title: 'downloads', url: '/new', note: 'dataset')
+    
     file_old = OpenStruct.new(type: 'old',
                               creation_date: Time.zone.now - 2.days,
-                              connector_metadata: OpenStruct.new(files_url: '/old'))
+                              connector_metadata: OpenStruct.new(repo_summary: old_summary))
     file_new = OpenStruct.new(type: 'new',
                               creation_date: Time.zone.now,
-                              connector_metadata: OpenStruct.new(files_url: '/new'))
+                              connector_metadata: OpenStruct.new(repo_summary: new_summary))
+    
     project.stubs(:download_files).returns([file_old, file_new])
-    Project.stubs(:find_by).with(id: project.id).returns(project)
+    Project.stubs(:find).with(project.id).returns(project)
 
     result = Repo::RepoActivityService.new.project_downloads(project.id)
     assert_equal ['/new', '/old'], result.map(&:url)

--- a/application/test/services/repo/repo_activity_service_test.rb
+++ b/application/test/services/repo/repo_activity_service_test.rb
@@ -15,16 +15,21 @@ class Repo::RepoActivityServiceTest < ActiveSupport::TestCase
     assert_equal entry1.type, result.first.type
   end
 
-  test 'project_download_repos returns sorted project urls' do
+  test 'project_downloads returns sorted project items' do
     project = OpenStruct.new(id: '123')
-    file_old = OpenStruct.new(creation_date: Time.zone.now - 2.days,
+    file_old = OpenStruct.new(type: 'old',
+                              creation_date: Time.zone.now - 2.days,
                               connector_metadata: OpenStruct.new(files_url: '/old'))
-    file_new = OpenStruct.new(creation_date: Time.zone.now,
+    file_new = OpenStruct.new(type: 'new',
+                              creation_date: Time.zone.now,
                               connector_metadata: OpenStruct.new(files_url: '/new'))
     project.stubs(:download_files).returns([file_old, file_new])
     Project.stubs(:find_by).with(id: project.id).returns(project)
 
-    result = Repo::RepoActivityService.new.project_download_repos(project.id)
-    assert_equal ['/new', '/old'], result
+    result = Repo::RepoActivityService.new.project_downloads(project.id)
+    assert_equal ['/new', '/old'], result.map(&:url)
+    assert_equal ['new', 'old'], result.map(&:type)
+    assert_equal ['downloads', 'downloads'], result.map(&:title)
+    assert_equal ['dataset', 'dataset'], result.map(&:note)
   end
 end

--- a/application/test/services/repo/repo_activity_service_test.rb
+++ b/application/test/services/repo/repo_activity_service_test.rb
@@ -3,16 +3,28 @@
 require 'test_helper'
 
 class Repo::RepoActivityServiceTest < ActiveSupport::TestCase
-
   test 'global returns entries from repo history' do
     entry1 = Repo::RepoHistory::Entry.new(repo_url: 'https://one', type: ConnectorType.get(:dataverse), title: 'One', note: 'v1', count: 1, last_added: '2024-01-02T00:00:00')
     entry2 = Repo::RepoHistory::Entry.new(repo_url: 'https://two', type: ConnectorType.get(:zenodo), title: 'Two', note: 'v2', count: 1, last_added: '2024-01-01T00:00:00')
     ::Configuration.stubs(:repo_history).returns(stub(all: [entry1, entry2]))
 
-      result = Repo::RepoActivityService.new.global
-      assert_equal ['https://one', 'https://two'], result.map(&:url)
-      assert_equal 'One', result.first.title
-      assert_equal 'v1', result.first.note
-      assert_equal entry1.type, result.first.type
-    end
+    result = Repo::RepoActivityService.new.global
+    assert_equal ['https://one', 'https://two'], result.map(&:url)
+    assert_equal 'One', result.first.title
+    assert_equal 'v1', result.first.note
+    assert_equal entry1.type, result.first.type
   end
+
+  test 'project_download_repos returns sorted project urls' do
+    project = OpenStruct.new(id: '123')
+    file_old = OpenStruct.new(creation_date: Time.zone.now - 2.days,
+                              connector_metadata: OpenStruct.new(files_url: '/old'))
+    file_new = OpenStruct.new(creation_date: Time.zone.now,
+                              connector_metadata: OpenStruct.new(files_url: '/new'))
+    project.stubs(:download_files).returns([file_old, file_new])
+    Project.stubs(:find_by).with(id: project.id).returns(project)
+
+    result = Repo::RepoActivityService.new.project_download_repos(project.id)
+    assert_equal ['/new', '/old'], result
+  end
+end

--- a/application/test/services/zenodo/project_service_test.rb
+++ b/application/test/services/zenodo/project_service_test.rb
@@ -34,6 +34,7 @@ class Zenodo::ProjectServiceTest < ActiveSupport::TestCase
     assert_equal record.id, file.metadata[:type_id]
     assert_equal 'records', file.metadata[:type]
     assert_equal 'https://zenodo.org', file.metadata[:zenodo_url]
+    assert_equal record.title, file.metadata[:title]
   end
 
   test 'create_files_from_deposition builds download records' do
@@ -50,5 +51,6 @@ class Zenodo::ProjectServiceTest < ActiveSupport::TestCase
     assert_equal deposition.id, file.metadata[:type_id]
     assert_equal 'depositions', file.metadata[:type]
     assert_equal 'https://zenodo.org', file.metadata[:zenodo_url]
+    assert_equal deposition.title, file.metadata[:title]
   end
 end

--- a/application/test/views/widgets/repository_activity_view_test.rb
+++ b/application/test/views/widgets/repository_activity_view_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RepositoryActivityViewTest < ActionView::TestCase
+  test 'renders project download urls tab when project_id provided' do
+    project_id = '123'
+
+    service = mock('service')
+    service.stubs(:global).returns([])
+    service.stubs(:project_download_repos).with(project_id).returns(['/new', '/old'])
+    Repo::RepoActivityService.stubs(:new).returns(service)
+
+    view.stubs(:params).returns(ActionController::Parameters.new(project_id: project_id))
+
+    html = render partial: 'widgets/repository_activity'
+
+    assert_includes html, I18n.t('widgets.repository_activity.tab_project_label')
+    assert_includes html, '/new'
+    assert_includes html, '/old'
+  end
+end

--- a/application/test/views/widgets/repository_activity_view_test.rb
+++ b/application/test/views/widgets/repository_activity_view_test.rb
@@ -8,9 +8,14 @@ class RepositoryActivityViewTest < ActionView::TestCase
 
     service = mock('service')
     service.stubs(:global).returns([])
-    service.stubs(:project_download_repos).with(project_id).returns(['/new', '/old'])
+    downloads = [
+      OpenStruct.new(url: '/new', type: 'new', date: Time.zone.now, title: 'downloads', note: 'dataset'),
+      OpenStruct.new(url: '/old', type: 'old', date: Time.zone.now - 1.day, title: 'downloads', note: 'dataset')
+    ]
+    service.stubs(:project_downloads).with(project_id).returns(downloads)
     Repo::RepoActivityService.stubs(:new).returns(service)
 
+    view.stubs(:connector_icon).returns('')
     view.stubs(:params).returns(ActionController::Parameters.new(project_id: project_id))
 
     html = render partial: 'widgets/repository_activity'


### PR DESCRIPTION
## Summary
- open repository activity modal from project download actions
- match repository activity icon on add files button
- show project-specific tab listing recent download URLs
- move project-specific URL lookup into `Repo::RepoActivityService`

## Testing
- `bundle exec rails test`
- `bundle exec rubocop` *(fails: 1002 offenses detected, Style/StringLiterals errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b86217fd648321bff9e5eb4b7d853a