### PR TITLE
Use GitHub App token for main branch commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,19 @@ jobs:
       version: ${{ steps.version.outputs.version }}
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout Loop SRC
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: src
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Git setup
         working-directory: src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,17 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout ${{ github.sha }}
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Run tests
         run: make test
@@ -25,8 +34,17 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout ${{ github.sha }}
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Generate coverage & badges
         run: make coverage


### PR DESCRIPTION
## Summary
- generate a GitHub App installation token in workflows that push to `main`
- use the GitHub App token when checking out code so pushes run with the app's credentials

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc8078e2cc8321b21c045befd1c3a7