### PR TITLE
Refactor log_download_file_event to use keyword arguments

### DIFF
--- a/application/app/connectors/dataverse/download_connector_processor.rb
+++ b/application/app/connectors/dataverse/download_connector_processor.rb
@@ -48,7 +48,7 @@ module Dataverse
         file.update({ metadata: connector_metadata.to_h })
         FileUtils.rm_f(temp_location) if download_processor.partial_downloads == false
         log_error('Download failed', { id: file.id, url: download_url, partial_downloads: download_processor.partial_downloads }, e)
-        log_download_file_event(file, 'events.download_file.error', {
+        log_download_file_event(file, message: 'events.download_file.error', metadata: {
           'error' => e.message,
           'url' => download_url,
           'partial_downloads' => download_processor.partial_downloads
@@ -95,7 +95,7 @@ module Dataverse
         true
       else
         log_error('Checksum verification failed', {file_path: file_path, expected_md5: expected_md5, current_md5: file_md5})
-        log_download_file_event(file, 'events.download_file.error_checksum_verification', {
+        log_download_file_event(file, message: 'events.download_file.error_checksum_verification', metadata: {
           'error' => 'Checksum verification failed after the file was downloaded',
           'file_path' => file_path,
           'expected_md5' => expected_md5,

--- a/application/app/connectors/zenodo/download_connector_processor.rb
+++ b/application/app/connectors/zenodo/download_connector_processor.rb
@@ -40,7 +40,7 @@ module Zenodo
         file.update({ metadata: connector_metadata.to_h })
         FileUtils.rm_f(temp_location) if download_processor.partial_downloads == false
         log_error('Download failed', { id: file.id, url: download_url, partial_downloads: download_processor.partial_downloads }, e)
-        log_download_file_event(file, 'events.download_file.error', {
+        log_download_file_event(file, message: 'events.download_file.error', metadata: {
           'error' => e.message,
           'url' => download_url,
           'partial_downloads' => download_processor.partial_downloads

--- a/application/app/controllers/download_files_controller.rb
+++ b/application/app/controllers/download_files_controller.rb
@@ -16,13 +16,13 @@ class DownloadFilesController < ApplicationController
     if file.status.downloading?
       command_client = Command::CommandClient.new(socket_path: ::Configuration.command_server_socket_file)
       request = Command::Request.new(command: 'download.cancel', body: {project_id: project_id, file_id: file_id})
-      log_download_file_event(file, 'events.download_file.cancel_started', { 'filename' => file.filename, 'previous_status' => previous_status })
+      log_download_file_event(file, message: 'events.download_file.cancel_started', metadata: { 'filename' => file.filename, 'previous_status' => previous_status })
       response = command_client.request(request)
       return redirect_back fallback_location: root_path, alert: t('download_files.file_cancellation_error', filename: file.filename) if response.status != 200
     end
 
     if file.update(status: FileStatus::CANCELLED)
-      log_download_file_event(file, 'events.download_file.cancel_completed', { 'filename' => file.filename, 'previous_status' => previous_status })
+      log_download_file_event(file, message: 'events.download_file.cancel_completed', metadata: { 'filename' => file.filename, 'previous_status' => previous_status })
       redirect_back fallback_location: root_path, notice: t('download_files.file_cancellation_success', filename: file.filename)
     else
       redirect_back fallback_location: root_path, alert: t('download_files.file_cancellation_update_error', filename: file.filename)

--- a/application/app/lib/event_logger.rb
+++ b/application/app/lib/event_logger.rb
@@ -16,7 +16,7 @@ module EventLogger
     )
   end
 
-  def log_download_file_event(file, message, metadata = {})
+  def log_download_file_event(file, message:, metadata:)
     unless file.is_a?(DownloadFile)
       raise ArgumentError, "Expected DownloadFile model, got #{file.class}"
     end

--- a/application/app/services/download/download_service.rb
+++ b/application/app/services/download/download_service.rb
@@ -31,7 +31,7 @@ module Download
             previous_status = file.status.to_s
             Thread.new do
               file.update(start_date: now, end_date: nil, status: FileStatus::DOWNLOADING)
-              log_download_file_event(file, 'events.download_file.started', {'previous_status' => previous_status})
+              log_download_file_event(file, message: 'events.download_file.started', metadata: {'previous_status' => previous_status})
               stats[:progress] += 1
               result = download_processor.download
               previous_status = file.status.to_s
@@ -39,11 +39,11 @@ module Download
             rescue => e
               log_error('Error while processing file', {file_id: file.id}, e)
               file.update(end_date: now, status: FileStatus::ERROR)
-              log_download_file_event(file, 'events.download_file.error', { 'error' => e.message, 'previous_status' => previous_status})
+              log_download_file_event(file, message: 'events.download_file.error', metadata: { 'error' => e.message, 'previous_status' => previous_status})
             ensure
               stats[:completed] += 1
               stats[:progress] -= 1
-              log_download_file_event(file, 'events.download_file.finished', { 'previous_status' => previous_status })
+              log_download_file_event(file, message: 'events.download_file.finished', metadata: { 'previous_status' => previous_status })
             end
           end
         # Wait for all downloads to complete

--- a/application/test/connectors/dataverse/download_connector_processor_test.rb
+++ b/application/test/connectors/dataverse/download_connector_processor_test.rb
@@ -74,8 +74,8 @@ class Dataverse::DownloadConnectorProcessorTest < ActiveSupport::TestCase
 
     @processor.expects(:log_download_file_event).with(
       @file,
-      'events.download_file.error_checksum_verification',
-      {
+      message: 'events.download_file.error_checksum_verification',
+      metadata: {
         'error' => 'Checksum verification failed after the file was downloaded',
         'file_path' => @download_path,
         'expected_md5' => @file.metadata[:md5],
@@ -157,8 +157,8 @@ class Dataverse::DownloadConnectorProcessorTest < ActiveSupport::TestCase
     expected_url = 'http://example.com/api/access/datafile/789?format=original'
     processor.expects(:log_download_file_event).with(
       file,
-      'events.download_file.error',
-      {'error' => 'boom', 'url' => expected_url, 'partial_downloads' => true}
+      message: 'events.download_file.error',
+      metadata: {'error' => 'boom', 'url' => expected_url, 'partial_downloads' => true}
     )
 
     result = processor.download
@@ -197,8 +197,8 @@ class Dataverse::DownloadConnectorProcessorTest < ActiveSupport::TestCase
     expected_url = 'http://example.com/api/access/datafile/790?format=original'
     processor.expects(:log_download_file_event).with(
       file,
-      'events.download_file.error',
-      {'error' => 'boom', 'url' => expected_url, 'partial_downloads' => false}
+      message: 'events.download_file.error',
+      metadata: {'error' => 'boom', 'url' => expected_url, 'partial_downloads' => false}
     )
 
     result = processor.download

--- a/application/test/connectors/zenodo/download_connector_processor_test.rb
+++ b/application/test/connectors/zenodo/download_connector_processor_test.rb
@@ -81,8 +81,8 @@ class Zenodo::DownloadConnectorProcessorTest < ActiveSupport::TestCase
 
     processor.expects(:log_download_file_event).with(
       file,
-      'events.download_file.error',
-      {'error' => 'boom', 'url' => 'https://zenodo.org/file.txt', 'partial_downloads' => true}
+      message: 'events.download_file.error',
+      metadata: {'error' => 'boom', 'url' => 'https://zenodo.org/file.txt', 'partial_downloads' => true}
     )
 
     result = processor.download
@@ -116,8 +116,8 @@ class Zenodo::DownloadConnectorProcessorTest < ActiveSupport::TestCase
 
     processor.expects(:log_download_file_event).with(
       file,
-      'events.download_file.error',
-      {'error' => 'boom', 'url' => 'https://zenodo.org/file.txt', 'partial_downloads' => false}
+      message: 'events.download_file.error',
+      metadata: {'error' => 'boom', 'url' => 'https://zenodo.org/file.txt', 'partial_downloads' => false}
     )
 
     result = processor.download

--- a/application/test/controllers/download_files_controller_test.rb
+++ b/application/test/controllers/download_files_controller_test.rb
@@ -63,8 +63,8 @@ class DownloadFilesControllerTest < ActionDispatch::IntegrationTest
     DownloadFile.stubs(:find).returns(@file)
     DownloadFilesController.any_instance.expects(:log_download_file_event).with(
       @file,
-      'events.download_file.cancel_completed',
-      { 'filename' => 'filename_test', 'previous_status' => 'success' }
+      message: 'events.download_file.cancel_completed',
+      metadata: { 'filename' => 'filename_test', 'previous_status' => 'success' }
     )
 
     post cancel_project_download_file_url(project_id: @project_id, id: @file_id)

--- a/application/test/services/download/download_service_test.rb
+++ b/application/test/services/download/download_service_test.rb
@@ -66,8 +66,8 @@ class Download::DownloadServiceTest < ActiveSupport::TestCase
       files_provider = DownloadFilesProviderMock.new([file])
       target = Download::DownloadService.new(files_provider)
       target.stubs(:now).returns(now_time)
-      target.expects(:log_download_file_event).with(file, 'events.download_file.started', {'previous_status' => ''}).once
-      target.expects(:log_download_file_event).with(file, 'events.download_file.finished', {'previous_status' => 'downloading'}).once
+      target.expects(:log_download_file_event).with(file, message: 'events.download_file.started', metadata: {'previous_status' => ''}).once
+      target.expects(:log_download_file_event).with(file, message: 'events.download_file.finished', metadata: {'previous_status' => 'downloading'}).once
 
       target.start
       assert true
@@ -93,9 +93,9 @@ class Download::DownloadServiceTest < ActiveSupport::TestCase
       files_provider = DownloadFilesProviderMock.new([file])
       target = Download::DownloadService.new(files_provider)
       target.stubs(:now).returns(now_time)
-      target.expects(:log_download_file_event).with(file, 'events.download_file.started', {'previous_status' => ''}).once
-      target.expects(:log_download_file_event).with(file, 'events.download_file.error', {'error' => 'An error occurred', 'previous_status' => ''}).once
-      target.expects(:log_download_file_event).with(file, 'events.download_file.finished', {'previous_status' => ''}).once
+      target.expects(:log_download_file_event).with(file, message: 'events.download_file.started', metadata: {'previous_status' => ''}).once
+      target.expects(:log_download_file_event).with(file, message: 'events.download_file.error', metadata: {'error' => 'An error occurred', 'previous_status' => ''}).once
+      target.expects(:log_download_file_event).with(file, message: 'events.download_file.finished', metadata: {'previous_status' => ''}).once
       target.start
       assert true
     end
@@ -119,8 +119,8 @@ class Download::DownloadServiceTest < ActiveSupport::TestCase
       files_provider = DownloadFilesProviderMock.new([file])
       target = Download::DownloadService.new(files_provider)
       target.stubs(:now).returns(now_time)
-      target.expects(:log_download_file_event).with(file, 'events.download_file.started', {'previous_status' => ''}).once
-      target.expects(:log_download_file_event).with(file, 'events.download_file.finished', {'previous_status' => 'downloading'}).once
+      target.expects(:log_download_file_event).with(file, message: 'events.download_file.started', metadata: {'previous_status' => ''}).once
+      target.expects(:log_download_file_event).with(file, message: 'events.download_file.finished', metadata: {'previous_status' => 'downloading'}).once
 
       target.start
       assert true
@@ -145,8 +145,8 @@ class Download::DownloadServiceTest < ActiveSupport::TestCase
       files_provider = DownloadFilesProviderMock.new([file])
       target = Download::DownloadService.new(files_provider)
       target.stubs(:now).returns(now_time)
-      target.expects(:log_download_file_event).with(file, 'events.download_file.started', {'previous_status' => 'downloading'}).once
-      target.expects(:log_download_file_event).with(file, 'events.download_file.finished', {'previous_status' => 'downloading'}).once
+      target.expects(:log_download_file_event).with(file, message: 'events.download_file.started', metadata: {'previous_status' => 'downloading'}).once
+      target.expects(:log_download_file_event).with(file, message: 'events.download_file.finished', metadata: {'previous_status' => 'downloading'}).once
       target.start
       assert true
     end


### PR DESCRIPTION
## Summary
- Make `EventLogger#log_download_file_event` accept keyword args for message and metadata
- Update download service, controller, and connector callers to pass keywords
- Adjust tests for new `log_download_file_event` signature

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec rake test` *(fails: Could not find rails-7.2.2.1...)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a1bdd75c832b813b4c3d24f50f62