### PR TITLE
Add upload bundle button to repository activity

### DIFF
--- a/application/app/views/projects/show/_project_actions.html.erb
+++ b/application/app/views/projects/show/_project_actions.html.erb
@@ -110,6 +110,19 @@
         } %>
   </div>
 
+  <button type="button"
+          class="btn btn-sm btn-outline-secondary"
+          aria-label="<%= t('.button_add_files_title') %>"
+          title="<%= t('.button_add_files_title') %>"
+          data-controller="modal"
+          data-action="click->modal#load"
+          data-modal-url-value="<%= widgets_path('repository_activity', project_id: project.id) %>"
+          data-modal-title-value="<%= t('widgets.repository_activity.modal_title') %>"
+          data-modal-id-value="global-modal">
+    <i class="bi bi-folder-symlink-fill" aria-hidden="true"></i>
+    <span class="ps-1"><%= t('.button_add_files_text') %></span>
+  </button>
+
   <!-- Open metadata link -->
   <%= render partial: '/shared/metadata_folder_link',
              locals: { path: Project.project_metadata_dir(project.id) } %>

--- a/application/app/views/widgets/_repository_activity.html.erb
+++ b/application/app/views/widgets/_repository_activity.html.erb
@@ -3,6 +3,7 @@
   service = Repo::RepoActivityService.new
   global = service.global
   project_downloads = service.project_downloads(params[:project_id])
+  project_id = params[:project_id]
 %>
 <div id="repository-items-tabs">
   <%# Tab Labels %>
@@ -42,6 +43,16 @@
                 } do %>
                   <input type="hidden" name="repo_url" value="<%= item.url %>">
                 <% end %>
+                <% if project_id %>
+                  <%= render layout: "shared/button_to", locals: {
+                    url: connector_project_upload_bundles_path(project_id: project_id),
+                    title: t('.button_create_upload_bundle_title'),
+                    class: 'btn-sm btn-outline-dark',
+                    icon: 'bi bi-folder-plus'
+                  } do %>
+                    <input type="hidden" name="remote_repo_url" value="<%= item.url %>">
+                  <% end %>
+                <% end %>
                 <%= link_to item.url, target: '_blank', class: 'btn btn-sm btn-outline-dark', title: t('.button_open_repository_title') do %>
                   <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
                   <span class="visually-hidden"><%= t('.button_open_repository_title') %></span>
@@ -75,6 +86,16 @@
                     icon: 'bi bi-folder2-open'
                   } do %>
                     <input type="hidden" name="repo_url" value="<%= item.url %>">
+                  <% end %>
+                  <% if project_id %>
+                    <%= render layout: "shared/button_to", locals: {
+                      url: connector_project_upload_bundles_path(project_id: project_id),
+                      title: t('.button_create_upload_bundle_title'),
+                      class: 'btn-sm btn-outline-dark',
+                      icon: 'bi bi-folder-plus'
+                    } do %>
+                      <input type="hidden" name="remote_repo_url" value="<%= item.url %>">
+                    <% end %>
                   <% end %>
                   <%= link_to item.url, target: '_blank', class: 'btn btn-sm btn-outline-dark', title: t('.button_open_repository_title') do %>
                     <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>

--- a/application/config/locales/views/en.yml
+++ b/application/config/locales/views/en.yml
@@ -124,6 +124,9 @@ en:
         button_active_project_title: "Active project"
         button_set_as_active_project_title: "Set as Active Project"
 
+        button_add_files_text: "Add Files"
+        button_add_files_title: "Add Files"
+
         button_create_upload_bundle_label: "Create Upload Bundle"
         button_create_upload_bundle_placeholder: "Dataset URL"
         button_create_upload_bundle_title: "Create Upload Bundle"
@@ -300,6 +303,7 @@ en:
       field_date_title: "Last used date"
       section_item_actions_label: "Item actions"
       button_explore_item_title: "Browse repository"
+      button_create_upload_bundle_title: "Create Upload Bundle"
       button_open_repository_title: "Open repository on website"
     reset:
       success_page_title: "Reset Completed"

--- a/application/test/views/projects/project_actions_view_test.rb
+++ b/application/test/views/projects/project_actions_view_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ProjectActionsViewTest < ActionView::TestCase
+  include ModelHelper
+
+  test 'renders repository activity button' do
+    project = create_project
+
+    view.stubs(:active_project?).returns(false)
+
+    html = render partial: 'projects/show/project_actions', locals: { project: project }
+
+    expected_url = widgets_path('repository_activity', project_id: project.id)
+    assert_includes html, expected_url
+    assert_includes html, t('projects.show.project_actions.button_add_files_title')
+  end
+end

--- a/application/test/views/widgets/repository_activity_view_test.rb
+++ b/application/test/views/widgets/repository_activity_view_test.rb
@@ -14,7 +14,6 @@ class RepositoryActivityViewTest < ActionView::TestCase
     ]
     service.stubs(:project_downloads).with(project_id).returns(downloads)
     Repo::RepoActivityService.stubs(:new).returns(service)
-
     view.stubs(:connector_icon).returns('')
     view.stubs(:params).returns(ActionController::Parameters.new(project_id: project_id))
 
@@ -23,5 +22,20 @@ class RepositoryActivityViewTest < ActionView::TestCase
     assert_includes html, I18n.t('widgets.repository_activity.tab_project_label')
     assert_includes html, '/new'
     assert_includes html, '/old'
+    assert_includes html, connector_project_upload_bundles_path(project_id: project_id)
+  end
+
+  test 'renders only global tab when project_id not provided' do
+    service = mock('service')
+    service.stubs(:global).returns([])
+    service.stubs(:project_downloads).with(nil).returns([])
+    Repo::RepoActivityService.stubs(:new).returns(service)
+    view.stubs(:connector_icon).returns('')
+    view.stubs(:params).returns(ActionController::Parameters.new)
+
+    html = render partial: 'widgets/repository_activity'
+
+    refute_includes html, I18n.t('widgets.repository_activity.tab_project_label')
+    refute_includes html, connector_project_upload_bundles_path(project_id: '1')
   end
 end


### PR DESCRIPTION
## Summary
- enable creating upload bundles from repository activity items when a project is specified
- localize new upload bundle control and add view spec coverage
- simplify upload bundle button rendering to use project_id param directly
- surface repository history modal from project actions for quick bundle creation
- add test coverage for repository activity when no project id is present

## Testing
- `bundle exec rake test TEST=test/views/widgets/repository_activity_view_test.rb`
- `bundle exec rake test TEST=test/views/projects/project_actions_view_test.rb`
- `bundle exec rubocop test/views/widgets/repository_activity_view_test.rb test/views/projects/project_actions_view_test.rb`


------
https://chatgpt.com/codex/tasks/task_e_68be0387173c8321bb5e9b83cd0b207a