### PR TITLE
Log download errors as events

### DIFF
--- a/application/app/connectors/dataverse/download_connector_processor.rb
+++ b/application/app/connectors/dataverse/download_connector_processor.rb
@@ -3,6 +3,7 @@ module Dataverse
   # Dataverse connector download processor. Responsible for downloading files of type Dataverse
   class DownloadConnectorProcessor
     include LoggingCommon
+    include EventLogger
 
     attr_reader :file, :connector_metadata, :cancelled
     def initialize(file)
@@ -47,6 +48,11 @@ module Dataverse
         file.update({ metadata: connector_metadata.to_h })
         FileUtils.rm_f(temp_location) if download_processor.partial_downloads == false
         log_error('Download failed', { id: file.id, url: download_url, partial_downloads: download_processor.partial_downloads }, e)
+        log_download_file_event(file, 'events.download_file.error', {
+          'error' => e.message,
+          'url' => download_url,
+          'partial_downloads' => download_processor.partial_downloads
+        })
         return response(FileStatus::ERROR, 'file download failed', e.message)
       end
 
@@ -89,6 +95,12 @@ module Dataverse
         true
       else
         log_error('Checksum verification failed', {file_path: file_path, expected_md5: expected_md5, current_md5: file_md5})
+        log_download_file_event(file, 'events.download_file.error', {
+          'error' => 'Checksum verification failed',
+          'file_path' => file_path,
+          'expected_md5' => expected_md5,
+          'current_md5' => file_md5
+        })
         false
       end
     end

--- a/application/app/connectors/zenodo/download_connector_processor.rb
+++ b/application/app/connectors/zenodo/download_connector_processor.rb
@@ -3,6 +3,7 @@
 module Zenodo
   class DownloadConnectorProcessor
     include LoggingCommon
+    include EventLogger
 
     attr_reader :file, :connector_metadata, :cancelled
 
@@ -39,6 +40,11 @@ module Zenodo
         file.update({ metadata: connector_metadata.to_h })
         FileUtils.rm_f(temp_location) if download_processor.partial_downloads == false
         log_error('Download failed', { id: file.id, url: download_url, partial_downloads: download_processor.partial_downloads }, e)
+        log_download_file_event(file, 'events.download_file.error', {
+          'error' => e.message,
+          'url' => download_url,
+          'partial_downloads' => download_processor.partial_downloads
+        })
         return response(FileStatus::ERROR, 'file download failed', e.message)
       end
 

--- a/application/test/connectors/zenodo/download_connector_processor_test.rb
+++ b/application/test/connectors/zenodo/download_connector_processor_test.rb
@@ -79,6 +79,12 @@ class Zenodo::DownloadConnectorProcessorTest < ActiveSupport::TestCase
     Download::BasicHttpRubyDownloader.stubs(:new).returns(mock_downloader)
     mock_downloader.expects(:download).raises(StandardError.new('boom'))
 
+    processor.expects(:log_download_file_event).with(
+      file,
+      'events.download_file.error',
+      includes('error' => 'boom', 'url' => 'https://zenodo.org/file.txt', 'partial_downloads' => true)
+    )
+
     result = processor.download
     assert_equal FileStatus::ERROR, result.status
     assert File.exist?(temp_location)
@@ -107,6 +113,12 @@ class Zenodo::DownloadConnectorProcessorTest < ActiveSupport::TestCase
     mock_downloader.stubs(:partial_downloads).returns(false)
     Download::BasicHttpRubyDownloader.stubs(:new).returns(mock_downloader)
     mock_downloader.expects(:download).raises(StandardError.new('boom'))
+
+    processor.expects(:log_download_file_event).with(
+      file,
+      'events.download_file.error',
+      includes('error' => 'boom', 'url' => 'https://zenodo.org/file.txt', 'partial_downloads' => false)
+    )
 
     result = processor.download
     assert_equal FileStatus::ERROR, result.status


### PR DESCRIPTION
## Summary
- record errors as download file events for Dataverse and Zenodo connectors
- add error details to event metadata
- verify error events in connector tests

## Testing
- `bin/rails test test/connectors/dataverse/download_connector_processor_test.rb test/connectors/zenodo/download_connector_processor_test.rb` *(fails: Could not find rails-7.2.2.1... Run `bundle install --gemfile` to install missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_68c178d3f170832bb330233d6b9101bd