### PR TITLE
docs: add testing guide

### DIFF
--- a/docs/guide/content/development_guide/architecture.md
+++ b/docs/guide/content/development_guide/architecture.md
@@ -84,7 +84,8 @@ overridden via YAML or environment variables (see the [Admin Guide](../admin.md)
 
 ## Testing
 
-OnDemand Loop uses a comprehensive testing strategy with multiple types of tests:
+OnDemand Loop uses a comprehensive testing strategy with multiple types of tests.
+For instructions on running the test suite see the [Testing](testing.md) guide.
 
 ### Unit and Integration Tests (`application/test`)
 

--- a/docs/guide/content/development_guide/index.md
+++ b/docs/guide/content/development_guide/index.md
@@ -46,8 +46,11 @@ The documentation is organized by topic to help you find what you need quickly:
 - [E2E Tests](e2e_tests.md)  
   End-to-end testing with Cypress, including local execution and CI/CD integration.
 
-- [GitHub Actions](github_actions.md)  
+- [GitHub Actions](github_actions.md)
   How CI is handled using GitHub Actions, including testing and deployment workflows.
+
+- [Testing](testing.md)
+  How the Rails test suite is structured and executed using the provided Make targets.
 
 Each page is self-contained but builds on shared understanding of the architecture and workflows.  
 If you're new to the project, we recommend starting with:

--- a/docs/guide/content/development_guide/testing.md
+++ b/docs/guide/content/development_guide/testing.md
@@ -1,0 +1,49 @@
+# Testing
+
+## Overview
+The Rails test suite lives under `application/test` and is organized by component:
+
+- `models/` – Active Record models
+- `controllers/` – controller actions
+- `services/` – application services and helpers
+- `connectors/` – repository integrations
+- `integration/` and `system/` – higher level flows
+- `views/`, `helpers/`, `lib/`, and `utils/` for other layers
+- `fixtures/` provides sample data for tests
+
+Tests use Rails' built‑in [Minitest](https://guides.rubyonrails.org/testing.html) framework. Each test file is named with the
+`*_test.rb` suffix and defines classes such as `ActiveSupport::TestCase` or `ActionDispatch::IntegrationTest`.
+Fixtures in `application/test/fixtures` supply reusable records for fast and deterministic tests.
+
+## Running tests
+Tests are executed inside a Docker container using Make targets defined in the project's `Makefile`.
+
+- `make test_bash` – start an interactive shell inside the test container.
+- `make test_exec` – run one or more commands non‑interactively by piping them to the target.
+
+### Run all tests
+```bash
+echo 'bundle exec rake test' | make test_exec
+```
+
+### Run a single test file
+```bash
+echo 'bundle exec rake test TEST=test/models/application_disk_record_test.rb' | make test_exec
+```
+
+### Run a specific test method
+```bash
+echo 'bundle exec rake test TEST=test/models/application_disk_record_test.rb TESTOPTS="--name=test_saved"' | make test_exec
+```
+
+### Run tests in a directory
+```bash
+echo 'bundle exec rake test TEST="test/services/**/*_test.rb"' | make test_exec
+```
+
+### Useful options
+```bash
+echo 'bundle exec rake test TESTOPTS="--verbose --stop-on-failure --seed=1234"' | make test_exec
+```
+
+For multiple commands or custom setup, chain commands with `echo -e` or launch `make test_bash` and run tests manually inside the container.

--- a/docs/guide/mkdocs.yml
+++ b/docs/guide/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
       - Open OnDemand: development_guide/ood.md
       - Dataverse Integration: development_guide/dataverse_integration.md
       - Contributing a Change: development_guide/contributing.md
+      - Testing: development_guide/testing.md
       - E2E Tests: development_guide/e2e_tests.md
       - GitHub Actions: development_guide/github_actions.md
       - Languages and Translations: development_guide/languages_and_translations.md


### PR DESCRIPTION
## Summary
- document Rails test suite structure and execution examples
- link new testing guide in development guide index and architecture
- add testing guide to MkDocs navigation

## Testing
- `echo 'bundle exec rake test TEST=test/models/application_disk_record_test.rb' | make test_exec` *(fails: docker: No such file or directory)*
- `make guide` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc32a5c770832187d98f0958c5b1c2