### PR TITLE
Show pointer cursor for clickable status badges

### DIFF
--- a/application/app/assets/stylesheets/custom_styles.scss
+++ b/application/app/assets/stylesheets/custom_styles.scss
@@ -19,6 +19,10 @@ div.creation-date span, span.creation-date {
   cursor: default;
 }
 
+.status-badge-button .badge.file-status {
+  cursor: pointer;
+}
+
 .btn-icon-sm {
   padding: 0.25rem;
   line-height: 1;

--- a/application/app/views/download_status/_files.html.erb
+++ b/application/app/views/download_status/_files.html.erb
@@ -33,7 +33,7 @@
               <%= render partial: '/shared/progress_bar', locals: { progress: data.file.connector_status.download_progress, file: data.file } %>
             <% else %>
               <%= button_tag type: 'button',
-                             class: 'btn p-0 border-0 bg-transparent',
+                             class: 'btn p-0 border-0 bg-transparent status-badge-button',
                              title: t('.button_view_events_title'),
                              data: {
                                controller: 'modal',

--- a/application/app/views/projects/show/_download_files.html.erb
+++ b/application/app/views/projects/show/_download_files.html.erb
@@ -30,7 +30,7 @@
         <div class="col-md-2 file-status d-flex justify-content-end gap-1">
           <div class="d-flex flex-column justify-content-center align-items-center">
             <%= button_tag type: 'button',
-                           class: 'btn p-0 border-0 bg-transparent',
+                           class: 'btn p-0 border-0 bg-transparent status-badge-button',
                            title: t('.button_view_events_title'),
                            data: {
                              controller: 'modal',


### PR DESCRIPTION
## Summary
- add `status-badge-button` class to status badges for downloadable files
- use pointer cursor for status badges inside these buttons

## Testing
- `make test` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d4c55b5c832b8012967979a8be20